### PR TITLE
Fix localization JSON and destiny mechanics setting

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -331,7 +331,7 @@
       }
     },
     "capacity": {
-      "mundane": "Mundane",
+      "mundane": "Mundane"
     },
     "monitor": {
       "physical": "Physical",

--- a/src/modules/config.js
+++ b/src/modules/config.js
@@ -47,6 +47,10 @@ export const ANARCHY = {
                 armorGivesResistance: 'ANARCHY.settings.damageMode.values.armorGivesResistance',
                 armorGiveResistanceHitsAvoid: 'ANARCHY.settings.damageMode.values.armorGiveResistanceHitsAvoid',
             },
+        },
+        useDestinyMechanics: {
+            name: 'ANARCHY.settings.useDestinyMechanics.name',
+            hint: 'ANARCHY.settings.useDestinyMechanics.hint',
         }
     },
     gmManager: {


### PR DESCRIPTION
## Summary
- remove trailing comma from en.json capacity section to restore valid JSON
- add missing configuration entry for the destiny mechanics setting to match localization keys

## Testing
- node -e "JSON.parse(require('fs').readFileSync('lang/en.json','utf8')); console.log('ok');"

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692be23507f0832da6cfa4733b729ba5)