### PR TITLE
Ensure owners see full item sheets

### DIFF
--- a/src/modules/actor/anarchy-actor-sheet.js
+++ b/src/modules/actor/anarchy-actor-sheet.js
@@ -29,7 +29,7 @@ export class AnarchyActorSheet extends ActorSheet {
         ownerActor: this.actor.getOwnerActor(),
         ownedActors: this.actor.getOwnedActors(),
         options: {
-          limited: this.document.limited,
+          limited: this.document.limited && !this.document.isOwner,
           owner: this.document.isOwner,
           cssClass: this.isEditable ? "editable" : "locked",
         },

--- a/src/modules/item/base-item-sheet.js
+++ b/src/modules/item/base-item-sheet.js
@@ -35,6 +35,7 @@ export class BaseItemSheet extends ItemSheet {
       {
         options: {
           isGM: game.user.isGM,
+          limited: this.document.limited && !this.document.isOwner,
           owner: this.document.isOwner,
           isOwned: (this.actor != undefined),
           editable: this.isEditable,


### PR DESCRIPTION
## Summary
- include limited permission check in the base item sheet so owners are not shown restricted views

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b72ffcab8832d938be17f36804a8f)