### PR TITLE
Add battlemech sheet and hybrid vehicle monitors

### DIFF
--- a/docs/vehicle-gap-analysis.md
+++ b/docs/vehicle-gap-analysis.md
@@ -1,0 +1,49 @@
+# Vehicle Handling Gap Analysis
+
+## Mech-scale vehicle rules from MWD.pdf (transcribed excerpts)
+> "If a 'Mech's head or torso location is destroyed, if the MechWarrior is killed, or the 'Mech suffers either an ammo explosion critical hit or two engine critical hits ... the 'Mech is out of commission for the rest of the battle."
+> "Combat Vehicle: If any of a combat vehicle's locations loses all its Structure, or if the unit suffers an ammo explosion, then the vehicle is destroyed."
+> "Whenever a unit takes Structure damage in any location or a 2 is rolled for a hit location, roll 2D6. On a result of 8+, that location suffers one critical hit."
+> "Combat vehicles can suffer critical hits in the following locations: Front ... Crew Compartment hit (3 Physical Damage to all crew) ... Front Weapon Group is destroyed ... Motive system damaged (–2 maximum Movement) ... Turret ... Rotor (VTOLs only ... destroying the Structure of a VTOL's rotor destroys the unit) ... Rear ... Ammo explosion (vehicle destroyed) ... –1 maximum Movement."
+> "Catastrophic damage ... Combat Vehicle: Crash damage, ammo explosion."
+
+## Current Anarchy vehicle handling
+- Vehicle actors largely mirror characters: they expose initiative and defense helpers but only compute total Structure as a single monitor without location tracking or critical modeling.【F:src/modules/actor/vehicle-actor.js†L19-L57】
+- Attack resolution simply compares hits, subtracts armor/resistance, and applies aggregate monitor damage via `ActorDamageManager.sufferDamage`, with no hit-location rolls, location Structure tracking, or critical-hit hooks for vehicles or 'Mechs.【F:src/modules/combat/combat-manager.js†L13-L89】【F:src/modules/actor/actor-damage.js†L19-L108】
+
+## Gap list: Anarchy vs. MDW vehicle rules
+1. **Hit locations**: MDW requires every damage group to roll a location (with special head rules), but the current system never rolls or stores hit locations for vehicles or 'Mechs.【F:docs/vehicle-gap-analysis.md†L5-L9】【F:src/modules/combat/combat-manager.js†L13-L89】
+2. **Location-based Structure**: Vehicles in MDW track Structure per facing (front/turret/rear) and lose the unit when any location is stripped, while the system only has a single Structure monitor with no per-location thresholds.【F:docs/vehicle-gap-analysis.md†L4-L9】【F:src/modules/actor/vehicle-actor.js†L19-L57】
+3. **Automatic critical resolution**: MDW calls for an automatic 2D6 critical check on Structure loss or a hit roll of 2, plus tables of effects by location, but the current damage flow applies raw damage and stops—no critical check or effect application exists.【F:docs/vehicle-gap-analysis.md†L7-L9】【F:src/modules/actor/actor-damage.js†L19-L108】
+4. **Crew consequences and catastrophic damage**: MDW distinguishes vehicle destruction from crew fate (catastrophic damage triggers ejection/abandonment options), whereas the system ties damage only to vehicle monitors and offers no crew injury or bailout handling.【F:docs/vehicle-gap-analysis.md†L4-L8】【F:src/modules/combat/combat-manager.js†L13-L89】
+5. **Movement/weapon degradation**: MDW critical tables explicitly reduce Movement and destroy weapon groups based on hit location; current combat resolution cannot alter vehicle Movement or weapon state when damage is applied.【F:docs/vehicle-gap-analysis.md†L6-L8】【F:src/modules/actor/actor-damage.js†L19-L108】
+
+## How existing damage thresholds relate to criticals
+The current vehicle track already imposes negative modifiers at damage thresholds, but those penalties are **not** the same as MDW-style criticals. Threshold penalties can remain as a universal “system strain” mechanic that applies to every vehicle; criticals layer on top to represent **location-specific failures** (weapon groups, motive systems, crew hits, ammo). In play: keep the existing threshold penalties as a baseline degradation, and add critical checks when location-tagged rules say so (Structure loss, hit roll of 2, or catastrophic results).
+
+## Middle-ground “cue-lite” vehicle handling
+A compact drop-in that preserves Anarchy’s single pools while adding Destiny-flavored hit locations and crits:
+
+1. **Shared Armor/Structure**: Keep one Armor and one Structure track per vehicle. Damage is applied to these pools after a **hit location roll** (Front/Sides/Rear/Core for vehicles; add Head/Torso for ’Mechs) so you can tag the impact even without per-location pools.
+2. **Thresholds + critical triggers**:
+   - Keep the existing **Structure thresholds** that impose global penalties as a simple degradation curve.
+   - Add a **critical check** whenever Structure is reduced (or on a hit roll of 2). Roll 2D6; on 8+ apply an effect based on the rolled location: weapon group disabled, motive/rotor penalty, crew compartment harm, ammo risk, or catastrophic result. This makes location matter without extra tracks.
+3. **Soft location stress (optional)**: Track a small stress counter per location (Front/Sides/Rear/Core/Head/Turret/Rotor). Hitting the same location repeatedly escalates its effects (e.g., second Motive hit = –2 Movement, third = immobilized), but still draws from the shared Structure pool.
+4. **Catastrophic endpoints**: Hitting 0 Structure, rolling an ammo explosion, or maxing out a location’s stress ends the vehicle (immobilized/destroyed) and hands the crew an eject/abandon/injury decision. No location Structure bookkeeping required.
+5. **Minimal data model changes**:
+   - Store the **rolled hit location** with each attack resolution.
+   - Keep the existing Structure thresholds for global penalties; add a **critical resolver** keyed by location to adjust movement caps, disable weapon groups, and surface crew outcomes.
+   - Surface catastrophic flags to the combat manager so initiative/turn order can retire destroyed or abandoned units cleanly.
+
+## How heat is handled and how to hybridize it
+- **MWD heat loop (summary)**: Mech-Scale attacks list a **Heat rating**; firing adds that many heat points. Each unit has a **Heat Capacity** and loses a fixed amount in the **End Phase**. Crossing key thresholds imposes **attack/defense penalties**, with high heat triggering **shutdown/ammo risk checks** or forcing a **shutdown to vent**, and catastrophic spikes can cook off ammunition. The loop is: declare attacks → add heat tokens → apply weapon damage → end phase dissipates heat → if current heat exceeds thresholds, apply penalties/checks.
+- **Hybrid proposal for single-pool vehicles**:
+  - Give every vehicle/’Mech a short **Heat track** (0–3/4 tokens) and a **Vent value** (tokens removed at end of turn). Weapons keep a **Heat cost** tag.
+  - **Heat bands**: 0–1 = nominal (no effect); 2 = running hot (–1 die on attacks); 3 = overheated (attack/defense –1 die and mandatory **Overheat check**: Piloting vs TN 2 or pick *Shutdown next action* or take a **critical check**). 4+ immediately forces **shutdown** and a critical check.
+  - **Shutdown**: skip actions next turn, clear to 1 Heat, then reboot as a simple action (no per-location tracking needed). If an ammo-carrying weapon fired while at 3+ Heat, roll a **catastrophic ammo check**: on failure, treat as ammo explosion critical.
+  - **End of turn**: remove **Vent** tokens (default 1) to return toward safe bands; Shadow Amps/tags can raise Vent or add situational cooling (e.g., +1 Vent if no weapons fired this round).
+  - This keeps the **decision loop** (heat budgeting, shutdown risk, ammo danger) without needing location heat sinks or per-weapon bookkeeping beyond a single Heat cost.
+
+## Applicability: 'Mechs vs. other vehicles
+- **'Mechs**: Use Head, Torso, Sides, Rear, and Core as locations. Threshold penalties keep a familiar degradation track, while location-tagged crits handle cockpit/torso destruction, ammo/engine failures, and weapon-group losses without per-location Structure.
+- **Standard combat vehicles (tanks, ships, aircraft, VTOLs)**: Roll Front/Side/Rear/Turret/Rotor as appropriate. Threshold penalties apply universally, and location-tagged crits cover crew compartment injury, turret/weapon disablement, motive/rotor penalties, ammo explosions, and catastrophic immobilization. The same single Armor/Structure pools power both use cases.

