### PR TITLE
Update Foundry namespace references

### DIFF
--- a/src/modules/actor/anarchy-actor-sheet.js
+++ b/src/modules/actor/anarchy-actor-sheet.js
@@ -5,7 +5,7 @@ import { Misc } from "../misc.js";
 import { Enums } from "../enums.js";
 import { SelectActor } from "../dialog/select-actor.js";
 
-export class AnarchyActorSheet extends ActorSheet {
+export class AnarchyActorSheet extends foundry.appv1.sheets.ActorSheet {
 
   get template() {
     return `${TEMPLATES_PATH}/actor/${this.actor.type}.hbs`;

--- a/src/modules/anarchy-system.js
+++ b/src/modules/anarchy-system.js
@@ -142,7 +142,7 @@ export class AnarchySystem {
   }
 
   loadActorSheets() {
-    Actors.unregisterSheet('core', ActorSheet);
+    Actors.unregisterSheet('core', foundry.appv1.sheets.ActorSheet);
     Actors.registerSheet(SYSTEM_NAME, CharacterActorSheet, {
       label: game.i18n.localize(ANARCHY.actor.characterSheet),
       makeDefault: false,
@@ -186,7 +186,7 @@ export class AnarchySystem {
   }
 
   loadItemSheets() {
-    Items.unregisterSheet('core', ItemSheet);
+    Items.unregisterSheet('core', foundry.appv1.sheets.ItemSheet);
     Items.registerSheet(SYSTEM_NAME, ContactItemSheet, { types: ["contact"], makeDefault: true });
     Items.registerSheet(SYSTEM_NAME, CyberdeckItemSheet, { types: ["cyberdeck"], makeDefault: true });
     Items.registerSheet(SYSTEM_NAME, GearItemSheet, { types: ["gear"], makeDefault: true });

--- a/src/modules/item/base-item-sheet.js
+++ b/src/modules/item/base-item-sheet.js
@@ -3,7 +3,7 @@ import { TEMPLATE, TEMPLATES_PATH } from "../constants.js";
 import { Enums } from "../enums.js";
 import { Misc } from "../misc.js";
 
-export class BaseItemSheet extends ItemSheet {
+export class BaseItemSheet extends foundry.appv1.sheets.ItemSheet {
 
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {

--- a/src/modules/roll/dice.js
+++ b/src/modules/roll/dice.js
@@ -94,7 +94,7 @@ export class AnarchyDice {
 }
 
 
-export class AnarchyGlitchDie extends Die {
+export class AnarchyGlitchDie extends foundry.dice.terms.Die {
   constructor(term) {
     term.faces = 6;
     super(term);
@@ -123,7 +123,7 @@ export class AnarchyGlitchDie extends Die {
 
 }
 
-export class AnarchyRiskDie extends Die {
+export class AnarchyRiskDie extends foundry.dice.terms.Die {
   constructor(term) {
     term.faces = 6;
     super(term);


### PR DESCRIPTION
## Summary
- update sheet base classes to use the namespaced foundry.appv1.sheets API
- adjust sheet registration to unregister/register against the namespaced classes
- move custom dice term classes to the foundry.dice.terms.Die namespace

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bdb8b3974832d92ee06246f05435d)