### PR TITLE
Handle legacy stun damage

### DIFF
--- a/src/modules/actor/actor-damage.js
+++ b/src/modules/actor/actor-damage.js
@@ -67,7 +67,7 @@ export class ActorDamageManager {
     ErrorManager.checkActorCanReceiveDamage(damageType, monitor, defender);
     const sufferDamageMethod = ActorDamageManager.damageModeMethod ?? ActorDamageManager.sufferDamageResistanceArmorMonitor;
     await sufferDamageMethod(defender, monitor, damage, success, avoidArmor, attacker);
-    await defender.applyArmorDamage(damageType, Modifiers.sumModifiers([attackWeapon], 'other', 'damageArmor'));
+    await defender.applyArmorDamage(monitor, Modifiers.sumModifiers([attackWeapon], 'other', 'damageArmor'));
   }
 
   static async sufferMarks(actor, sourceActor) {

--- a/src/modules/actor/character-actor.js
+++ b/src/modules/actor/character-actor.js
@@ -147,6 +147,9 @@ export class CharacterActor extends AnarchyBaseActor {
   }
 
   getDamageMonitor(damageType) {
+    if (damageType == 'stun') {
+      damageType = TEMPLATE.monitors.fatigue;
+    }
     switch (damageType) {
       case TEMPLATE.monitors.fatigue:
       case TEMPLATE.monitors.physical:


### PR DESCRIPTION
## Summary
- map legacy stun damage types to the fatigue monitor for characters
- apply armor damage using the resolved monitor to match legacy mappings

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bdb3f6380832db452106e248fb3c4)