### PR TITLE
Use namespaced Foundry APIs

### DIFF
--- a/src/modules/actor/character-actor.js
+++ b/src/modules/actor/character-actor.js
@@ -9,6 +9,8 @@ import { RollCelebrity } from "../dialog/roll-celebrity.js";
 import { ANARCHY_HOOKS } from "../hooks-manager.js";
 import { MATRIX, Matrix, NO_MATRIX_MONITOR } from "../matrix-helper.js";
 
+const { renderTemplate } = foundry.applications.handlebars;
+
 const HBS_TEMPLATE_ACTOR_DRAIN = `${TEMPLATES_PATH}/chat/actor-drain.hbs`;
 const HBS_TEMPLATE_ACTOR_SAY_WORD = `${TEMPLATES_PATH}/chat/actor-say-word.hbs`;
 

--- a/src/modules/anarchy-system.js
+++ b/src/modules/anarchy-system.js
@@ -142,6 +142,7 @@ export class AnarchySystem {
   }
 
   loadActorSheets() {
+    const { Actors } = foundry.documents.collections;
     Actors.unregisterSheet('core', foundry.appv1.sheets.ActorSheet);
     Actors.registerSheet(SYSTEM_NAME, CharacterActorSheet, {
       label: game.i18n.localize(ANARCHY.actor.characterSheet),
@@ -186,6 +187,7 @@ export class AnarchySystem {
   }
 
   loadItemSheets() {
+    const { Items } = foundry.documents.collections;
     Items.unregisterSheet('core', foundry.appv1.sheets.ItemSheet);
     Items.registerSheet(SYSTEM_NAME, ContactItemSheet, { types: ["contact"], makeDefault: true });
     Items.registerSheet(SYSTEM_NAME, CyberdeckItemSheet, { types: ["cyberdeck"], makeDefault: true });

--- a/src/modules/app/gm-anarchy.js
+++ b/src/modules/app/gm-anarchy.js
@@ -4,6 +4,8 @@ import { SYSTEM_NAME, TEMPLATE } from "../constants.js";
 import { ErrorManager } from "../error-manager.js";
 import { RemoteCall } from "../remotecall.js";
 
+const { renderTemplate } = foundry.applications.handlebars;
+
 const GM_ANARCHY = "anarchy-gm";
 const GM_SCENE_ANARCHY = "scene-anarchy-gm";
 const GM_ADD_ANARCHY = 'GMAnarchy.addAnarchy';

--- a/src/modules/app/gm-convergence.js
+++ b/src/modules/app/gm-convergence.js
@@ -3,6 +3,8 @@ import { ANARCHY } from "../config.js";
 import { SYSTEM_NAME, TEMPLATES_PATH } from "../constants.js";
 import { RemoteCall } from "../remotecall.js";
 
+const { loadTemplates, renderTemplate } = foundry.applications.handlebars;
+
 const CONVERGENCES = "convergences";
 const SETTING_KEY_CONVERGENCES = `${SYSTEM_NAME}.${CONVERGENCES}`;
 const ROLL_CONVERGENCE = 'GMConvergence.rollConvergence';

--- a/src/modules/app/gm-difficulty.js
+++ b/src/modules/app/gm-difficulty.js
@@ -1,6 +1,8 @@
 import { ANARCHY } from "../config.js";
 import { SYSTEM_NAME } from "../constants.js";
 
+const { renderTemplate } = foundry.applications.handlebars;
+
 const GM_DIFFICULTY_POOLS = "gm-difficulty-pools";
 const SYSTEM_KEY_GM_DIFFICULTY_POOL = `${SYSTEM_NAME}.${GM_DIFFICULTY_POOLS}`;
 export class GMDifficulty {

--- a/src/modules/app/gm-manager.js
+++ b/src/modules/app/gm-manager.js
@@ -2,6 +2,8 @@ import { HandleDragApplication } from "./handle-drag.js";
 import { ANARCHY } from "../config.js";
 import { SYSTEM_NAME } from "../constants.js";
 import { GMDifficulty } from "./gm-difficulty.js";
+
+const { renderTemplate } = foundry.applications.handlebars;
 const GM_MANAGER = "gm-manager";
 const GM_MANAGER_POSITION = "gm-manager-position";
 const GM_MANAGER_INITIAL_POSITION = { top: 200, left: 200 };

--- a/src/modules/combat/combat-manager.js
+++ b/src/modules/combat/combat-manager.js
@@ -4,6 +4,8 @@ import { ANARCHY } from "../config.js";
 import { ANARCHY_SYSTEM, SYSTEM_SCOPE, TEMPLATES_PATH } from "../constants.js";
 import { RollManager } from "../roll/roll-manager.js";
 
+const { renderTemplate } = foundry.applications.handlebars;
+
 const TEMPLATE_INFORM_DEFENDER = `${TEMPLATES_PATH}/combat/inform-defender.hbs`;
 
 export class CombatManager {

--- a/src/modules/dialog/roll-celebrity.js
+++ b/src/modules/dialog/roll-celebrity.js
@@ -3,6 +3,8 @@ import { TEMPLATES_PATH } from "../constants.js";
 import { Misc } from "../misc.js";
 import { Modifiers } from "../modifiers/modifiers.js";
 
+const { renderTemplate } = foundry.applications.handlebars;
+
 const HBS_TEMPLATE_CHAT_CELEBRITY_ROLL = `${TEMPLATES_PATH}/chat/celebrity-roll.hbs`;
 
 export class RollCelebrity extends Dialog {

--- a/src/modules/dialog/select-actor.js
+++ b/src/modules/dialog/select-actor.js
@@ -2,6 +2,8 @@ import { ANARCHY } from "../config.js";
 import { TEMPLATES_PATH } from "../constants.js";
 import { Icons } from "../icons.js";
 
+const { renderTemplate } = foundry.applications.handlebars;
+
 export class SelectActor extends Dialog {
 
   static async selectActor(title,

--- a/src/modules/handlebars-manager.js
+++ b/src/modules/handlebars-manager.js
@@ -7,6 +7,8 @@ import { Icons } from "./icons.js";
 import { WeaponItem } from "./item/weapon-item.js";
 import { Misc } from "./misc.js";
 
+const { loadTemplates } = foundry.applications.handlebars;
+
 const HBS_PARTIAL_TEMPLATES = [
   // -- monitors
   'systems/mwd/templates/monitors/anarchy-actor.hbs',

--- a/src/modules/roll/dice-cursor.js
+++ b/src/modules/roll/dice-cursor.js
@@ -1,5 +1,7 @@
 import { Misc } from "../misc.js";
 
+const { loadTemplates, renderTemplate } = foundry.applications.handlebars;
+
 
 const DICE_FAS_ICONS = {
   highlighted: ['far fa-times-circle', 'fas fa-dice-one', 'fas fa-dice-two', 'fas fa-dice-three', 'fas fa-dice-four', 'fas fa-dice-five', 'fas fa-dice-six'],

--- a/src/modules/roll/roll-dialog.js
+++ b/src/modules/roll/roll-dialog.js
@@ -5,6 +5,8 @@ import { Misc } from "../misc.js";
 import { DiceCursor } from "./dice-cursor.js";
 import { ROLL_PARAMETER_CATEGORY } from "./roll-parameters.js";
 
+const { loadTemplates, renderTemplate } = foundry.applications.handlebars;
+
 /**
  * Extend the base Dialog to select roll parameters
  * @extends {Dialog}

--- a/src/modules/roll/roll-manager.js
+++ b/src/modules/roll/roll-manager.js
@@ -7,6 +7,8 @@ import { Tokens } from "../token/tokens.js";
 import { AnarchyRoll } from "./anarchy-roll.js";
 import { ROLL_PARAMETER_CATEGORY } from "./roll-parameters.js";
 
+const { loadTemplates, renderTemplate } = foundry.applications.handlebars;
+
 const HBS_TEMPLATE_CHAT_ANARCHY_ROLL = `${TEMPLATES_PATH}/chat/anarchy-roll.hbs`;
 
 const HBS_CHAT_TEMPLATES = [

--- a/src/modules/roll/roll-parameters.js
+++ b/src/modules/roll/roll-parameters.js
@@ -6,6 +6,8 @@ import { MATRIX } from "../matrix-helper.js";
 import { Misc } from "../misc.js";
 import { Modifiers } from "../modifiers/modifiers.js";
 
+const { loadTemplates, renderTemplate } = foundry.applications.handlebars;
+
 export const ROLL_PARAMETER_CATEGORY = {
   title: 'title',
   pool: 'pool',

--- a/src/modules/token/hud-shortcuts.js
+++ b/src/modules/token/hud-shortcuts.js
@@ -2,6 +2,8 @@ import { ANARCHY } from "../config.js";
 import { TEMPLATES_PATH } from "../constants.js";
 import { Misc } from "../misc.js";
 
+const { loadTemplates, renderTemplate } = foundry.applications.handlebars;
+
 const TEMPLATE_HUD_SHORTCUTS = `${TEMPLATES_PATH}/token/hud-shortcuts.hbs`;
 
 export class HUDShortcuts {


### PR DESCRIPTION
## Summary
- replace global Actor and Item sheet registration with foundry.documents.collections namespaces
- use foundry.applications.handlebars helpers for rendering and template loading to silence deprecation warnings

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bdd15fde0832da173b220ca036fb2)