### PR TITLE
Remove SCSS imports from module scripts

### DIFF
--- a/src/modules/actor/anarchy-actor-sheet.js
+++ b/src/modules/actor/anarchy-actor-sheet.js
@@ -29,15 +29,22 @@ export class AnarchyActorSheet extends ActorSheet {
         ownerActor: this.actor.getOwnerActor(),
         ownedActors: this.actor.getOwnedActors(),
         options: {
-          limited: this.document.limited,
+          limited: !this.document.isOwner,
           owner: this.document.isOwner,
           cssClass: this.isEditable ? "editable" : "locked",
         },
         ENUMS: foundry.utils.mergeObject({ attributeAction: this.actor.getAttributeActions() }, Enums.getEnums()),
         ANARCHY: ANARCHY
       });
-    hbsData.options.classes.push(`actor-${this.actor.type}`);
-    hbsData.options.classes = Misc.distinct(hbsData.options.classes);
+    const editableClass = this.isEditable ? "editable" : "locked";
+    const baseClasses = hbsData.options?.classes ?? [];
+    const classes = Misc.distinct([
+      ...baseClasses,
+      `actor-${this.actor.type}`,
+      editableClass
+    ]);
+    hbsData.options.classes = classes;
+    hbsData.options.cssClass = classes.join(" ");
     hbsData.system = this.actor.system;
 
     Misc.classifyInto(hbsData.items, this.actor.items);

--- a/src/modules/actor/character-enhanced-sheet.js
+++ b/src/modules/actor/character-enhanced-sheet.js
@@ -1,7 +1,5 @@
 import { TEMPLATES_PATH } from "../constants.js";
 import { CharacterBaseSheet } from "./character-base-sheet.js";
