### PR TITLE
Fix GM manager rendering and preload heat partial

### DIFF
--- a/src/modules/app/gm-manager.js
+++ b/src/modules/app/gm-manager.js
@@ -9,9 +9,9 @@ const GM_MANAGER_POSITION = "gm-manager-position";
 const GM_MANAGER_INITIAL_POSITION = { top: 200, left: 200 };
 const GM_MANAGER_TEMPLATE = 'systems/mwd/templates/app/gm-manager.hbs';
 
-const { ApplicationV2 } = foundry.applications.api;
+const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 
-export class GMManager extends ApplicationV2 {
+export class GMManager extends HandlebarsApplicationMixin(ApplicationV2) {
 
   static get DEFAULT_OPTIONS() {
     return foundry.utils.mergeObject(super.DEFAULT_OPTIONS, {

--- a/src/modules/handlebars-manager.js
+++ b/src/modules/handlebars-manager.js
@@ -14,6 +14,7 @@ const HBS_PARTIAL_TEMPLATES = [
   'systems/mwd/templates/monitors/anarchy-actor.hbs',
   'systems/mwd/templates/monitors/armor.hbs',
   'systems/mwd/templates/monitors/edge.hbs',
+  'systems/mwd/templates/monitors/heat.hbs',
   'systems/mwd/templates/actor/parts/matrix-cyberdeck.hbs',
   'systems/mwd/templates/monitors/matrix.hbs',
   'systems/mwd/templates/monitors/physical.hbs',


### PR DESCRIPTION
## Summary
- make GM manager renderable by mixing in Handlebars support
- preload the heat monitor partial so vehicle sheets can find it

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bf3021760832d9104505a4834258f)