--- a/lang/en.json
+++ b/lang/en.json
@@ -188,6 +188,7 @@
       "characterTabbedSheet": "Character sheet (tabs)",
       "characterEnhancedSheet": "Character enhanced sheet (tabs)",
       "vehicleSheet": "Vehicle sheet",
+      "battlemechSheet": "Battlemech sheet",
       "deviceSheet": "Device sheet",
       "spriteSheet": "Sprite sheet",
       "icSheet": "IC sheet",
@@ -229,6 +230,7 @@
         "matrix": "Matrix",
         "armor": "Armor",
         "structure": "Structure",
+        "heat": "Heat",
         "resistance": "Resistance",
         "marks": "Marks",
         "convergence": "Convergence"
@@ -238,7 +240,13 @@
         "attacks": "Attacks",
         "stealth": "Stealth",
         "category": "Category",
-        "skill": "Skill"
+        "skill": "Skill",
+        "heatDissipation": "Heat dissipation",
+        "criticalTrack": "Criticals",
+        "locationFront": "Front effects",
+        "locationSide": "Side effects",
+        "locationRear": "Rear effects",
+        "locationCore": "Core effects"
       },
       "ownership": {
         "owner": "Owner",
@@ -249,6 +257,7 @@
     "actorType": {
       "character": "Character",
       "vehicle": "Vehicle",
+      "battlemech": "Battlemech",
       "device": "Device",
       "sprite": "Sprite",
       "ic": "IC"

--- a/src/modules/actor/base-actor.js
+++ b/src/modules/actor/base-actor.js
@@ -134,7 +134,7 @@ export class AnarchyBaseActor extends Actor {
 
   hasOwnAnarchy() { return false; }
   hasGMAnarchy() { return !this.hasPlayerOwner; }
-  isVehicle() { return this.type == TEMPLATE.actorTypes.vehicle }
+  isVehicle() { return [TEMPLATE.actorTypes.vehicle, TEMPLATE.actorTypes.battlemech].includes(this.type) }
   prepareData() {
     super.prepareData()
     this.cleanupFavorites()

--- a/src/modules/actor/battlemech-actor.js
+++ b/src/modules/actor/battlemech-actor.js
@@ -1,0 +1,9 @@
+import { ICONS_PATH } from "../constants.js";
+import { VehicleActor } from "./vehicle-actor.js";
+
+export class BattlemechActor extends VehicleActor {
+
+  static get defaultIcon() {
+    return `${ICONS_PATH}/vehicles/apc.svg`;
+  }
+}

--- a/src/modules/actor/battlemech-sheet.js
+++ b/src/modules/actor/battlemech-sheet.js
@@ -1,0 +1,11 @@
+import { VehicleSheet } from "./vehicle-sheet.js";
+
+export class BattlemechSheet extends VehicleSheet {
+
+  static get defaultOptions() {
+    return foundry.utils.mergeObject(super.defaultOptions, {
+      width: 600,
+      height: 650
+    });
+  }
+}

--- a/src/modules/actor/vehicle-actor.js
+++ b/src/modules/actor/vehicle-actor.js
@@ -1,6 +1,7 @@
 import { ANARCHY } from "../config.js";
 import { ICONS_PATH, TEMPLATE } from "../constants.js";
 import { ErrorManager } from "../error-manager.js";
+import { NO_MATRIX_MONITOR } from "../matrix-helper.js";
 import { AnarchyUsers } from "../users.js";
 import { AnarchyBaseActor } from "./base-actor.js";
 
@@ -22,7 +23,9 @@ export class VehicleActor extends AnarchyBaseActor {
   }
 
   prepareDerivedData() {
-    this.system.monitors.matrix.max = this._getMonitorMax(TEMPLATE.attributes.system)
+    if (this.system.monitors?.matrix) {
+      this.system.monitors.matrix.max = this._getMonitorMax(TEMPLATE.attributes.system)
+    }
     super.prepareDerivedData()
   }
 
@@ -34,6 +37,9 @@ export class VehicleActor extends AnarchyBaseActor {
   }
 
   getMatrixDetails() {
+    if (!this.system.monitors?.matrix) {
+      return NO_MATRIX_MONITOR
+    }
     return {
       hasMatrix: true,
       logic: TEMPLATE.attributes.system,

--- a/src/modules/anarchy-system.js
+++ b/src/modules/anarchy-system.js
@@ -18,9 +18,11 @@ import { AnarchyBaseActor } from './actor/base-actor.js';
 import { CharacterActor } from './actor/character-actor.js';
 import { DeviceActor } from './actor/device-actor.js';
 import { VehicleActor } from './actor/vehicle-actor.js';
+import { BattlemechActor } from './actor/battlemech-actor.js';
 import { CharacterActorSheet } from './actor/character-sheet.js';
 import { DeviceSheet } from './actor/device-sheet.js';
 import { VehicleSheet } from './actor/vehicle-sheet.js';
+import { BattlemechSheet } from './actor/battlemech-sheet.js';
 import { CharacterNPCSheet } from './actor/character-npc-sheet.js';
 import { SkillItem } from './item/skill-item.js';
 import { MetatypeItem } from './item/metatype-item.js';
@@ -78,6 +80,7 @@ export class AnarchySystem {
     this.actorClasses = {
       character: CharacterActor,
       vehicle: VehicleActor,
+      battlemech: BattlemechActor,
       device: DeviceActor,
       sprite: SpriteActor,
       ic: ICActor
@@ -170,6 +173,11 @@ export class AnarchySystem {
       label: game.i18n.localize(ANARCHY.actor.vehicleSheet),
       makeDefault: true,
       types: ['vehicle']
+    });
+    Actors.registerSheet(SYSTEM_NAME, BattlemechSheet, {
+      label: game.i18n.localize(ANARCHY.actor.battlemechSheet),
+      makeDefault: true,
+      types: ['battlemech']
     });
     Actors.registerSheet(SYSTEM_NAME, DeviceSheet, {
       label: game.i18n.localize(ANARCHY.actor.deviceSheet),

--- a/src/modules/attribute-actions.js
+++ b/src/modules/attribute-actions.js
@@ -30,12 +30,12 @@ const DEFENSE = ANARCHY_SYSTEM.defenses;
 
 const ATTRIBUTE_ACTIONS = [
   action(ACTION.defense, __ => ATTR.agility, __ => ATTR.logic, Icons.fontAwesome('fas fa-shield-alt'), [ACTOR.character]),
-  action(ACTION.defense, __ => ATTR.autopilot, __ => ATTR.handling, Icons.fontAwesome('fas fa-tachometer-alt'), [ACTOR.vehicle]),
+  action(ACTION.defense, __ => ATTR.autopilot, __ => ATTR.handling, Icons.fontAwesome('fas fa-tachometer-alt'), [ACTOR.vehicle, ACTOR.battlemech]),
   // TODO: add a way to pilot a vehicle to fallback defense of controled vehicle
   action(ACTION.resistTorture, __ => ATTR.strength, __ => ATTR.willpower, Icons.fontAwesome('fas fa-angry'), [ACTOR.character]),
 
   action(ACTION.perception, __ => ATTR.logic, __ => ATTR.willpower, Icons.fontAwesome('fas fa-eye'), [ACTOR.character]),
-  action(ACTION.perception, __ => ATTR.autopilot, undefined, Icons.fontAwesome('fas fa-video'), [ACTOR.vehicle]),
+  action(ACTION.perception, __ => ATTR.autopilot, undefined, Icons.fontAwesome('fas fa-video'), [ACTOR.vehicle, ACTOR.battlemech]),
   action(ACTION.perception, actor => actor.getMatrixLogic(), actor => actor.getMatrixLogic(), Icons.fontAwesome('fas fa-video'), [ACTOR.device, ACTOR.sprite, ACTOR.ic]),
 
   action(ACTION.composure, __ => ATTR.charisma, __ => ATTR.willpower, Icons.fontAwesome('fas fa-meh'), [ACTOR.character]),
@@ -44,7 +44,7 @@ const ATTRIBUTE_ACTIONS = [
   action(ACTION.catch, __ => ATTR.agility, __ => ATTR.agility, Icons.fontAwesome('fas fa-baseball-ball'), [ACTOR.character]),
   action(ACTION.lift, __ => ATTR.strength, __ => ATTR.strength, Icons.fontAwesome('fas fa-dumbbell'), [ACTOR.character]),
 
-  action(ACTION.matrixDefense, actor => actor.getMatrixLogic(), actor => actor.getMatrixFirewall(), Icons.fontAwesome('fas fa-shield-virus'), [ACTOR.character, ACTOR.sprite, ACTOR.ic, ACTOR.device, ACTOR.vehicle]),
+  action(ACTION.matrixDefense, actor => actor.getMatrixLogic(), actor => actor.getMatrixFirewall(), Icons.fontAwesome('fas fa-shield-virus'), [ACTOR.character, ACTOR.sprite, ACTOR.ic, ACTOR.device, ACTOR.vehicle, ACTOR.battlemech]),
   action(ACTION.astralDefense, ___ => ATTR.logic, ___ => ATTR.willpower, Icons.fontAwesome('fas fa-shield-virus'), [ACTOR.character]),
 
 ]

--- a/src/modules/common/checkbars.js
+++ b/src/modules/common/checkbars.js
@@ -43,6 +43,22 @@ export const DEFAULT_CHECKBARS = {
     iconHit: Icons.fontAwesome('fas fa-bahai'),
     resource: MONITORS.structure
   },
+  heat: {
+    path: 'system.monitors.heat.value',
+    monitor: it => it.system.monitors.heat,
+    iconChecked: Icons.fontAwesome('fas fa-fire'),
+    iconUnchecked: Icons.fontAwesome('far fa-sun'),
+    iconHit: Icons.fontAwesome('fas fa-temperature-high'),
+    resource: MONITORS.heat
+  },
+  criticals: {
+    path: 'system.hybrid.criticals.value',
+    monitor: it => it.system.hybrid?.criticals ?? { value: 0, max: 0 },
+    iconChecked: Icons.fontAwesome('fas fa-bolt'),
+    iconUnchecked: Icons.fontAwesome('far fa-dot-circle'),
+    iconHit: Icons.fontAwesome('fas fa-exclamation-triangle'),
+    resource: MONITORS.structure
+  },
   matrix: {
     path: 'system.monitors.matrix.value',
     monitor: it => it.getMatrixMonitor(),

--- a/src/modules/config.js
+++ b/src/modules/config.js
@@ -212,6 +212,7 @@ export const ANARCHY = {
             matrix: 'ANARCHY.actor.monitors.matrix',
             armor: 'ANARCHY.actor.monitors.armor',
             structure: 'ANARCHY.actor.monitors.structure',
+            heat: 'ANARCHY.actor.monitors.heat',
             resistance: 'ANARCHY.actor.monitors.resistance',
             marks: 'ANARCHY.actor.monitors.marks',
             convergence: 'ANARCHY.actor.monitors.convergence',
@@ -232,6 +233,7 @@ export const ANARCHY = {
     actorType: {
         character: 'ANARCHY.actorType.character',
         vehicle: 'ANARCHY.actorType.vehicle',
+        battlemech: 'ANARCHY.actorType.battlemech',
         device: 'ANARCHY.actorType.device',
         sprite: 'ANARCHY.actorType.sprite',
         ic: 'ANARCHY.actorType.ic',

--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -27,6 +27,7 @@ export const TEMPLATE = {
   actorTypes: {
     character: 'character',
     vehicle: 'vehicle',
+    battlemech: 'battlemech',
     device: 'device',
     sprite: 'sprite',
     ic: 'ic',
@@ -62,6 +63,7 @@ export const TEMPLATE = {
     armor: 'armor',
     physical: 'physical',
     structure: 'structure',
+    heat: 'heat',
     matrix: 'matrix',
     marks: 'marks',
     convergence: 'convergence',

--- a/style.css
+++ b/style.css
@@ -1640,4 +1640,17 @@
   width: calc(100% - 16px);
 }
 
+.hybrid-locations .location-grid {
+  gap: 4px;
+}
+
+.hybrid-locations .location-row {
+  align-items: center;
+}
+
+.hybrid-locations .location-label {
+  min-width: 80px;
+  font-weight: 600;
+}
+
 /*# sourceMappingURL=style.css.map */

--- a/template.json
+++ b/template.json
@@ -1,6 +1,6 @@
 {
   "Actor": {
-    "types": ["character", "vehicle", "device", "sprite", "ic"],
+    "types": ["character", "vehicle", "battlemech", "device", "sprite", "ic"],
     "templates": {
       "description": {
         "ownerId": "",
@@ -176,6 +176,32 @@
           "value": 0,
           "max": 15,
           "resistance": 2
+        },
+        "armor": {
+          "value": 0,
+          "max": 12,
+          "resistance": 1
+        },
+        "heat": {
+          "value": 0,
+          "max": 3,
+          "resistance": 0
+        }
+      },
+      "hybrid": {
+        "heat": {
+          "dissipation": 1
+        },
+        "criticals": {
+          "value": 0,
+          "max": 3,
+          "notes": ""
+        },
+        "locations": {
+          "front": "",
+          "sides": "",
+          "rear": "",
+          "core": ""
         }
       },
       "moves": 0,
@@ -184,6 +210,60 @@
       "category": "",
       "skill": "pilotingGround",
       "passengers": 4
+    },
+    "battlemech": {
+      "templates": [
+        "description",
+        "attribute-autopilot",
+        "attribute-handling"
+      ],
+      "attributes": {
+        "system": {
+          "value": 5
+        },
+        "firewall": {
+          "value": 0
+        }
+      },
+      "monitors": {
+        "structure": {
+          "value": 0,
+          "max": 18,
+          "resistance": 1
+        },
+        "armor": {
+          "value": 0,
+          "max": 15,
+          "resistance": 1
+        },
+        "heat": {
+          "value": 0,
+          "max": 4,
+          "resistance": 0
+        }
+      },
+      "hybrid": {
+        "heat": {
+          "dissipation": 1
+        },
+        "criticals": {
+          "value": 0,
+          "max": 4,
+          "notes": ""
+        },
+        "locations": {
+          "front": "",
+          "sides": "",
+          "rear": "",
+          "core": ""
+        }
+      },
+      "moves": 0,
+      "attacks": 0,
+      "stealth": 0,
+      "category": "mech",
+      "skill": "gunnery",
+      "passengers": 1
     },
     "device": {
       "templates": ["description", "matrix-monitor"],

--- a/templates/actor/battlemech.hbs
+++ b/templates/actor/battlemech.hbs
@@ -1,4 +1,4 @@
-<form class="{{options.cssClass}} vehicle-sheet" autocomplete="off">
+<form class="{{options.cssClass}} battlemech-sheet" autocomplete="off">
   <header class="sheet-header">
     <div class="passport-header">
       <div class="passport-img">
@@ -8,12 +8,6 @@
         <div class="passport-details-row">
           <div class="passport-detail">
             <input class="info-value" name="name" type="text" value="{{data.name}}" placeholder="{{localize ANARCHY.actor.actorName}}"/>
-          </div>
-          <div class="passport-detail">
-            {{> "systems/mwd/templates/actor/vehicle/vehicle-category.hbs"}}
-          </div>
-          <div class="passport-detail">
-            {{> "systems/mwd/templates/actor/vehicle/vehicle-skill.hbs"}}
           </div>
           <div class="passport-detail">
             {{> 'systems/mwd/templates/actor/parts/ownership.hbs'}}
@@ -48,14 +42,6 @@
           value="{{system.hybrid.heat.dissipation}}"
         />
       </label>
-      </div>
-    </div>
-    <div class="section-group monitors-row">
-      <div class="anarchy-block">
-      {{> "systems/mwd/templates/monitors/matrix.hbs"}}
-      </div>
-      <div class="anarchy-block">
-      {{> "systems/mwd/templates/monitors/marks.hbs"}}
       </div>
     </div>
     <div class="section-group monitors-row">

--- a/templates/monitors/heat.hbs
+++ b/templates/monitors/heat.hbs
@@ -1,0 +1,25 @@
+<div class="flexcol anarchy-monitor">
+  <label class="monitor-label">
+    {{localize ANARCHY.actor.monitors.heat}}
+    <input class="info-value" type="number" data-dtype="Number" maxlength="2"
+      name="system.monitors.heat.max"
+      value="{{system.monitors.heat.max}}"
+    />
+  </label>
+  {{> "systems/mwd/templates/common/checkbar.hbs"
+    code='heat'
+    value=system.monitors.heat.value
+    max=system.monitors.heat.max
+    rowlength=6
+  }}
+  <label class="resitance-label">
+    {{localize ANARCHY.actor.monitors.resistance}}
+    <input class="info-value" type="number" data-dtype="Number" maxlength="2"
+      name="system.monitors.heat.resistance"
+      value="{{system.monitors.heat.resistance}}"
+    />
+    {{#if system.monitors.heat.resistanceBonus}}
+    {{numberFormat system.monitors.heat.resistanceBonus sign=true}}
+    {{/if}}
+  </label>
+</div>


### PR DESCRIPTION
## Summary
- extend the data model with hybrid armor, heat, critical, and location fields for vehicles and new battlemech actors
- add dedicated vehicle and battlemech sheets showing pooled armor/structure, heat tracking, critical track, and location notes
- register the new battlemech actor type and sheet with updated attribute actions and monitor handling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692be1fda200832d9f65c846c21b70db)