-import "../../styles/character-enhanced-sheet.scss";
-
 export class CharacterEnhancedSheet extends CharacterBaseSheet {
 
   get template() {

--- a/src/modules/app/gm-manager.js
+++ b/src/modules/app/gm-manager.js
@@ -2,9 +2,6 @@ import { HandleDragApplication } from "./handle-drag.js";
 import { ANARCHY } from "../config.js";
 import { SYSTEM_NAME } from "../constants.js";
 import { GMDifficulty } from "./gm-difficulty.js";
-import "../../styles/gm-manager.scss";
-
-
 const GM_MANAGER = "gm-manager";
 const GM_MANAGER_POSITION = "gm-manager-position";
 const GM_MANAGER_INITIAL_POSITION = { top: 200, left: 200 };

--- a/src/modules/handlebars-manager.js
+++ b/src/modules/handlebars-manager.js
@@ -140,10 +140,22 @@ const HBS_PARTIAL_TEMPLATES = [
   'systems/mwd/templates/common/actor-reference.hbs',
   // dialogs
   'systems/mwd/templates/dialog/roll-modifier.hbs',
+  // chat
+  'systems/mwd/templates/chat/anarchy-roll-title.hbs',
+  'systems/mwd/templates/chat/edge-reroll-button.hbs',
+  'systems/mwd/templates/chat/parts/actor-image.hbs',
+  'systems/mwd/templates/chat/parts/generic-parameter.hbs',
+  'systems/mwd/templates/chat/parts/result-mode-weapon.hbs',
+  'systems/mwd/templates/chat/roll-modifier.hbs',
   // apps
   'systems/mwd/templates/app/gm-anarchy.hbs',
   'systems/mwd/templates/app/gm-difficulty.hbs',
   'systems/mwd/templates/app/gm-difficulty-buttons.hbs',
+  'systems/mwd/templates/app/gm-convergence.hbs',
+  // roll (roll rendering helpers)
+  'systems/mwd/templates/roll/parts/dice-cursor.hbs',
+  'systems/mwd/templates/roll/parts/parameter-label.hbs',
+  'systems/mwd/templates/roll/roll-parameters-category.hbs',
 ];
 
 export class HandlebarsManager {

--- a/src/modules/item/base-item-sheet.js
+++ b/src/modules/item/base-item-sheet.js
@@ -1,6 +1,7 @@
 import { ANARCHY } from "../config.js";
 import { TEMPLATE, TEMPLATES_PATH } from "../constants.js";
 import { Enums } from "../enums.js";
+import { Misc } from "../misc.js";
 
 export class BaseItemSheet extends ItemSheet {
 
@@ -35,6 +36,7 @@ export class BaseItemSheet extends ItemSheet {
       {
         options: {
           isGM: game.user.isGM,
+          limited: !this.document.isOwner,
           owner: this.document.isOwner,
           isOwned: (this.actor != undefined),
           editable: this.isEditable,
@@ -44,6 +46,12 @@ export class BaseItemSheet extends ItemSheet {
         ANARCHY: ANARCHY
       });
     hbsData.system = this.item.system;
+
+    const editableClass = this.isEditable ? "editable" : "locked";
+    const baseClasses = hbsData.options?.classes ?? [];
+    const classes = Misc.distinct([...baseClasses, editableClass]);
+    hbsData.options.classes = classes;
+    hbsData.options.cssClass = classes.join(" ");
 
     return hbsData;
   }

--- a/src/start.js
+++ b/src/start.js
@@ -1,5 +1,3 @@
-import { AnarchySystem } from "./modules/anarchy-system.js"
+import { AnarchySystem } from "./modules/anarchy-system.js";
 
 AnarchySystem.start();
-
-import "./styles/global.scss"

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,0 +1,3 @@
+@use "./global.scss";
+@use "./character-enhanced-sheet.scss";
+@use "./gm-manager.scss";

--- a/style.css
+++ b/style.css
@@ -1,7 +1,1649 @@
-// only required in dev
+.wrapper-hexabox {
+  --wrapper-padding: 6px;
+  --wrapper-background-color: white;
+  --wrapper-border-color: black;
+  position: relative;
+  padding: var(--wrapper-padding);
+  text-align: center;
+}
+.wrapper-hexabox > .content {
+  height: 100%;
+  background-color: var(--wrapper-background-color);
+}
+.wrapper-hexabox > .side {
+  position: absolute;
+  background-color: var(--wrapper-background-color);
+}
+.wrapper-hexabox > .side.up {
+  height: var(--wrapper-padding);
+  left: var(--wrapper-padding);
+  right: var(--wrapper-padding);
+  border-top: var(--wrapper-thickness, 2px) solid var(--wrapper-border-color);
+  top: 0px;
+}
+.wrapper-hexabox > .side.down {
+  height: var(--wrapper-padding);
+  left: var(--wrapper-padding);
+  right: var(--wrapper-padding);
+  border-bottom: var(--wrapper-thickness, 2px) solid var(--wrapper-border-color);
+  bottom: 0px;
+}
+.wrapper-hexabox > .side.left {
+  width: var(--wrapper-padding);
+  left: 0px;
+  border-left: var(--wrapper-thickness, 2px) solid var(--wrapper-border-color);
+  top: var(--wrapper-padding);
+  bottom: var(--wrapper-padding);
+}
+.wrapper-hexabox > .side.right {
+  width: var(--wrapper-padding);
+  right: 0px;
+  border-right: var(--wrapper-thickness, 2px) solid var(--wrapper-border-color);
+  top: var(--wrapper-padding);
+  bottom: var(--wrapper-padding);
+}
+.wrapper-hexabox > .angle {
+  width: 0px;
+  height: 0px;
+  position: absolute;
+}
+.wrapper-hexabox > .angle.tl {
+  top: 0;
+  left: 0;
+  border-top: var(--wrapper-padding) solid transparent;
+  border-right: var(--wrapper-padding) solid var(--wrapper-background-color);
+}
+.wrapper-hexabox > .angle.tl::before {
+  content: "";
+  position: absolute;
+  display: block;
+  border-top: var(--wrapper-thickness, 2px) solid var(--wrapper-border-color);
+  width: calc(1.41 * var(--wrapper-padding));
+  left: 1px;
+  top: -1px;
+  transform-origin: bottom left;
+  transform: rotate(-45deg);
+}
+.wrapper-hexabox > .angle.tr {
+  top: 0;
+  right: 0;
+  border-top: var(--wrapper-padding) solid transparent;
+  border-left: var(--wrapper-padding) solid var(--wrapper-background-color);
+}
+.wrapper-hexabox > .angle.tr::before {
+  content: "";
+  position: absolute;
+  display: block;
+  border-top: var(--wrapper-thickness, 2px) solid var(--wrapper-border-color);
+  width: calc(1.41 * var(--wrapper-padding));
+  left: 0px;
+  top: -2px;
+  transform-origin: bottom left;
+  transform: rotate(-135deg);
+}
+.wrapper-hexabox > .angle.br {
+  bottom: 0;
+  right: 0;
+  border-bottom: var(--wrapper-padding) solid transparent;
+  border-left: var(--wrapper-padding) solid var(--wrapper-background-color);
+}
+.wrapper-hexabox > .angle.br::before {
+  content: "";
+  position: absolute;
+  display: block;
+  border-top: var(--wrapper-thickness, 2px) solid var(--wrapper-border-color);
+  width: calc(1.41 * var(--wrapper-padding));
+  top: -3px;
+  left: -2px;
+  transform-origin: bottom left;
+  transform: rotate(135deg);
+}
+.wrapper-hexabox > .angle.bl {
+  bottom: 0;
+  left: 0;
+  border-bottom: var(--wrapper-padding) solid transparent;
+  border-right: var(--wrapper-padding) solid var(--wrapper-background-color);
+}
+.wrapper-hexabox > .angle.bl::before {
+  content: "";
+  position: absolute;
+  display: block;
+  border-top: var(--wrapper-thickness, 2px) solid var(--wrapper-border-color);
+  width: calc(1.41 * var(--wrapper-padding));
+  top: -2px;
+  left: 0px;
+  transform-origin: bottom left;
+  transform: rotate(45deg);
+}
 
-// in prod, foundry loads style.css, as compiled by vite/rollup,
-// mostly from the `import lancer.scss` line at the top of lancer.ts
+.sheet .character-enhanced {
+  --darkglass-color-font: black !important;
+  --darkglass-background-attributes: white !important;
+  color: var(--darkglass-color-font);
+  container-type: inline-size;
+}
+.sheet .character-enhanced a {
+  transition: all 200ms;
+  cursor: pointer !important;
+}
+.sheet .character-enhanced a:hover {
+  text-shadow: inherit;
+  transform: scale(1.1);
+}
+.sheet .character-enhanced h2 {
+  border-bottom: 0px solid transparent;
+}
+.sheet .character-enhanced input {
+  background-color: #f1f4ff;
+}
+.sheet .character-enhanced header {
+  height: 150px;
+  display: grid;
+  grid-template-columns: 150px 1fr;
+  position: relative;
+}
+@container (max-width:700px) {
+  .sheet .character-enhanced header {
+    height: 220px;
+  }
+  .sheet .character-enhanced header .name-attributes {
+    grid-template-rows: 50px 170px !important;
+  }
+  .sheet .character-enhanced header .attributes {
+    grid-template-columns: 1fr 1fr 1fr !important;
+  }
+  .sheet .character-enhanced header .avatar img {
+    margin-top: 47px;
+  }
+  .sheet .character-enhanced header .name-attributes .name {
+    width: calc(100% + 145px);
+    margin-left: -136px;
+  }
+  .sheet .character-enhanced header .roleplay {
+    grid-template-columns: 1fr !important;
+  }
+}
+.sheet .character-enhanced header .avatar {
+  position: relative;
+  position: relative;
+  margin-top: -6px;
+  margin-left: -6px;
+}
+.sheet .character-enhanced header .avatar > .angle.tr {
+  display: none;
+}
+.sheet .character-enhanced header .avatar .metatype {
+  position: absolute;
+  bottom: 0px;
+  right: 0px;
+  width: 100px;
+  font-size: 10px;
+}
+.sheet .character-enhanced header .avatar .metatype .anarchy-metatype {
+  gap: 8px;
+  background-color: white;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding-right: 6px;
+}
+.sheet .character-enhanced header .avatar .metatype .anarchy-metatype.info-value {
+  padding-right: 0px;
+}
+.sheet .character-enhanced header .avatar .metatype .anarchy-metatype span {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.sheet .character-enhanced header .name-attributes {
+  display: grid;
+  grid-template-rows: 50px 100px;
+}
+.sheet .character-enhanced header .name-attributes .name {
+  transform: translate(-12px, -4px);
+  margin-right: -12px;
+  padding-top: 0px;
+  position: relative;
+}
+.sheet .character-enhanced header .name-attributes .name > .side.up,
+.sheet .character-enhanced header .name-attributes .name > .angle.tr,
+.sheet .character-enhanced header .name-attributes .name > .angle.tl {
+  display: none;
+}
+.sheet .character-enhanced header .name-attributes .name > .right,
+.sheet .character-enhanced header .name-attributes .name > .left {
+  top: 0px;
+}
+.sheet .character-enhanced header .name-attributes .name .input {
+  margin-right: 70px;
+  height: 40px;
+  margin-top: 3px;
+  margin-left: 2px;
+  font-size: 24px;
+}
+.sheet .character-enhanced header .name-attributes .name .input input {
+  font-family: "BebasNeue";
+  padding: 11px 0px 4px 4px;
+  background-color: transparent;
+  font-weight: bold;
+}
+.sheet .character-enhanced header .name-attributes .name .awarness {
+  position: absolute;
+  right: 5px;
+  top: 5px;
+  display: flex;
+  flex-direction: row-reverse;
+  gap: 8px;
+  align-items: center;
+}
+.sheet .character-enhanced header .name-attributes .name .awarness select {
+  border: 0px;
+  background-color: white;
+}
+.sheet .character-enhanced header .name-attributes .name .awarness .connection-mode,
+.sheet .character-enhanced header .name-attributes .name .awarness .view-mode {
+  transform: translateY(3px);
+  font-size: 12px;
+}
+.sheet .character-enhanced header .name-attributes .name .awarness .connection-mode i,
+.sheet .character-enhanced header .name-attributes .name .awarness .view-mode i {
+  font-size: 16px;
+}
+.sheet .character-enhanced header .name-attributes .name .awarness .connection-mode,
+.sheet .character-enhanced header .name-attributes .name .awarness .view-mode {
+  display: flex;
+  flex-direction: column;
+}
+.sheet .character-enhanced header .name-attributes .attributes {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr;
+  background-image: linear-gradient(to bottom, #ffffff 0%, #dcdddf 50%, #989999 100%);
+  padding-bottom: 32px;
+  margin-right: -4px;
+}
+.sheet .character-enhanced header .name-attributes .attributes .attribute {
+  display: grid;
+  grid-template-rows: 1fr 2fr;
+  padding: 2px 8px 0 8px;
+  font-family: "BebasNeue";
+}
+.sheet .character-enhanced header .name-attributes .attributes .attribute .label {
+  font-size: 18px;
+  text-transform: uppercase;
+  text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
+  color: #f4c000;
+  font-weight: bold;
+  font-family: "BebasNeue";
+  letter-spacing: 2px;
+}
+.sheet .character-enhanced header .name-attributes .attributes .attribute .attribute-infos {
+  position: relative;
+}
+.sheet .character-enhanced header .name-attributes .attributes .attribute .attribute-infos a {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 28px;
+}
+.sheet .character-enhanced header .name-attributes .attributes .attribute .attribute-infos .value {
+  position: absolute;
+  bottom: -4px;
+  right: -4px;
+  font-size: 14px;
+  width: 18px;
+  height: 22px;
+}
+.sheet .character-enhanced .item {
+  opacity: 1;
+  transition: opacity 200ms ease-out;
+}
+.sheet .character-enhanced .item.inactive {
+  background: transparent !important;
+  opacity: 0.3;
+}
+.sheet .character-enhanced .roleplay {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  font-size: 20px;
+  gap: 0px;
+  font-weight: bold;
+  margin-right: -5px;
+}
+@container (max-width:700px) {
+  .sheet .character-enhanced .roleplay {
+    display: none;
+  }
+}
+.sheet .character-enhanced .roleplay h3 {
+  border-bottom: none;
+  padding: 8px 0 0 0;
+  text-transform: uppercase;
+  font-size: 1.1em;
+  font-weight: bold;
+  font-family: BebasNeue;
+  letter-spacing: 1px;
+  display: flex;
+  align-content: center;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+}
+.sheet .character-enhanced .roleplay h3 a {
+  display: flex;
+  align-items: center;
+  align-content: center;
+  justify-content: center;
+}
+.sheet .character-enhanced .roleplay .behavior,
+.sheet .character-enhanced .roleplay .keyword {
+  border-top: 2px solid black;
+  padding-top: 2px;
+  box-shadow: var(--anarchy-shadow-section);
+  z-index: 0;
+}
+.sheet .character-enhanced .roleplay .behavior {
+  transform: translateX(-1px);
+}
+.sheet .character-enhanced .roleplay .quote {
+  --wrapper-padding: 19px;
+  margin-top: -26px;
+  padding-bottom: 0px;
+}
+.sheet .character-enhanced .roleplay .quote .side.up {
+  box-shadow: var(--anarchy-shadow-section);
+  height: 12px;
+  transform: translateY(7px);
+}
+.sheet .character-enhanced .roleplay .quote .angle.tl,
+.sheet .character-enhanced .roleplay .quote .angle.tr {
+  transform: translateY(7px);
+}
+.sheet .character-enhanced .roleplay .quote .side.down,
+.sheet .character-enhanced .roleplay .quote .side.left,
+.sheet .character-enhanced .roleplay .quote .side.right,
+.sheet .character-enhanced .roleplay .quote .angle.bl,
+.sheet .character-enhanced .roleplay .quote .angle.br {
+  display: none;
+}
+.sheet .character-enhanced .roleplay .quote .center {
+  background-color: white;
+}
+.sheet .character-enhanced .roleplay .quote .center .label {
+  transform: translateY(-14px);
+}
+.sheet .character-enhanced .roleplay input {
+  height: 20px;
+  font-size: 14px;
+  border-top: 0px;
+  border-left: 0px;
+  border-right: 0px;
+  border-bottom: 1px solid black;
+  border-radius: 0px;
+  margin-bottom: 5px;
+}
+.sheet .character-enhanced .section-monitors,
+.sheet .character-enhanced .section-skills,
+.sheet .character-enhanced .section-roleplay,
+.sheet .character-enhanced .section-keywords,
+.sheet .character-enhanced .section-cues,
+.sheet .character-enhanced .section-dispositions,
+.sheet .character-enhanced .section-actions,
+.sheet .character-enhanced .section-qualities,
+.sheet .character-enhanced .section-equipments,
+.sheet .character-enhanced .section-owned,
+.sheet .character-enhanced .section-shadowamps {
+  max-height: 1000px;
+  transition: max-height 400ms cubic-bezier(0.14, 0.87, 0.5, 0.97);
+}
+.sheet .character-enhanced .section-monitors:not(.wrapper),
+.sheet .character-enhanced .section-skills:not(.wrapper),
+.sheet .character-enhanced .section-roleplay:not(.wrapper),
+.sheet .character-enhanced .section-keywords:not(.wrapper),
+.sheet .character-enhanced .section-cues:not(.wrapper),
+.sheet .character-enhanced .section-dispositions:not(.wrapper),
+.sheet .character-enhanced .section-actions:not(.wrapper),
+.sheet .character-enhanced .section-qualities:not(.wrapper),
+.sheet .character-enhanced .section-equipments:not(.wrapper),
+.sheet .character-enhanced .section-owned:not(.wrapper),
+.sheet .character-enhanced .section-shadowamps:not(.wrapper) {
+  transition: max-height 400ms cubic-bezier(0.78, 0.32, 0.88, 0.38);
+  overflow: hidden;
+}
+.sheet .character-enhanced .section-monitors.closed,
+.sheet .character-enhanced .section-skills.closed,
+.sheet .character-enhanced .section-roleplay.closed,
+.sheet .character-enhanced .section-keywords.closed,
+.sheet .character-enhanced .section-cues.closed,
+.sheet .character-enhanced .section-dispositions.closed,
+.sheet .character-enhanced .section-actions.closed,
+.sheet .character-enhanced .section-qualities.closed,
+.sheet .character-enhanced .section-equipments.closed,
+.sheet .character-enhanced .section-owned.closed,
+.sheet .character-enhanced .section-shadowamps.closed {
+  max-height: 0px;
+}
+.sheet .character-enhanced .section-monitors.quote.closed,
+.sheet .character-enhanced .section-skills.quote.closed,
+.sheet .character-enhanced .section-roleplay.quote.closed,
+.sheet .character-enhanced .section-keywords.quote.closed,
+.sheet .character-enhanced .section-cues.quote.closed,
+.sheet .character-enhanced .section-dispositions.quote.closed,
+.sheet .character-enhanced .section-actions.quote.closed,
+.sheet .character-enhanced .section-qualities.quote.closed,
+.sheet .character-enhanced .section-equipments.quote.closed,
+.sheet .character-enhanced .section-owned.quote.closed,
+.sheet .character-enhanced .section-shadowamps.quote.closed {
+  max-height: 36px;
+}
+.sheet .character-enhanced .section-roleplay {
+  max-height: 300px;
+  transition: max-height 300ms ease-out;
+}
+.sheet .character-enhanced .section-roleplay:not(.wrapper) {
+  transition: max-height 300ms ease-out;
+  overflow: hidden;
+}
+.sheet .character-enhanced .click-section {
+  cursor: pointer;
+}
+.sheet .character-enhanced .actions {
+  background-color: #e3e4e6;
+  border-top: 2px solid black;
+  z-index: 0;
+  position: relative;
+  margin-left: -4px;
+  margin-right: -4px;
+  padding: 0 0rem 2rem 0rem;
+  box-shadow: var(--anarchy-shadow-section);
+}
+.sheet .character-enhanced .actions h2 {
+  --wrapper-padding: 19px;
+  --wrapper-background-color: #e3e4e6;
+  display: inline-block;
+  margin-top: -19px;
+  padding-bottom: 0px;
+  margin-bottom: 0px;
+}
+.sheet .character-enhanced .actions h2 .side.up {
+  box-shadow: var(--anarchy-shadow-section);
+}
+.sheet .character-enhanced .actions h2 .side.down,
+.sheet .character-enhanced .actions h2 .side.right,
+.sheet .character-enhanced .actions h2 .side.left,
+.sheet .character-enhanced .actions h2 .angle.br,
+.sheet .character-enhanced .actions h2 .angle.bl {
+  display: none;
+}
+.sheet .character-enhanced .actions h2 .content {
+  color: black;
+  font-size: 1.2em;
+  border-bottom: none;
+  text-transform: uppercase;
+  font-weight: bold;
+  font-family: "BebasNeue";
+  letter-spacing: 2px;
+  background-color: #e3e4e6;
+  transform: translateY(-14px);
+  display: flex;
+  align-content: center;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+}
+.sheet .character-enhanced .actions h2 .content a {
+  text-shadow: -1px 0 transparent, 1px -1px 0 transparent, -1px 1px 0 transparent, 1px 1px 0 transparent;
+  display: flex;
+  align-items: center;
+  align-content: center;
+  justify-content: center;
+}
+.sheet .character-enhanced .actions .action-list {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  padding: 0 16px;
+}
+@container (max-width:500px) {
+  .sheet .character-enhanced .actions .action-list {
+    grid-template-columns: 1fr;
+  }
+}
+.sheet .character-enhanced .actions .action-list .item-list > .content {
+  padding: 8px;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: 1fr 1fr;
+  background-color: white;
+}
+.sheet .character-enhanced .actions .action-list .item-list > .content a {
+  background-color: transparent;
+  --wrapper-background-color: #f4c000;
+  --wrapper-padding: 8px;
+  color: white;
+  font-size: 18px;
+  text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
+  transition: 200ms;
+}
+.sheet .character-enhanced .actions .action-list .item-list > .content a:hover {
+  transform: scale(1.05);
+}
+.sheet .character-enhanced .actions .action-list .item-list > .content a > .content {
+  padding: 0px 8px 0px 24px;
+  font-size: 16px;
+  align-items: center;
+  justify-content: center;
+  display: grid;
+}
+.sheet .character-enhanced .actions .action-list .item-list > .content a > .content .attribute-button-icon {
+  --wrapper-background-color: #f4c000;
+  position: absolute;
+  top: -5px;
+  left: -5px;
+  width: 36px;
+}
+.sheet .character-enhanced .actions .action-list .item-list > .content a > .content label {
+  display: block;
+  text-align: center;
+  font-size: 14px;
+  text-shadow: none;
+  color: black;
+  cursor: pointer;
+}
+.sheet .character-enhanced .actions .action-list .weapons .content .title {
+  margin-top: 0px;
+  padding: 4px;
+  font-family: "BebasNeue";
+  font-size: 18px;
+  letter-spacing: 1px;
+  text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
+  color: white;
+}
+.sheet .character-enhanced .actions .action-list .weapons .content .weapon-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 0 2px;
+}
+.sheet .character-enhanced .actions .action-list .weapons .content .weapon-list .weapon {
+  padding: 6px;
+  transition: 200ms;
+  background-color: transparent;
+  --wrapper-border-color: black;
+}
+.sheet .character-enhanced .actions .action-list .weapons .content .weapon-list .weapon:hover {
+  transform: scale(1.01);
+}
+.sheet .character-enhanced .actions .action-list .weapons .content .weapon-list .weapon .content {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 50px 1fr;
+  cursor: pointer;
+}
+.sheet .character-enhanced .actions .action-list .weapons .content .weapon-list .weapon .content .item-controls {
+  position: absolute;
+  bottom: 4px;
+  right: 6px;
+  text-align: center;
+}
+.sheet .character-enhanced .actions .action-list .weapons .content .weapon-list .weapon .content .weapon-name {
+  font-family: "BebasNeue";
+  font-size: 16px;
+  letter-spacing: 0px;
+}
+.sheet .character-enhanced .actions .action-list .weapons .content .weapon-list .weapon .content .weapon-desc {
+  font-size: 12px;
+  padding: 2px 0;
+}
+.sheet .character-enhanced .actions .action-list .weapons .content .weapon-list .weapon .content .weapon-desc span p {
+  margin: 0;
+}
+.sheet .character-enhanced .actions .action-list .weapons .content .weapon-list .weapon .content .weapon-img {
+  width: 42px !important;
+}
+.sheet .character-enhanced .actions .action-list .weapons .content .weapon-list .weapon .content .weapon-img .item-img {
+  width: 42px !important;
+  height: 42px !important;
+}
+.sheet .character-enhanced .actions .action-list .weapons .content .weapon-list .weapon .content .weapon-info {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+.sheet .character-enhanced .actions .action-list .weapons .content .weapon-list .weapon .content .weapon-info .weapon-stats {
+  display: grid;
+  flex-direction: row;
+  grid-template-columns: 1fr 1fr;
+}
+.sheet .character-enhanced .actions .action-list .weapons .content .weapon-list .weapon .content .weapon-info .weapon-stats .weapon-range {
+  text-wrap: nowrap;
+  font-family: "BebasNeue";
+}
+.sheet .character-enhanced .actions .action-list .weapons .content .weapon-list .weapon .content .weapon-info .weapon-stats .weapon-dmg {
+  font-family: "BebasNeue";
+}
+.sheet .character-enhanced .skills {
+  background-color: #fec81c;
+  border-top: 2px solid black;
+  z-index: 0;
+  position: relative;
+  margin-left: -4px;
+  margin-right: -4px;
+  padding: 0 0rem 2rem 0rem;
+  box-shadow: var(--anarchy-shadow-section);
+}
+.sheet .character-enhanced .skills h2 {
+  --wrapper-padding: 19px;
+  --wrapper-background-color: #fec81c;
+  display: inline-block;
+  margin-top: -19px;
+  padding-bottom: 0px;
+  margin-bottom: 0px;
+}
+.sheet .character-enhanced .skills h2 .side.up {
+  box-shadow: var(--anarchy-shadow-section);
+}
+.sheet .character-enhanced .skills h2 .side.down,
+.sheet .character-enhanced .skills h2 .side.right,
+.sheet .character-enhanced .skills h2 .side.left,
+.sheet .character-enhanced .skills h2 .angle.br,
+.sheet .character-enhanced .skills h2 .angle.bl {
+  display: none;
+}
+.sheet .character-enhanced .skills h2 .content {
+  color: white;
+  font-size: 1.2em;
+  border-bottom: none;
+  text-transform: uppercase;
+  text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
+  font-weight: bold;
+  font-family: "BebasNeue";
+  letter-spacing: 2px;
+  background-color: #fec81c;
+  transform: translateY(-14px);
+  display: flex;
+  align-content: center;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+}
+.sheet .character-enhanced .skills h2 .content a {
+  text-shadow: -1px 0 transparent, 1px -1px 0 transparent, -1px 1px 0 transparent, 1px 1px 0 transparent;
+  display: flex;
+  align-items: center;
+  align-content: center;
+  justify-content: center;
+}
+.sheet .character-enhanced .skills .item-list {
+  overflow: auto;
+  margin-bottom: 16px;
+  padding: 1rem 1rem 0 1rem;
+  margin-top: 0rem;
+  gap: 1rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+}
+.sheet .character-enhanced .skills .item-list .anarchy-skill {
+  --wrapper-padding: 12px;
+}
+.sheet .character-enhanced .skills .item-list .anarchy-skill .content {
+  max-width: none;
+  display: grid;
+  flex-direction: row;
+  grid-template-columns: 46px 1fr;
+}
+.sheet .character-enhanced .skills .item-list .anarchy-skill .content .skill-img {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 6px;
+}
+.sheet .character-enhanced .skills .item-list .anarchy-skill .content .skill-img .anarchy-img {
+  width: 46px;
+  height: 46px;
+}
+.sheet .character-enhanced .skills .item-list .anarchy-skill .content .skill-img .item-controls {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+}
+.sheet .character-enhanced .skills .item-list .anarchy-skill .content .skill-txt {
+  padding: 0px 16px;
+}
+.sheet .character-enhanced .skills .item-list .anarchy-skill .content .skill-txt .title {
+  font-family: "BebasNeue";
+  font-size: 18px;
+  letter-spacing: 1px;
+}
+.sheet .character-enhanced .skills .item-list .anarchy-skill .level {
+  position: absolute;
+  top: 10px;
+  transform: translateY(-50%);
+  position: absolute;
+  width: 32px;
+  height: 32px;
+  font-weight: bold;
+  left: -6px;
+  transform: translateY(-50%);
+}
+.sheet .character-enhanced .skills .item-list .anarchy-skill .level .content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+}
+.sheet .character-enhanced .shadowamps {
+  background-color: #dcdddf;
+  border-top: 2px solid black;
+  z-index: 0;
+  position: relative;
+  margin-top: 0px;
+  margin-left: -4px;
+  margin-right: -4px;
+  padding: 0 0rem 2rem 0rem;
+  box-shadow: var(--anarchy-shadow-section);
+}
+.sheet .character-enhanced .shadowamps .item-controls {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+}
+.sheet .character-enhanced .shadowamps h2 {
+  --wrapper-padding: 19px;
+  --wrapper-background-color: #dcdddf;
+  display: inline-block;
+  margin-top: -19px;
+  padding-bottom: 0px;
+  margin-bottom: 0px;
+}
+.sheet .character-enhanced .shadowamps h2 .side.up {
+  box-shadow: var(--anarchy-shadow-section);
+}
+.sheet .character-enhanced .shadowamps h2 .side.down,
+.sheet .character-enhanced .shadowamps h2 .side.right,
+.sheet .character-enhanced .shadowamps h2 .side.left,
+.sheet .character-enhanced .shadowamps h2 .angle.br,
+.sheet .character-enhanced .shadowamps h2 .angle.bl {
+  display: none;
+}
+.sheet .character-enhanced .shadowamps h2 .content {
+  color: white;
+  font-size: 1.2em;
+  border-bottom: none;
+  text-transform: uppercase;
+  text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
+  font-weight: bold;
+  font-family: "BebasNeue";
+  letter-spacing: 2px;
+  background-color: #dcdddf;
+  transform: translateY(-14px);
+  display: flex;
+  align-content: center;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+}
+.sheet .character-enhanced .shadowamps h2 .content a {
+  text-shadow: -1px 0 transparent, 1px -1px 0 transparent, -1px 1px 0 transparent, 1px 1px 0 transparent;
+  display: flex;
+  align-items: center;
+  align-content: center;
+  justify-content: center;
+}
+.sheet .character-enhanced .shadowamps .item-list {
+  overflow: auto;
+  margin-bottom: 16px;
+  gap: 1rem;
+  padding: 1rem 1rem 0 1rem;
+  margin-top: 0rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+}
+.sheet .character-enhanced .shadowamps .item-list .anarchy-shadowamp {
+  --wrapper-padding: 12px;
+}
+.sheet .character-enhanced .shadowamps .item-list .anarchy-shadowamp .content {
+  display: flex;
+  flex-direction: row;
+}
+.sheet .character-enhanced .shadowamps .item-list .anarchy-shadowamp .content .shadowamp-img {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-width: 46px;
+}
+.sheet .character-enhanced .shadowamps .item-list .anarchy-shadowamp .content .shadowamp-img .anarchy-img {
+  width: 46px;
+  height: 46px;
+}
+.sheet .character-enhanced .shadowamps .item-list .anarchy-shadowamp .content .shadowamp-content {
+  max-width: none;
+  padding-left: 12px;
+  text-align: left;
+}
+.sheet .character-enhanced .shadowamps .item-list .anarchy-shadowamp .content .shadowamp-content .title {
+  font-family: "BebasNeue";
+  font-weight: bold;
+  font-size: 18px;
+  letter-spacing: 1px;
+}
+.sheet .character-enhanced .shadowamps .item-list .anarchy-shadowamp .level {
+  position: absolute;
+  transform: translateY(-50%);
+  position: absolute;
+  width: 32px;
+  height: 32px;
+  top: 10px;
+  font-weight: bold;
+  left: -6px;
+  transform: translateY(-50%);
+}
+.sheet .character-enhanced .shadowamps .item-list .anarchy-shadowamp .level .content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+}
+.sheet .character-enhanced .monitors {
+  background-color: #dcdddf;
+  border-top: 2px solid black;
+  z-index: 0;
+  position: relative;
+  margin-top: 24px;
+  margin-left: -4px;
+  margin-right: -4px;
+  padding: 0 1rem 2rem 1rem;
+  box-shadow: var(--anarchy-shadow-section);
+}
+@container (max-width:700px) {
+  .sheet .character-enhanced .monitors {
+    margin-top: 0;
+  }
+}
+.sheet .character-enhanced .monitors h2 {
+  --wrapper-padding: 19px;
+  --wrapper-background-color: #dcdddf;
+  display: inline-block;
+  margin-top: -19px;
+  padding-bottom: 0px;
+  margin-bottom: 0px;
+}
+.sheet .character-enhanced .monitors h2 .side.up {
+  box-shadow: var(--anarchy-shadow-section);
+}
+.sheet .character-enhanced .monitors h2 .side.down,
+.sheet .character-enhanced .monitors h2 .side.right,
+.sheet .character-enhanced .monitors h2 .side.left,
+.sheet .character-enhanced .monitors h2 .angle.br,
+.sheet .character-enhanced .monitors h2 .angle.bl {
+  display: none;
+}
+.sheet .character-enhanced .monitors h2 .content {
+  color: white;
+  font-size: 1.2em;
+  border-bottom: none;
+  text-transform: uppercase;
+  text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
+  font-weight: bold;
+  font-family: "BebasNeue";
+  letter-spacing: 2px;
+  background-color: #dcdddf;
+  transform: translateY(-14px);
+  display: flex;
+  align-content: center;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+}
+.sheet .character-enhanced .monitors h2 .content a {
+  text-shadow: -1px 0 transparent, 1px -1px 0 transparent, -1px 1px 0 transparent, 1px 1px 0 transparent;
+  display: flex;
+  align-items: center;
+  align-content: center;
+  justify-content: center;
+}
+.sheet .character-enhanced .monitors .monitor-list {
+  display: grid;
+  grid-template-columns: 1fr 376px;
+  gap: 8px;
+}
+.sheet .character-enhanced .monitors .monitor-list .checkbar-img {
+  width: 24px;
+  height: 24px;
+}
+.sheet .character-enhanced .monitors .monitor-list .tokens {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.sheet .character-enhanced .monitors .monitor-list .health {
+  display: grid;
+  grid-template-columns: 120px 120px 120px;
+  gap: 8px;
+}
+.sheet .character-enhanced .monitors .monitor-list .armor .content,
+.sheet .character-enhanced .monitors .monitor-list .physical .content,
+.sheet .character-enhanced .monitors .monitor-list .fatigue .content,
+.sheet .character-enhanced .monitors .monitor-list .tokens .content {
+  padding-top: 8px;
+  position: relative;
+  background-color: white;
+}
+.sheet .character-enhanced .monitors .monitor-list .armor .content .title,
+.sheet .character-enhanced .monitors .monitor-list .physical .content .title,
+.sheet .character-enhanced .monitors .monitor-list .fatigue .content .title,
+.sheet .character-enhanced .monitors .monitor-list .tokens .content .title {
+  height: 20px;
+  font-size: 18px;
+  color: white;
+  text-transform: uppercase;
+  text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
+  font-weight: bold;
+  font-family: "BebasNeue";
+  letter-spacing: 2px;
+  display: flex;
+  flex-direction: row;
+  gap: 4px;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 4px;
+}
+.sheet .character-enhanced .monitors .monitor-list .armor .content .title input.info-value,
+.sheet .character-enhanced .monitors .monitor-list .physical .content .title input.info-value,
+.sheet .character-enhanced .monitors .monitor-list .fatigue .content .title input.info-value,
+.sheet .character-enhanced .monitors .monitor-list .tokens .content .title input.info-value {
+  text-align: center;
+  font-size: 16px;
+  width: 28px;
+  height: 20px;
+}
+.sheet .character-enhanced .monitors .monitor-list .armor .content .anarchy-monitor,
+.sheet .character-enhanced .monitors .monitor-list .physical .content .anarchy-monitor,
+.sheet .character-enhanced .monitors .monitor-list .fatigue .content .anarchy-monitor,
+.sheet .character-enhanced .monitors .monitor-list .tokens .content .anarchy-monitor {
+  margin-top: 8px;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  font-family: "BebasNeue";
+}
+.sheet .character-enhanced .monitors .monitor-list .armor .content .anarchy-monitor .checkbar-root,
+.sheet .character-enhanced .monitors .monitor-list .physical .content .anarchy-monitor .checkbar-root,
+.sheet .character-enhanced .monitors .monitor-list .fatigue .content .anarchy-monitor .checkbar-root,
+.sheet .character-enhanced .monitors .monitor-list .tokens .content .anarchy-monitor .checkbar-root {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+}
+.sheet .character-enhanced .monitors .monitor-list .armor .content .anarchy-monitor .checkbar-root .checkbar,
+.sheet .character-enhanced .monitors .monitor-list .physical .content .anarchy-monitor .checkbar-root .checkbar,
+.sheet .character-enhanced .monitors .monitor-list .fatigue .content .anarchy-monitor .checkbar-root .checkbar,
+.sheet .character-enhanced .monitors .monitor-list .tokens .content .anarchy-monitor .checkbar-root .checkbar {
+  justify-content: center;
+  display: grid;
+  gap: 12px 5px;
+}
+.sheet .character-enhanced .monitors .monitor-list .armor .content .anarchy-monitor .checkbar-root .checkbar .click-checkbar-element,
+.sheet .character-enhanced .monitors .monitor-list .physical .content .anarchy-monitor .checkbar-root .checkbar .click-checkbar-element,
+.sheet .character-enhanced .monitors .monitor-list .fatigue .content .anarchy-monitor .checkbar-root .checkbar .click-checkbar-element,
+.sheet .character-enhanced .monitors .monitor-list .tokens .content .anarchy-monitor .checkbar-root .checkbar .click-checkbar-element {
+  position: relative;
+}
+.sheet .character-enhanced .monitors .monitor-list .armor .content .anarchy-monitor .checkbar-root .checkbar .click-checkbar-element:after,
+.sheet .character-enhanced .monitors .monitor-list .physical .content .anarchy-monitor .checkbar-root .checkbar .click-checkbar-element:after,
+.sheet .character-enhanced .monitors .monitor-list .fatigue .content .anarchy-monitor .checkbar-root .checkbar .click-checkbar-element:after,
+.sheet .character-enhanced .monitors .monitor-list .tokens .content .anarchy-monitor .checkbar-root .checkbar .click-checkbar-element:after {
+  content: "";
+  position: absolute;
+  border-top: 1px dotted #777;
+  width: 6px;
+  right: -5px;
+  top: 6px;
+}
+.sheet .character-enhanced .monitors .monitor-list .armor .content .anarchy-monitor .checkbar-root .checkbar .click-checkbar-element:nth-child(3n):after,
+.sheet .character-enhanced .monitors .monitor-list .physical .content .anarchy-monitor .checkbar-root .checkbar .click-checkbar-element:nth-child(3n):after,
+.sheet .character-enhanced .monitors .monitor-list .fatigue .content .anarchy-monitor .checkbar-root .checkbar .click-checkbar-element:nth-child(3n):after,
+.sheet .character-enhanced .monitors .monitor-list .tokens .content .anarchy-monitor .checkbar-root .checkbar .click-checkbar-element:nth-child(3n):after {
+  width: 33px;
+  right: 15px;
+  top: 21px;
+  transform: rotate(151deg);
+}
+.sheet .character-enhanced .monitors .monitor-list .armor .content .anarchy-monitor .checkbar-root .checkbar .click-checkbar-element:last-child:after,
+.sheet .character-enhanced .monitors .monitor-list .physical .content .anarchy-monitor .checkbar-root .checkbar .click-checkbar-element:last-child:after,
+.sheet .character-enhanced .monitors .monitor-list .fatigue .content .anarchy-monitor .checkbar-root .checkbar .click-checkbar-element:last-child:after,
+.sheet .character-enhanced .monitors .monitor-list .tokens .content .anarchy-monitor .checkbar-root .checkbar .click-checkbar-element:last-child:after {
+  display: none;
+}
+.sheet .character-enhanced .monitors .monitor-list .armor .content .anarchy-monitor .adjust,
+.sheet .character-enhanced .monitors .monitor-list .physical .content .anarchy-monitor .adjust,
+.sheet .character-enhanced .monitors .monitor-list .fatigue .content .anarchy-monitor .adjust,
+.sheet .character-enhanced .monitors .monitor-list .tokens .content .anarchy-monitor .adjust {
+  display: flex;
+  flex-direction: column;
+  margin-left: -10px;
+}
+.sheet .character-enhanced .monitors .monitor-list .armor .content .anarchy-monitor .adjust div,
+.sheet .character-enhanced .monitors .monitor-list .physical .content .anarchy-monitor .adjust div,
+.sheet .character-enhanced .monitors .monitor-list .fatigue .content .anarchy-monitor .adjust div,
+.sheet .character-enhanced .monitors .monitor-list .tokens .content .anarchy-monitor .adjust div {
+  height: 29px;
+  display: flex;
+  align-content: center;
+  justify-content: center;
+}
+.sheet .character-enhanced .monitors .monitor-list .armor .content .anarchy-monitor .adjust div.activated,
+.sheet .character-enhanced .monitors .monitor-list .physical .content .anarchy-monitor .adjust div.activated,
+.sheet .character-enhanced .monitors .monitor-list .fatigue .content .anarchy-monitor .adjust div.activated,
+.sheet .character-enhanced .monitors .monitor-list .tokens .content .anarchy-monitor .adjust div.activated {
+  color: red;
+  font-weight: bold;
+}
+.sheet .character-enhanced .monitors .monitor-list .armor .resistance-label,
+.sheet .character-enhanced .monitors .monitor-list .physical .resistance-label,
+.sheet .character-enhanced .monitors .monitor-list .fatigue .resistance-label,
+.sheet .character-enhanced .monitors .monitor-list .tokens .resistance-label {
+  font-size: 14px;
+  font-family: "BebasNeue";
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 6px;
+}
+.sheet .character-enhanced .monitors .monitor-list .armor .resistance-label .value,
+.sheet .character-enhanced .monitors .monitor-list .physical .resistance-label .value,
+.sheet .character-enhanced .monitors .monitor-list .fatigue .resistance-label .value,
+.sheet .character-enhanced .monitors .monitor-list .tokens .resistance-label .value {
+  font-size: 16px;
+  font-weight: bold;
+}
+.sheet .character-enhanced .monitors .monitor-list .physical .content,
+.sheet .character-enhanced .monitors .monitor-list .fatigue .content {
+  display: grid;
+  grid-template-rows: 20px 1fr 20px;
+}
+.sheet .character-enhanced .monitors .monitor-list .physical .content .anarchy-monitor,
+.sheet .character-enhanced .monitors .monitor-list .fatigue .content .anarchy-monitor {
+  display: grid;
+  grid-template-columns: 1fr 16px;
+}
+.sheet .character-enhanced .monitors .monitor-list .anarchy-essence {
+  height: 100%;
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 8px;
+}
+.sheet .character-enhanced .monitors .monitor-list .anarchy-essence div {
+  flex: 1;
+}
+.sheet .character-enhanced .monitors .monitor-list .edge-credibility {
+  height: 100%;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 8px;
+}
+.sheet .character-enhanced .monitors .monitor-list .edge-credibility div {
+  flex: 1;
+}
+.sheet .character-enhanced .monitors .monitor-list .edge-credibility .edge .content,
+.sheet .character-enhanced .monitors .monitor-list .edge-credibility .rumors .content,
+.sheet .character-enhanced .monitors .monitor-list .edge-credibility .credibility .content {
+  display: grid;
+}
+@container (max-width: 650px) {
+  .sheet .character-enhanced .monitors .monitor-list {
+    grid-template-columns: 1fr;
+  }
+  .sheet .character-enhanced .monitors .monitor-list .health {
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+}
+.sheet .character-enhanced .roleplay-keywords,
+.sheet .character-enhanced .roleplay-dispositions,
+.sheet .character-enhanced .roleplay-cues {
+  background-color: white;
+  display: none;
+  border-top: 2px solid black;
+  z-index: 0;
+  position: relative;
+  margin-top: 0px;
+  margin-left: -4px;
+  margin-right: -4px;
+  padding: 0 1rem 2rem 1rem;
+  box-shadow: var(--anarchy-shadow-section);
+}
+@container (max-width: 700px) {
+  .sheet .character-enhanced .roleplay-keywords,
+  .sheet .character-enhanced .roleplay-dispositions,
+  .sheet .character-enhanced .roleplay-cues {
+    display: inherit;
+  }
+  .sheet .character-enhanced .roleplay-keywords h3,
+  .sheet .character-enhanced .roleplay-dispositions h3,
+  .sheet .character-enhanced .roleplay-cues h3 {
+    display: none;
+  }
+}
+.sheet .character-enhanced .roleplay-keywords h2,
+.sheet .character-enhanced .roleplay-dispositions h2,
+.sheet .character-enhanced .roleplay-cues h2 {
+  --wrapper-padding: 19px;
+  --wrapper-background-color: white;
+  display: inline-block;
+  margin-top: -19px;
+  padding-bottom: 0px;
+  margin-bottom: 0px;
+}
+.sheet .character-enhanced .roleplay-keywords h2 .side.up,
+.sheet .character-enhanced .roleplay-dispositions h2 .side.up,
+.sheet .character-enhanced .roleplay-cues h2 .side.up {
+  box-shadow: var(--anarchy-shadow-section);
+}
+.sheet .character-enhanced .roleplay-keywords h2 .side.down,
+.sheet .character-enhanced .roleplay-keywords h2 .side.right,
+.sheet .character-enhanced .roleplay-keywords h2 .side.left,
+.sheet .character-enhanced .roleplay-keywords h2 .angle.br,
+.sheet .character-enhanced .roleplay-keywords h2 .angle.bl,
+.sheet .character-enhanced .roleplay-dispositions h2 .side.down,
+.sheet .character-enhanced .roleplay-dispositions h2 .side.right,
+.sheet .character-enhanced .roleplay-dispositions h2 .side.left,
+.sheet .character-enhanced .roleplay-dispositions h2 .angle.br,
+.sheet .character-enhanced .roleplay-dispositions h2 .angle.bl,
+.sheet .character-enhanced .roleplay-cues h2 .side.down,
+.sheet .character-enhanced .roleplay-cues h2 .side.right,
+.sheet .character-enhanced .roleplay-cues h2 .side.left,
+.sheet .character-enhanced .roleplay-cues h2 .angle.br,
+.sheet .character-enhanced .roleplay-cues h2 .angle.bl {
+  display: none;
+}
+.sheet .character-enhanced .roleplay-keywords h2 .content,
+.sheet .character-enhanced .roleplay-dispositions h2 .content,
+.sheet .character-enhanced .roleplay-cues h2 .content {
+  color: black;
+  font-size: 1.2em;
+  border-bottom: none;
+  text-transform: uppercase;
+  font-weight: bold;
+  font-family: "BebasNeue";
+  letter-spacing: 2px;
+  background-color: white;
+  transform: translateY(-14px);
+  display: flex;
+  align-content: center;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+}
+.sheet .character-enhanced .roleplay-keywords h2 .content a,
+.sheet .character-enhanced .roleplay-dispositions h2 .content a,
+.sheet .character-enhanced .roleplay-cues h2 .content a {
+  text-shadow: -1px 0 transparent, 1px -1px 0 transparent, -1px 1px 0 transparent, 1px 1px 0 transparent;
+  display: flex;
+  align-items: center;
+  align-content: center;
+  justify-content: center;
+}
+.sheet .character-enhanced .owned,
+.sheet .character-enhanced .equipments {
+  background-color: #fec81c;
+}
+.sheet .character-enhanced .owned.owned,
+.sheet .character-enhanced .equipments.owned {
+  background-color: #e3e4e6;
+}
+.sheet .character-enhanced .owned.owned h2,
+.sheet .character-enhanced .equipments.owned h2 {
+  --wrapper-background-color: #e3e4e6;
+}
+.sheet .character-enhanced .owned.owned h2 .content,
+.sheet .character-enhanced .equipments.owned h2 .content {
+  background-color: #e3e4e6;
+}
+.sheet .character-enhanced .owned,
+.sheet .character-enhanced .equipments {
+  border-top: 2px solid black;
+  z-index: 0;
+  position: relative;
+  margin-top: 0px;
+  margin-left: -4px;
+  margin-right: -4px;
+  padding: 0 1rem 2rem 1rem;
+  box-shadow: var(--anarchy-shadow-section);
+}
+.sheet .character-enhanced .owned h2,
+.sheet .character-enhanced .equipments h2 {
+  --wrapper-padding: 19px;
+  --wrapper-background-color: #fec81c;
+  display: inline-block;
+  margin-top: -19px;
+  padding-bottom: 0px;
+  margin-bottom: 0px;
+}
+.sheet .character-enhanced .owned h2 .side.up,
+.sheet .character-enhanced .equipments h2 .side.up {
+  box-shadow: var(--anarchy-shadow-section);
+}
+.sheet .character-enhanced .owned h2 .side.down,
+.sheet .character-enhanced .owned h2 .side.right,
+.sheet .character-enhanced .owned h2 .side.left,
+.sheet .character-enhanced .owned h2 .angle.br,
+.sheet .character-enhanced .owned h2 .angle.bl,
+.sheet .character-enhanced .equipments h2 .side.down,
+.sheet .character-enhanced .equipments h2 .side.right,
+.sheet .character-enhanced .equipments h2 .side.left,
+.sheet .character-enhanced .equipments h2 .angle.br,
+.sheet .character-enhanced .equipments h2 .angle.bl {
+  display: none;
+}
+.sheet .character-enhanced .owned h2 .content,
+.sheet .character-enhanced .equipments h2 .content {
+  color: white;
+  font-size: 1.2em;
+  border-bottom: none;
+  text-transform: uppercase;
+  text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
+  font-weight: bold;
+  font-family: "BebasNeue";
+  letter-spacing: 2px;
+  background-color: #fec81c;
+  transform: translateY(-14px);
+  display: flex;
+  align-content: center;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+}
+.sheet .character-enhanced .owned h2 .content a,
+.sheet .character-enhanced .equipments h2 .content a {
+  text-shadow: -1px 0 transparent, 1px -1px 0 transparent, -1px 1px 0 transparent, 1px 1px 0 transparent;
+  display: flex;
+  align-items: center;
+  align-content: center;
+  justify-content: center;
+}
+.sheet .character-enhanced .owned .gear-list,
+.sheet .character-enhanced .equipments .gear-list {
+  padding: 0;
+  gap: 8px 1rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+}
+.sheet .character-enhanced .owned .gear-list .gear .content,
+.sheet .character-enhanced .equipments .gear-list .gear .content {
+  padding: 4px;
+}
+.sheet .character-enhanced .owned .gear-list .gear .content p,
+.sheet .character-enhanced .equipments .gear-list .gear .content p {
+  text-align: justify;
+}
+.sheet .character-enhanced .owned .gear-list .gear .content label,
+.sheet .character-enhanced .equipments .gear-list .gear .content label {
+  font-family: "BebasNeue";
+  font-size: 18px;
+  letter-spacing: 1px;
+  font-weight: bold;
+}
+.sheet .character-enhanced .owned .gear-list .gear .item-controls,
+.sheet .character-enhanced .equipments .gear-list .gear .item-controls {
+  position: absolute;
+  bottom: 4px;
+  right: 4px;
+  text-align: center;
+}
+.sheet .character-enhanced .owned .cyberdecks .title,
+.sheet .character-enhanced .equipments .cyberdecks .title {
+  margin-top: 1rem;
+  padding: 4px;
+  font-family: "BebasNeue";
+  font-size: 18px;
+  letter-spacing: 1px;
+  text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
+  color: white;
+}
+.sheet .character-enhanced .owned .cyberdecks .cyberdeck-list,
+.sheet .character-enhanced .equipments .cyberdecks .cyberdeck-list {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+.sheet .character-enhanced .owned .cyberdecks .cyberdeck-list .cyberdeck,
+.sheet .character-enhanced .equipments .cyberdecks .cyberdeck-list .cyberdeck {
+  --wrapper-padding: 25px;
+  --wrapper-thickness: 3px;
+}
+.sheet .character-enhanced .owned .cyberdecks .cyberdeck-list .cyberdeck .content,
+.sheet .character-enhanced .equipments .cyberdecks .cyberdeck-list .cyberdeck .content {
+  display: grid;
+  grid-template-columns: 32px 1fr;
+  gap: 1rem;
+}
+.sheet .character-enhanced .owned .cyberdecks .cyberdeck-list .cyberdeck .content .cyberdeck-details,
+.sheet .character-enhanced .equipments .cyberdecks .cyberdeck-list .cyberdeck .content .cyberdeck-details {
+  display: flex;
+  flex-direction: column;
+}
+.sheet .character-enhanced .owned .cyberdecks .cyberdeck-list .cyberdeck .content .cyberdeck-details .name,
+.sheet .character-enhanced .equipments .cyberdecks .cyberdeck-list .cyberdeck .content .cyberdeck-details .name {
+  font-family: "BebasNeue";
+  font-weight: bold;
+  font-size: 18px;
+  letter-spacing: 1px;
+  transform: translateY(-12px);
+}
+.sheet .character-enhanced .owned .cyberdecks .cyberdeck-list .cyberdeck .content .cyberdeck-details .information,
+.sheet .character-enhanced .equipments .cyberdecks .cyberdeck-list .cyberdeck .content .cyberdeck-details .information {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+}
+.sheet .character-enhanced .owned .cyberdecks .cyberdeck-list .cyberdeck .content .cyberdeck-details .information > :first-child,
+.sheet .character-enhanced .equipments .cyberdecks .cyberdeck-list .cyberdeck .content .cyberdeck-details .information > :first-child {
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+}
+.sheet .character-enhanced .owned .cyberdecks .cyberdeck-list .cyberdeck .content .cyberdeck-details .information .attribute,
+.sheet .character-enhanced .equipments .cyberdecks .cyberdeck-list .cyberdeck .content .cyberdeck-details .information .attribute {
+  text-align: center;
+}
+.sheet .character-enhanced .owned .cyberdecks .cyberdeck-list .cyberdeck .content .cyberdeck-details .information .attribute .anarchy-attribute,
+.sheet .character-enhanced .equipments .cyberdecks .cyberdeck-list .cyberdeck .content .cyberdeck-details .information .attribute .anarchy-attribute {
+  display: flex;
+  height: 35px;
+  align-items: center;
+  justify-content: center;
+}
+.sheet .character-enhanced .owned .cyberdecks .cyberdeck-list .cyberdeck .content .cyberdeck-details .information .attribute .anarchy-attribute a,
+.sheet .character-enhanced .equipments .cyberdecks .cyberdeck-list .cyberdeck .content .cyberdeck-details .information .attribute .anarchy-attribute a {
+  display: block;
+  width: 100%;
+}
+.sheet .character-enhanced .owned .cyberdecks .cyberdeck-list .cyberdeck .item-controls,
+.sheet .character-enhanced .equipments .cyberdecks .cyberdeck-list .cyberdeck .item-controls {
+  position: absolute;
+  top: 14px;
+  right: 32px;
+  text-align: center;
+}
+.sheet .character-enhanced .story {
+  background-color: #e3e4e6;
+  border-top: 2px solid black;
+  z-index: 0;
+  position: relative;
+  margin-top: 0px;
+  margin-left: -4px;
+  margin-right: -4px;
+  padding: 0 1rem 2rem 1rem;
+  box-shadow: var(--anarchy-shadow-section);
+}
+.sheet .character-enhanced .story h2 {
+  --wrapper-padding: 19px;
+  --wrapper-background-color: #e3e4e6;
+  display: inline-block;
+  margin-top: -19px;
+  padding-bottom: 0px;
+  margin-bottom: 0px;
+}
+.sheet .character-enhanced .story h2 .side.up {
+  box-shadow: var(--anarchy-shadow-section);
+}
+.sheet .character-enhanced .story h2 .side.down,
+.sheet .character-enhanced .story h2 .side.right,
+.sheet .character-enhanced .story h2 .side.left,
+.sheet .character-enhanced .story h2 .angle.br,
+.sheet .character-enhanced .story h2 .angle.bl {
+  display: none;
+}
+.sheet .character-enhanced .story h2 .content {
+  color: black;
+  font-size: 1.2em;
+  border-bottom: none;
+  text-transform: uppercase;
+  font-weight: bold;
+  font-family: "BebasNeue";
+  letter-spacing: 2px;
+  background-color: #e3e4e6;
+  transform: translateY(-14px);
+  display: flex;
+  align-content: center;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+}
+.sheet .character-enhanced .story h2 .content a {
+  text-shadow: -1px 0 transparent, 1px -1px 0 transparent, -1px 1px 0 transparent, 1px 1px 0 transparent;
+  display: flex;
+  align-items: center;
+  align-content: center;
+  justify-content: center;
+}
+.sheet .character-enhanced .story .social-info {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+@container (max-width:500px) {
+  .sheet .character-enhanced .story .social-info {
+    grid-template-columns: 1fr;
+  }
+}
+.sheet .character-enhanced .story .social-info {
+  gap: 1rem;
+}
+.sheet .character-enhanced .story .social-info .title {
+  margin-top: 0px;
+  padding: 4px;
+  font-family: "BebasNeue";
+  font-size: 18px;
+  letter-spacing: 1px;
+  text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
+  color: white;
+}
+.sheet .character-enhanced .story .social-info .celeb-table {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+}
+.sheet .character-enhanced .story .social-info .celeb-table > div {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+}
+.sheet .character-enhanced .story .social-info .celeb-table > div .input input {
+  text-align: center;
+}
+.sheet .character-enhanced .story .social-info .karma .karma-wrapper {
+  display: grid;
+  grid-template-columns: 1fr 4px 1fr;
+  gap: 16px;
+}
+.sheet .character-enhanced .story .social-info .karma .karma-wrapper .karma-row:first-child {
+  justify-content: flex-end;
+}
+.sheet .character-enhanced .story .social-info .karma .karma-wrapper .karma-row:last-child {
+  justify-content: flex-start;
+}
+.sheet .character-enhanced .story .social-info .karma .karma-wrapper .karma-row {
+  display: flex;
+  gap: 4px;
+}
+.sheet .character-enhanced .story .social-info .karma .karma-wrapper .karma-row input {
+  text-align: center;
+}
+.sheet .character-enhanced .story .contacts .title {
+  margin-top: 1rem;
+  padding: 4px;
+  font-family: "BebasNeue";
+  font-size: 18px;
+  letter-spacing: 1px;
+  text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
+  color: white;
+}
+.sheet .character-enhanced .story .contacts .contact-list {
+  padding: 0;
+  gap: 8px 1rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+}
+.sheet .character-enhanced .story .contacts .contact-list .contact .content {
+  padding: 4px;
+}
+.sheet .character-enhanced .story .contacts .contact-list .contact .content p {
+  text-align: justify;
+}
+.sheet .character-enhanced .story .contacts .contact-list .contact .content label {
+  font-family: "BebasNeue";
+  letter-spacing: 1px;
+  font-size: 20px;
+  letter-spacing: 1px;
+}
+.sheet .character-enhanced .story .contacts .contact-list .contact .item-controls {
+  position: absolute;
+  bottom: 4px;
+  right: 4px;
+  text-align: center;
+}
+.sheet .character-enhanced .qualities {
+  background-color: #e3e4e6;
+  border-top: 2px solid black;
+  z-index: 0;
+  position: relative;
+  margin-top: 0px;
+  margin-left: -4px;
+  margin-right: -4px;
+  padding: 0 1rem 2rem 1rem;
+  box-shadow: var(--anarchy-shadow-section);
+}
+.sheet .character-enhanced .qualities h2 {
+  --wrapper-padding: 19px;
+  --wrapper-background-color: #e3e4e6;
+  display: inline-block;
+  margin-top: -19px;
+  padding-bottom: 0px;
+  margin-bottom: 0px;
+}
+.sheet .character-enhanced .qualities h2 .side.up {
+  box-shadow: var(--anarchy-shadow-section);
+}
+.sheet .character-enhanced .qualities h2 .side.down,
+.sheet .character-enhanced .qualities h2 .side.right,
+.sheet .character-enhanced .qualities h2 .side.left,
+.sheet .character-enhanced .qualities h2 .angle.br,
+.sheet .character-enhanced .qualities h2 .angle.bl {
+  display: none;
+}
+.sheet .character-enhanced .qualities h2 .content {
+  color: black;
+  font-size: 1.2em;
+  border-bottom: none;
+  text-transform: uppercase;
+  font-weight: bold;
+  font-family: "BebasNeue";
+  letter-spacing: 2px;
+  background-color: #e3e4e6;
+  transform: translateY(-14px);
+  display: flex;
+  align-content: center;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+}
+.sheet .character-enhanced .qualities h2 .content a {
+  text-shadow: -1px 0 transparent, 1px -1px 0 transparent, -1px 1px 0 transparent, 1px 1px 0 transparent;
+  display: flex;
+  align-items: center;
+  align-content: center;
+  justify-content: center;
+}
+.sheet .character-enhanced .qualities .item-list {
+  overflow: auto;
+  margin-bottom: 16px;
+  gap: 1rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+}
+.sheet .character-enhanced .qualities .item-list .anarchy-quality {
+  --wrapper-padding: 12px;
+}
+.sheet .character-enhanced .qualities .item-list .anarchy-quality.quality-negative .angle::before {
+  border-top: var(--wrapper-thickness, 2px) dashed var(--wrapper-border-color);
+}
+.sheet .character-enhanced .qualities .item-list .anarchy-quality.quality-negative .side.up {
+  border-top: var(--wrapper-thickness, 2px) dashed var(--wrapper-border-color);
+}
+.sheet .character-enhanced .qualities .item-list .anarchy-quality.quality-negative .side.right {
+  border-right: var(--wrapper-thickness, 2px) dashed var(--wrapper-border-color);
+}
+.sheet .character-enhanced .qualities .item-list .anarchy-quality.quality-negative .side.left {
+  border-left: var(--wrapper-thickness, 2px) dashed var(--wrapper-border-color);
+}
+.sheet .character-enhanced .qualities .item-list .anarchy-quality.quality-negative .side.down {
+  border-bottom: var(--wrapper-thickness, 2px) dashed var(--wrapper-border-color);
+}
+.sheet .character-enhanced .qualities .item-list .anarchy-quality .content {
+  display: grid;
+  flex-direction: row;
+  grid-template-columns: 46px 1fr;
+}
+.sheet .character-enhanced .qualities .item-list .anarchy-quality .content .quality-img {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 6px;
+}
+.sheet .character-enhanced .qualities .item-list .anarchy-quality .content .quality-img .anarchy-img {
+  width: 46px;
+  height: 46px;
+}
+.sheet .character-enhanced .qualities .item-list .anarchy-quality .content .quality-content {
+  max-width: none;
+  padding-left: 12px;
+  text-align: left;
+}
+.sheet .character-enhanced .qualities .item-list .anarchy-quality .content .quality-content .title {
+  font-family: "BebasNeue";
+  font-weight: bold;
+  font-size: 18px;
+  letter-spacing: 1px;
+}
+.sheet .character-enhanced .qualities .item-list .anarchy-quality .content .quality-content .item-description {
+  display: inline-block;
+  max-height: 150px;
+  overflow: auto;
+}
+.sheet .character-enhanced .qualities .item-list .anarchy-quality .content .quality-content .item-description p {
+  margin: 0 !important;
+}
+.sheet .character-enhanced .description .title,
+.sheet .character-enhanced .gmnotes .title {
+  margin-top: 1rem;
+  padding: 4px;
+  font-family: "BebasNeue";
+  font-size: 18px;
+  letter-spacing: 1px;
+  text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
+  color: white;
+}
+.sheet .character-enhanced .description .editor,
+.sheet .character-enhanced .gmnotes .editor {
+  text-align: initial;
+}
 
-// in dev, foundry loads style.css, this file, which is a no-op
-// in dev, lancer.ts imports lancer.scss directly
+#gm-manager header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+#gm-manager header button.gm-manager-hide-button {
+  width: 32px;
+}
+
+.chat-tools {
+  display: flex;
+  z-index: 1000;
+  flex: 0 0 28px;
+  margin: 0 0px 4px 8px;
+  width: calc(100% - 16px);
+}
+
+/*# sourceMappingURL=style.css.map */

--- a/templates/actor/character-tabbed.hbs
+++ b/templates/actor/character-tabbed.hbs
@@ -30,7 +30,7 @@
           </div>
           {{/if}}
         </div>
-        <div class=".passport-action-row">
+        <div class="passport-action-row">
           <div class="passport-action">
             {{> "systems/mwd/templates/actor/parts/attributebuttons.hbs"}}
           </div>

--- a/templates/actor/character.hbs
+++ b/templates/actor/character.hbs
@@ -30,7 +30,7 @@
           </div>
           {{/if}}
         </div>
-        <div class=".passport-action-row">
+        <div class="passport-action-row">
           <div class="passport-action">
             {{> "systems/mwd/templates/actor/parts/attributebuttons.hbs"}}
           </div>

--- a/templates/actor/device.hbs
+++ b/templates/actor/device.hbs
@@ -13,7 +13,7 @@
             {{> 'systems/mwd/templates/actor/parts/ownership.hbs'}}
           </div>
         </div>
-        <div class=".passport-action-row">
+        <div class="passport-action-row">
           <div class="passport-action">
             {{> "systems/mwd/templates/actor/parts/attributebuttons.hbs"}}
           </div>

--- a/templates/actor/ic.hbs
+++ b/templates/actor/ic.hbs
@@ -13,7 +13,7 @@
             {{> 'systems/mwd/templates/actor/parts/ownership.hbs'}}
           </div>
         </div>
-        <div class=".passport-action-row">
+        <div class="passport-action-row">
           <div class="passport-action">
             {{> "systems/mwd/templates/actor/parts/attributebuttons.hbs"}}
           </div>

--- a/templates/actor/npc-sheet.hbs
+++ b/templates/actor/npc-sheet.hbs
@@ -24,7 +24,7 @@
           </div>
           {{/if}}
         </div>
-        <div class=".passport-action-row">
+        <div class="passport-action-row">
           <div class="passport-action">
             {{> "systems/mwd/templates/actor/parts/attributebuttons.hbs"}}
           </div>

--- a/templates/actor/parts/actions-ownership.hbs
+++ b/templates/actor/parts/actions-ownership.hbs
@@ -1,5 +1,5 @@
 {{#unless options.limited}}
-<div class=".passport-action-row">
+<div class="passport-action-row">
   <div class="passport-action">
     {{> "systems/mwd/templates/actor/parts/attributebuttons.hbs"}}
   </div>

--- a/templates/actor/sprite.hbs
+++ b/templates/actor/sprite.hbs
@@ -13,7 +13,7 @@
             {{> 'systems/mwd/templates/actor/parts/ownership.hbs'}}
           </div>
         </div>
-        <div class=".passport-action-row">
+        <div class="passport-action-row">
           <div class="passport-action">
             {{> "systems/mwd/templates/actor/parts/attributebuttons.hbs"}}
           </div>

--- a/templates/actor/vehicle.hbs
+++ b/templates/actor/vehicle.hbs
@@ -19,7 +19,7 @@
             {{> 'systems/mwd/templates/actor/parts/ownership.hbs'}}
           </div>
         </div>
-        <div class=".passport-action-row">
+        <div class="passport-action-row">
           <div class="passport-action">
             {{> "systems/mwd/templates/actor/parts/attributebuttons.hbs"}}
           </div>


### PR DESCRIPTION
## Summary
- stop importing gm-manager and enhanced sheet SCSS directly from module scripts to avoid MIME errors
- rely on the compiled stylesheet declared in system.json for these module styles

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b72ffcab8832d938be17f36804a8f)