### PR TITLE
Add Destiny opposed roll mechanics toggle

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -47,6 +47,10 @@
           "armorGivesResistance": "RD = Armor/3 + Str/4, damaged per blow, AA ignores armor",
           "armorGiveResistanceHitsAvoid": "RD = Armor/3, damaged per blow, AA reduces resistance"
         }
+      },
+      "useDestinyMechanics": {
+        "name": "Use Destiny opposed roll mechanics",
+        "hint": "Roll 2D6 and add the computed pool as a modifier instead of counting successes."
       }
     },
     "gmManager": {

--- a/src/modules/anarchy-system.js
+++ b/src/modules/anarchy-system.js
@@ -56,6 +56,7 @@ import { Modifiers } from './modifiers/modifiers.js';
 import { ActorDamageManager } from './actor/actor-damage.js';
 import { AttributeActions } from './attribute-actions.js';
 import { DiceCursor } from './roll/dice-cursor.js';
+import { SystemSettings } from './system-settings.js';
 
 /* -------------------------------------------- */
 /*  Foundry VTT AnarchySystem Initialization    */
@@ -98,6 +99,7 @@ export class AnarchySystem {
     this.gmAnarchy = new GMAnarchy();
     this.gmConvergence = new GMConvergence();
     Enums.init();
+    SystemSettings.register();
 
     this.skills = new Skills();
     this.modifiers = new Modifiers();

--- a/src/modules/roll/anarchy-roll.js
+++ b/src/modules/roll/anarchy-roll.js
@@ -48,6 +48,11 @@ export class AnarchyRoll {
   }
 
   async evaluate() {
+    if (this.param.destinyMode) {
+      await this.rollDestiny();
+      return;
+    }
+
     await this.rollPool();
     await this.rollRerolls();
     await this.rollRerollForced();
@@ -58,6 +63,17 @@ export class AnarchyRoll {
   async rollPool() {
     this.subrolls.pool = new Roll(`${this.param.pool}d6cs>=${this.param.target}[${ROLL_THEME['dicePool']}]`)
     await this.subrolls.pool.evaluate({ async: true })
+    this.total = this.subrolls.pool.total;
+  }
+
+  async rollDestiny() {
+    const bonus = this.param.pool ?? 0;
+    const parts = ["2d6"];
+    if (bonus !== 0) {
+      parts.push(bonus > 0 ? `+ ${bonus}` : `${bonus}`);
+    }
+    this.subrolls.pool = new Roll(parts.join(" "));
+    await this.subrolls.pool.evaluate({ async: true });
     this.total = this.subrolls.pool.total;
   }
 

--- a/src/modules/roll/roll-manager.js
+++ b/src/modules/roll/roll-manager.js
@@ -1,6 +1,6 @@
 import { ChatManager, CAN_USE_EDGE, MESSAGE_DATA, OWNING_ACTOR } from "../chat/chat-manager.js";
 import { ANARCHY } from "../config.js";
-import { TEMPLATES_PATH } from "../constants.js";
+import { SYSTEM_NAME, TEMPLATES_PATH } from "../constants.js";
 import { Enums } from "../enums.js";
 import { Misc } from "../misc.js";
 import { Tokens } from "../token/tokens.js";
@@ -37,6 +37,7 @@ export class RollManager {
     })
 
     roll.param = game.system.anarchy.rollParameters.compute(roll.parameters);
+    roll.param.destinyMode = game.settings.get(SYSTEM_NAME, "useDestinyMechanics");
     roll.param.edge = roll.parameters.find(it => it.category == ROLL_PARAMETER_CATEGORY.edge && it.used) ? 1 : 0;
     roll.param.anarchy = roll.parameters.filter(it => it.flags?.isAnarchy && it.used).length;
     roll.options.canUseEdge = roll.options.canUseEdge && !roll.param.edge;

--- a/src/modules/system-settings.js
+++ b/src/modules/system-settings.js
@@ -1,7 +1,19 @@
+import { ANARCHY } from "./config.js";
 import { SYSTEM_NAME } from "./constants.js";
 
 
 export class SystemSettings {
+
+  static register() {
+    game.settings.register(SYSTEM_NAME, "useDestinyMechanics", {
+      name: game.i18n.localize(ANARCHY.settings.useDestinyMechanics.name),
+      hint: game.i18n.localize(ANARCHY.settings.useDestinyMechanics.hint),
+      scope: "world",
+      config: true,
+      type: Boolean,
+      default: true,
+    });
+  }
 
   static getSystemProperty(property, fallback) {
     let value = game.settings.get(SYSTEM_NAME, property) ?? fallback;


### PR DESCRIPTION
## Summary
- add a world setting to enable Destiny-style opposed rolls that convert pools into 2d6 modifiers
- initialize system settings during startup so the new toggle is available in configuration
- update roll handling to honor the setting and use the 2d6+bonus flow when enabled

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bde7fc5a8832db631a43cd98f5f3d)