### PR TITLE
Fix sheet class handling and preload missing templates

### DIFF
--- a/src/modules/actor/anarchy-actor-sheet.js
+++ b/src/modules/actor/anarchy-actor-sheet.js
@@ -29,15 +29,22 @@ export class AnarchyActorSheet extends ActorSheet {
         ownerActor: this.actor.getOwnerActor(),
         ownedActors: this.actor.getOwnedActors(),
         options: {
-          limited: this.document.limited,
+          limited: !this.document.isOwner,
           owner: this.document.isOwner,
           cssClass: this.isEditable ? "editable" : "locked",
         },
         ENUMS: foundry.utils.mergeObject({ attributeAction: this.actor.getAttributeActions() }, Enums.getEnums()),
         ANARCHY: ANARCHY
       });
-    hbsData.options.classes.push(`actor-${this.actor.type}`);
-    hbsData.options.classes = Misc.distinct(hbsData.options.classes);
+    const editableClass = this.isEditable ? "editable" : "locked";
+    const baseClasses = hbsData.options?.classes ?? [];
+    const classes = Misc.distinct([
+      ...baseClasses,
+      `actor-${this.actor.type}`,
+      editableClass
+    ]);
+    hbsData.options.classes = classes;
+    hbsData.options.cssClass = classes.join(" ");
     hbsData.system = this.actor.system;
 
     Misc.classifyInto(hbsData.items, this.actor.items);

--- a/src/modules/handlebars-manager.js
+++ b/src/modules/handlebars-manager.js
@@ -140,10 +140,22 @@ const HBS_PARTIAL_TEMPLATES = [
   'systems/mwd/templates/common/actor-reference.hbs',
   // dialogs
   'systems/mwd/templates/dialog/roll-modifier.hbs',
+  // chat
+  'systems/mwd/templates/chat/anarchy-roll-title.hbs',
+  'systems/mwd/templates/chat/edge-reroll-button.hbs',
+  'systems/mwd/templates/chat/parts/actor-image.hbs',
+  'systems/mwd/templates/chat/parts/generic-parameter.hbs',
+  'systems/mwd/templates/chat/parts/result-mode-weapon.hbs',
+  'systems/mwd/templates/chat/roll-modifier.hbs',
   // apps
   'systems/mwd/templates/app/gm-anarchy.hbs',
   'systems/mwd/templates/app/gm-difficulty.hbs',
   'systems/mwd/templates/app/gm-difficulty-buttons.hbs',
+  'systems/mwd/templates/app/gm-convergence.hbs',
+  // roll (roll rendering helpers)
+  'systems/mwd/templates/roll/parts/dice-cursor.hbs',
+  'systems/mwd/templates/roll/parts/parameter-label.hbs',
+  'systems/mwd/templates/roll/roll-parameters-category.hbs',
 ];
 
 export class HandlebarsManager {

--- a/src/modules/item/base-item-sheet.js
+++ b/src/modules/item/base-item-sheet.js
@@ -1,6 +1,7 @@
 import { ANARCHY } from "../config.js";
 import { TEMPLATE, TEMPLATES_PATH } from "../constants.js";
 import { Enums } from "../enums.js";
+import { Misc } from "../misc.js";
 
 export class BaseItemSheet extends ItemSheet {
 
@@ -35,6 +36,7 @@ export class BaseItemSheet extends ItemSheet {
       {
         options: {
           isGM: game.user.isGM,
+          limited: !this.document.isOwner,
           owner: this.document.isOwner,
           isOwned: (this.actor != undefined),
           editable: this.isEditable,
@@ -44,6 +46,12 @@ export class BaseItemSheet extends ItemSheet {
         ANARCHY: ANARCHY
       });
     hbsData.system = this.item.system;
+
+    const editableClass = this.isEditable ? "editable" : "locked";
+    const baseClasses = hbsData.options?.classes ?? [];
+    const classes = Misc.distinct([...baseClasses, editableClass]);
+    hbsData.options.classes = classes;
+    hbsData.options.cssClass = classes.join(" ");
 
     return hbsData;
   }

--- a/templates/actor/character-tabbed.hbs
+++ b/templates/actor/character-tabbed.hbs
@@ -30,7 +30,7 @@
           </div>
           {{/if}}
         </div>
-        <div class=".passport-action-row">
+        <div class="passport-action-row">
           <div class="passport-action">
             {{> "systems/mwd/templates/actor/parts/attributebuttons.hbs"}}
           </div>

--- a/templates/actor/character.hbs
+++ b/templates/actor/character.hbs
@@ -30,7 +30,7 @@
           </div>
           {{/if}}
         </div>
-        <div class=".passport-action-row">
+        <div class="passport-action-row">
           <div class="passport-action">
             {{> "systems/mwd/templates/actor/parts/attributebuttons.hbs"}}
           </div>

--- a/templates/actor/device.hbs
+++ b/templates/actor/device.hbs
@@ -13,7 +13,7 @@
             {{> 'systems/mwd/templates/actor/parts/ownership.hbs'}}
           </div>
         </div>
-        <div class=".passport-action-row">
+        <div class="passport-action-row">
           <div class="passport-action">
             {{> "systems/mwd/templates/actor/parts/attributebuttons.hbs"}}
           </div>

--- a/templates/actor/ic.hbs
+++ b/templates/actor/ic.hbs
@@ -13,7 +13,7 @@
             {{> 'systems/mwd/templates/actor/parts/ownership.hbs'}}
           </div>
         </div>
-        <div class=".passport-action-row">
+        <div class="passport-action-row">
           <div class="passport-action">
             {{> "systems/mwd/templates/actor/parts/attributebuttons.hbs"}}
           </div>

--- a/templates/actor/npc-sheet.hbs
+++ b/templates/actor/npc-sheet.hbs
@@ -24,7 +24,7 @@
           </div>
           {{/if}}
         </div>
-        <div class=".passport-action-row">
+        <div class="passport-action-row">
           <div class="passport-action">
             {{> "systems/mwd/templates/actor/parts/attributebuttons.hbs"}}
           </div>

--- a/templates/actor/parts/actions-ownership.hbs
+++ b/templates/actor/parts/actions-ownership.hbs
@@ -1,5 +1,5 @@
 {{#unless options.limited}}
-<div class=".passport-action-row">
+<div class="passport-action-row">
   <div class="passport-action">
     {{> "systems/mwd/templates/actor/parts/attributebuttons.hbs"}}
   </div>

--- a/templates/actor/sprite.hbs
+++ b/templates/actor/sprite.hbs
@@ -13,7 +13,7 @@
             {{> 'systems/mwd/templates/actor/parts/ownership.hbs'}}
           </div>
         </div>
-        <div class=".passport-action-row">
+        <div class="passport-action-row">
           <div class="passport-action">
             {{> "systems/mwd/templates/actor/parts/attributebuttons.hbs"}}
           </div>

--- a/templates/actor/vehicle.hbs
+++ b/templates/actor/vehicle.hbs
@@ -19,7 +19,7 @@
             {{> 'systems/mwd/templates/actor/parts/ownership.hbs'}}
           </div>
         </div>
-        <div class=".passport-action-row">
+        <div class="passport-action-row">
           <div class="passport-action">
             {{> "systems/mwd/templates/actor/parts/attributebuttons.hbs"}}
           </div>


### PR DESCRIPTION
## Summary
- ensure actor and item sheets build cssClass from full class list so styling applies when rendering
- correct passport action row class names across actor templates to restore layout styling
- preload chat, roll, and GM partial templates to avoid missing-partial rendering issues

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b72ffcab8832d938be17f36804a8f)