### PR TITLE
Implement battlemech loadout system

### DIFF
--- a/docs/weapon-mounting-system.md
+++ b/docs/weapon-mounting-system.md
@@ -1,0 +1,165 @@
+# Weapon & Melee Mounting System
+
+This document summarizes the mounting rules for Foundry VTT implementations of **MechWarrior: Destiny**. It focuses on hardpoints, mount points, weapon groups, and melee subsystems while omitting tonnage, ammo, or critical slot rules.
+
+## 1. Mount Points (MP)
+
+Mount points determine how many weapon groups a 'Mech can field.
+
+| Weight Class | Mount Points |
+| ------------ | ------------ |
+| Light        | 4            |
+| Medium       | 5            |
+| Heavy        | 6            |
+| Assault      | 7            |
+
+- Each weapon group consumes 1 MP.
+- A primary weapon group consumes **2 MP**.
+
+### Mount Point Budget Rule
+
+- **No primary weapon:** `maxGroups = MP`
+- **Primary weapon present:** `maxGroups = MP - 1` (because the primary group uses 2 MP)
+
+The system must enforce this whenever groups are created, deleted, or toggled.
+
+## 2. Hardpoints
+
+Hardpoints describe what types of ranged weapons a 'Mech can physically mount. Each hardpoint is defined as:
+
+```ts
+{
+  id: string,
+  type: "energy" | "ballistic" | "missile" | "support",
+  size: "small" | "medium" | "large",
+  location: "head" | "torso" | "arm" | "leg",
+  occupiedBy: groupId | null
+}
+```
+
+Ranged weapons require exactly one matching hardpoint (type + size). No ranged weapon requires more than one hardpoint. The system assigns hardpoints to weapons during validation.
+
+## 3. Weapon Groups
+
+Weapon groups are the attack bundles players fire in Destiny. Each group:
+
+```ts
+{
+  id: string,
+  name: string,
+  weaponIds: string[],
+  isPrimary: boolean
+}
+```
+
+Rules:
+
+- One weapon group = one attack roll.
+- Groups may contain multiple weapons.
+- All weapons in a group must occupy valid, free hardpoints.
+- Only one group may have `isPrimary = true`.
+
+Groups plus the primary weapon must respect the mount point budget.
+
+## 4. Primary Weapon Rules
+
+A primary weapon is a special weapon group with `isPrimary: true`. It costs **2 MP** and provides special bonuses handled elsewhere.
+
+### Valid Primary Sources
+
+A primary weapon must come from one of two chassis configurations:
+
+#### 4.1 Normal Primary (via large hardpoint)
+
+A ranged weapon sized **large** mounted on a `size: "large"` hardpoint.
+
+#### 4.2 Converted Primary Slot (canon-exception chassis)
+
+Some canon mechs have a signature weapon even without a large hardpoint. For these chassis, define:
+
+```ts
+system.primarySlot = {
+  mode: "converted",
+  allowedWeaponIds: ["id-of-default-primary"], // optional
+  typeRestriction: "energy" | "ballistic" | null // optional
+}
+```
+
+A primary weapon group on a chassis with a converted slot:
+
+- Does **not** need a large hardpoint.
+- Must obey any type or allowed weapon restrictions.
+- Still consumes **2 MP**.
+
+## 5. Ranged Weapon Validation (Core Logic)
+
+When the user changes loadout or groups, perform:
+
+### 5.1 Mount Point Check
+
+- If primary present: `if (groups.length > totalMP - 1) invalid()`
+- If no primary: `if (groups.length > totalMP) invalid()`
+
+### 5.2 Primary Check
+
+- If `primarySlot.mode !== "converted"`, the primary weapon must match a **large** hardpoint type/size.
+- If `primarySlot.mode === "converted"`, skip size validation and optionally enforce `allowedWeaponIds` or `typeRestriction`.
+
+### 5.3 Hardpoint Assignment
+
+For each non-melee weapon in all groups:
+
+- Find an unused hardpoint with matching type + size.
+- Mark it occupied by that group.
+- If no hardpoint is found, invalidate the loadout.
+
+## 6. Melee Weapons (Separate Subsystem)
+
+Melee weapons do **not** use hardpoints, mount points, or weapon groups. Instead, each chassis defines:
+
+```ts
+system.melee = {
+  baseProfile: { name, damage, notes },
+  maxWeapons: number,
+  allowedLocations: string[]
+}
+```
+
+Each actor derives:
+
+```ts
+system.meleeProfiles = [
+  base unarmed profile,
+  + up to maxWeapons equipped melee items
+]
+```
+
+Rules:
+
+- Melee weapons have `weaponCategory = "melee"`.
+- Melee weapons are ignored during ranged weapon validation.
+- Melee profiles generate independently and appear as selectable melee attacks.
+- Optionally restrict mounting by `allowedLocations`.
+
+## 7. Validation Triggers
+
+- On weapon/group assignment (`preUpdateActor`).
+- When toggling `isPrimary`.
+- When adding/removing hardpoints on a chassis.
+- When equipping melee weapons.
+
+## 8. UI Expectations
+
+- Display mount point usage: `Used MP (Primary = 2) / Total MP`.
+- Display hardpoints and whether they are filled.
+- Provide a weapon group editor for ranged weapons.
+- Provide a dedicated melee attack section (derived from melee profiles).
+
+## 9. Summary
+
+- Ranged = hardpoints + mount points + weapon groups.
+- Primary weapon = special weapon group, costs 2 MP.
+- Hardpoints = type/size slots for ranged weapons only.
+- Melee = separate subsystem.
+- Validation enforces MP budget, primary legality, and hardpoint availability.
+- Melee bypasses hardpoints and mount points entirely.

--- a/lang/en.json
+++ b/lang/en.json
@@ -281,6 +281,9 @@
       "weapon": {
         "skill": "Skill",
         "drain": "Drain",
+        "category": "Weapon category",
+        "hardpoint": "Hardpoint",
+        "mountLocation": "Mount location",
         "damage": "Damages",
         "strength": "+ strength",
         "defense": "Defense",
@@ -439,6 +442,93 @@
       "combat": "Combat",
       "aerospace": "Aerospace",
       "mech": "Mech"
+    },
+    "mwd": {
+      "weightClass": {
+        "label": "Weight class",
+        "light": "Light",
+        "medium": "Medium",
+        "heavy": "Heavy",
+        "assault": "Assault"
+      },
+      "hardpoint": {
+        "type": {
+          "energy": "Energy",
+          "ballistic": "Ballistic",
+          "missile": "Missile",
+          "support": "Support"
+        },
+        "size": {
+          "small": "Small",
+          "medium": "Medium",
+          "large": "Large"
+        },
+        "location": {
+          "head": "Head",
+          "torso": "Torso",
+          "arm": "Arm",
+          "leg": "Leg"
+        }
+      },
+      "primarySlot": {
+        "mode": {
+          "normal": "Large hardpoint",
+          "converted": "Converted slot"
+        }
+      },
+      "weaponCategory": {
+        "ranged": "Ranged",
+        "melee": "Melee"
+      },
+      "melee": {
+        "title": "Melee options",
+        "baseProfile": "Unarmed",
+        "baseProfileLabel": "Base melee profile",
+        "damagePlaceholder": "Damage code",
+        "notesPlaceholder": "Notes",
+        "maxWeapons": "Maximum equipped melee weapons",
+        "allowedLocations": "Allowed locations",
+        "availableProfiles": "Available melee profiles",
+        "location": {
+          "head": "Head",
+          "torso": "Torso",
+          "arm": "Arm",
+          "leg": "Leg"
+        },
+        "locationAny": "Any location"
+      },
+      "loadout": {
+        "title": "Weapon loadout",
+        "mountPoints": "Mount points used",
+        "primarySlot": {
+          "label": "Primary weapon slot",
+          "noRestriction": "No type restriction",
+          "allowedWeapons": "Allowed primary weapons"
+        },
+        "hardpoints": "Hardpoints",
+        "weaponGroups": "Weapon groups",
+        "primaryTag": "Primary",
+        "occupied": "{{weaponGroup}} assigned",
+        "emptyHardpoint": "Empty",
+        "errors": {
+          "label": "Errors",
+          "multiplePrimary": "Only one primary weapon group is allowed.",
+          "mountPointsExceeded": "Loadout uses {used} mount points but only {total} are available.",
+          "hardpointUnavailable": "No matching hardpoint for {weapon} ({type}, {size}).",
+          "primaryNeedsLarge": "{weapon} must use a large hardpoint to be primary.",
+          "primaryWithoutWeapon": "Primary group needs at least one weapon.",
+          "weaponAlreadyGrouped": "{weapon} is already assigned to another group.",
+          "primaryNotAllowedWeapon": "{weapon} is not allowed in the converted primary slot.",
+          "primaryTypeRestriction": "{weapon} does not match the converted primary slot restriction ({type}).",
+          "meleeLimitExceeded": "Equipped melee weapons {equipped} exceed limit {limit}.",
+          "meleeLocationRestricted": "{weapon} cannot be mounted at that location."
+        },
+        "warnings": {
+          "label": "Warnings",
+          "weaponMissing": "Weapon with id {weapon} is missing."
+        },
+        "newGroup": "New weapon group"
+      }
     },
     "modifier": {
       "column": {

--- a/src/modules/actor/battlemech-actor.js
+++ b/src/modules/actor/battlemech-actor.js
@@ -1,9 +1,16 @@
 import { ICONS_PATH } from "../constants.js";
 import { VehicleActor } from "./vehicle-actor.js";
+import { BattlemechLoadout } from "../mwd/battlemech-loadout.js";
 
 export class BattlemechActor extends VehicleActor {
 
   static get defaultIcon() {
     return `${ICONS_PATH}/vehicles/apc.svg`;
+  }
+
+  prepareDerivedData() {
+    super.prepareDerivedData();
+    const loadout = new BattlemechLoadout(this).compute();
+    this.system.mwd.loadout = loadout;
   }
 }

--- a/src/modules/actor/battlemech-sheet.js
+++ b/src/modules/actor/battlemech-sheet.js
@@ -1,11 +1,63 @@
+import { ANARCHY } from "../config.js";
 import { VehicleSheet } from "./vehicle-sheet.js";
 
 export class BattlemechSheet extends VehicleSheet {
 
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
-      width: 600,
-      height: 650
+      width: 780,
+      height: 750
+    });
+  }
+
+  activateListeners(html) {
+    super.activateListeners(html);
+
+    html.find('.click-add-hardpoint').click(async event => {
+      event.stopPropagation();
+      const hardpoints = foundry.utils.deepClone(this.actor.system.mwd.hardpoints ?? []);
+      hardpoints.push({
+        id: foundry.utils.randomID(),
+        type: Object.keys(ANARCHY.mwd.hardpointType)[0],
+        size: Object.keys(ANARCHY.mwd.hardpointSize)[0],
+        location: Object.keys(ANARCHY.mwd.hardpointLocation)[0],
+      });
+      await this.actor.update({ 'system.mwd.hardpoints': hardpoints });
+    });
+
+    html.find('.click-delete-hardpoint').click(async event => {
+      event.stopPropagation();
+      const index = Number($(event.currentTarget).attr('data-index'));
+      const hardpoints = foundry.utils.deepClone(this.actor.system.mwd.hardpoints ?? []);
+      hardpoints.splice(index, 1);
+      await this.actor.update({ 'system.mwd.hardpoints': hardpoints });
+    });
+
+    html.find('.click-add-weapon-group').click(async event => {
+      event.stopPropagation();
+      const weaponGroups = foundry.utils.deepClone(this.actor.system.mwd.weaponGroups ?? []);
+      weaponGroups.push({
+        id: foundry.utils.randomID(),
+        name: game.i18n.localize(ANARCHY.mwd.loadout.newGroup),
+        weaponIds: [],
+        isPrimary: weaponGroups.length === 0,
+      });
+      await this.actor.update({ 'system.mwd.weaponGroups': weaponGroups });
+    });
+
+    html.find('.click-delete-weapon-group').click(async event => {
+      event.stopPropagation();
+      const index = Number($(event.currentTarget).attr('data-index'));
+      const weaponGroups = foundry.utils.deepClone(this.actor.system.mwd.weaponGroups ?? []);
+      weaponGroups.splice(index, 1);
+      await this.actor.update({ 'system.mwd.weaponGroups': weaponGroups });
+    });
+
+    html.find('.input-primary-group').change(async event => {
+      const index = Number($(event.currentTarget).attr('data-index'));
+      const weaponGroups = foundry.utils.deepClone(this.actor.system.mwd.weaponGroups ?? []);
+      weaponGroups.forEach((group, idx) => group.isPrimary = idx === index ? event.currentTarget.checked : false);
+      await this.actor.update({ 'system.mwd.weaponGroups': weaponGroups });
     });
   }
 }

--- a/src/modules/config.js
+++ b/src/modules/config.js
@@ -417,6 +417,45 @@ export const ANARCHY = {
         aerospace: 'ANARCHY.vehicleCategory.aerospace',
         mech: 'ANARCHY.vehicleCategory.mech',
     },
+    mwd: {
+        weightClass: {
+            light: 'ANARCHY.mwd.weightClass.light',
+            medium: 'ANARCHY.mwd.weightClass.medium',
+            heavy: 'ANARCHY.mwd.weightClass.heavy',
+            assault: 'ANARCHY.mwd.weightClass.assault',
+        },
+        hardpointType: {
+            energy: 'ANARCHY.mwd.hardpoint.type.energy',
+            ballistic: 'ANARCHY.mwd.hardpoint.type.ballistic',
+            missile: 'ANARCHY.mwd.hardpoint.type.missile',
+            support: 'ANARCHY.mwd.hardpoint.type.support',
+        },
+        hardpointSize: {
+            small: 'ANARCHY.mwd.hardpoint.size.small',
+            medium: 'ANARCHY.mwd.hardpoint.size.medium',
+            large: 'ANARCHY.mwd.hardpoint.size.large',
+        },
+        hardpointLocation: {
+            head: 'ANARCHY.mwd.hardpoint.location.head',
+            torso: 'ANARCHY.mwd.hardpoint.location.torso',
+            arm: 'ANARCHY.mwd.hardpoint.location.arm',
+            leg: 'ANARCHY.mwd.hardpoint.location.leg',
+        },
+        primarySlotMode: {
+            normal: 'ANARCHY.mwd.primarySlot.mode.normal',
+            converted: 'ANARCHY.mwd.primarySlot.mode.converted',
+        },
+        weaponCategory: {
+            ranged: 'ANARCHY.mwd.weaponCategory.ranged',
+            melee: 'ANARCHY.mwd.weaponCategory.melee',
+        },
+        meleeLocation: {
+            head: 'ANARCHY.mwd.melee.location.head',
+            torso: 'ANARCHY.mwd.melee.location.torso',
+            arm: 'ANARCHY.mwd.melee.location.arm',
+            leg: 'ANARCHY.mwd.melee.location.leg',
+        },
+    },
     modifier: {
         column: {
             group: 'ANARCHY.modifier.column.group',

--- a/src/modules/enums.js
+++ b/src/modules/enums.js
@@ -17,6 +17,13 @@ export class Enums {
   static hbsShadowampCategories;
   static hbsAreas;
   static hbsRanges;
+  static hbsMwdWeightClasses;
+  static hbsMwdHardpointTypes;
+  static hbsMwdHardpointSizes;
+  static hbsMwdHardpointLocations;
+  static hbsMwdPrimaryModes;
+  static hbsMwdWeaponCategories;
+  static hbsMwdMeleeLocations;
 
   static sortedAttributeKeys;
 
@@ -32,6 +39,13 @@ export class Enums {
     Enums.hbsAreas = Enums.mapObjetToKeyValue(ANARCHY.area);
     Enums.hbsRanges = Enums.mapObjetToKeyValue(ANARCHY.range);
     Enums.hbsVehicleCategories = Enums.mapObjetToKeyValue(ANARCHY.vehicleCategory);
+    Enums.hbsMwdWeightClasses = Enums.mapObjetToKeyValue(ANARCHY.mwd.weightClass);
+    Enums.hbsMwdHardpointTypes = Enums.mapObjetToKeyValue(ANARCHY.mwd.hardpointType);
+    Enums.hbsMwdHardpointSizes = Enums.mapObjetToKeyValue(ANARCHY.mwd.hardpointSize);
+    Enums.hbsMwdHardpointLocations = Enums.mapObjetToKeyValue(ANARCHY.mwd.hardpointLocation);
+    Enums.hbsMwdPrimaryModes = Enums.mapObjetToKeyValue(ANARCHY.mwd.primarySlotMode);
+    Enums.hbsMwdWeaponCategories = Enums.mapObjetToKeyValue(ANARCHY.mwd.weaponCategory);
+    Enums.hbsMwdMeleeLocations = Enums.mapObjetToKeyValue(ANARCHY.mwd.meleeLocation);
 
     Enums.sortedAttributeKeys = Object.keys(ANARCHY.attributes);
 
@@ -53,7 +67,14 @@ export class Enums {
         .map(it => { return { value: it.code, label: game.i18n.localize(it.labelkey), labelkey: it.labelkey }; }),
       areas: Enums.hbsAreas,
       ranges: Enums.hbsRanges,
-      vehicleCategories: Enums.hbsVehicleCategories
+      vehicleCategories: Enums.hbsVehicleCategories,
+      mwdWeightClasses: Enums.hbsMwdWeightClasses,
+      mwdHardpointTypes: Enums.hbsMwdHardpointTypes,
+      mwdHardpointSizes: Enums.hbsMwdHardpointSizes,
+      mwdHardpointLocations: Enums.hbsMwdHardpointLocations,
+      mwdPrimaryModes: Enums.hbsMwdPrimaryModes,
+      mwdWeaponCategories: Enums.hbsMwdWeaponCategories,
+      mwdMeleeLocations: Enums.hbsMwdMeleeLocations,
     };
   }
 

--- a/src/modules/handlebars-manager.js
+++ b/src/modules/handlebars-manager.js
@@ -99,6 +99,7 @@ const HBS_PARTIAL_TEMPLATES = [
   'systems/mwd/templates/actor/parts/weapon-range.hbs',
   'systems/mwd/templates/actor/parts/weapon.hbs',
   'systems/mwd/templates/actor/parts/weapons.hbs',
+  'systems/mwd/templates/actor/parts/battlemech-loadout.hbs',
   //-- NPC
   'systems/mwd/templates/actor/npc-parts/quality.hbs',
   'systems/mwd/templates/actor/npc-parts/qualities.hbs',
@@ -167,6 +168,8 @@ export class HandlebarsManager {
 
   registerBasicHelpers() {
     Handlebars.registerHelper('concat', (...args) => Misc.join(args.slice(0, -1)));
+    Handlebars.registerHelper('eq', (a, b) => a === b);
+    Handlebars.registerHelper('ne', (a, b) => a !== b);
     Handlebars.registerHelper('substring', (str, from, to) => str?.substring(from, to));
     Handlebars.registerHelper('toUpperCase', Grammar.toUpperCaseNoAccent);
     Handlebars.registerHelper('weaponDamageLetter', Damage.letter);
@@ -187,6 +190,7 @@ export class HandlebarsManager {
     Handlebars.registerHelper('min', (v1, v2) => Math.min(v1, v2));
     Handlebars.registerHelper('max', (v1, v2) => Math.max(v1, v2));
     Handlebars.registerHelper('either', (a, b) => a ? a : b);
+    Handlebars.registerHelper('includes', (list, value) => list?.includes(value));
     Handlebars.registerHelper('isInteger', a => a !== undefined && Number.isInteger(a));
     Handlebars.registerHelper('actorAttribute', (attribute, actor, item = undefined) => actor.getAttributeValue(attribute, item));
     Handlebars.registerHelper('localizeAttribute', Enums.localizeAttribute);

--- a/src/modules/mwd/battlemech-loadout.js
+++ b/src/modules/mwd/battlemech-loadout.js
@@ -1,0 +1,209 @@
+import { ANARCHY } from "../config.js";
+
+const MOUNT_POINTS = {
+  light: 4,
+  medium: 5,
+  heavy: 6,
+  assault: 7,
+};
+
+const DEFAULT_PRIMARY_SLOT = { mode: "normal", allowedWeaponIds: [], typeRestriction: "" };
+const DEFAULT_MELEE = {
+  baseProfile: { name: "Unarmed", damage: "", notes: "" },
+  maxWeapons: 0,
+  allowedLocations: [],
+};
+
+export class BattlemechLoadout {
+  constructor(actor) {
+    this.actor = actor;
+    this.mwd = actor.system.mwd ?? {};
+  }
+
+  compute() {
+    const weightClass = this.mwd.weightClass ?? "medium";
+    const mountPointTotal = MOUNT_POINTS[weightClass] ?? MOUNT_POINTS.medium;
+    const hardpoints = this._normalizeHardpoints();
+    const groups = this._normalizeWeaponGroups();
+    const primaryGroup = groups.find(it => it.isPrimary);
+    const primaryGroups = groups.filter(it => it.isPrimary);
+    const primarySlot = this._primarySlot();
+    const errors = [];
+    const warnings = [];
+
+    if (primaryGroups.length > 1) {
+      errors.push(game.i18n.localize(ANARCHY.mwd.loadout.errors.multiplePrimary));
+    }
+
+    const maxGroupCount = primaryGroup ? mountPointTotal - 1 : mountPointTotal;
+    const usedMountPoints = groups.length + (primaryGroup ? 1 : 0);
+    if (groups.length > maxGroupCount) {
+      errors.push(game.i18n.format(ANARCHY.mwd.loadout.errors.mountPointsExceeded, {
+        used: usedMountPoints,
+        total: mountPointTotal,
+      }));
+    }
+
+    const rangedWeapons = this._getWeapons(it => (it.system.weaponCategory ?? "ranged") !== "melee");
+    const rangedById = new Map(rangedWeapons.map(it => [it.id, it]));
+    const usedWeapons = new Set();
+
+    const hardpointState = hardpoints.map(hp => ({ ...hp, occupiedBy: null, occupiedByName: undefined }));
+
+    for (const group of groups) {
+      for (const weaponId of group.weaponIds ?? []) {
+        const weapon = rangedById.get(weaponId);
+        if (!weapon) {
+          warnings.push(game.i18n.format(ANARCHY.mwd.loadout.warnings.weaponMissing, { weapon: weaponId }));
+          continue;
+        }
+        const weaponType = weapon.system.hardpointType ?? "energy";
+        const weaponSize = weapon.system.hardpointSize ?? "small";
+        if (usedWeapons.has(weaponId)) {
+          errors.push(game.i18n.format(ANARCHY.mwd.loadout.errors.weaponAlreadyGrouped, { weapon: weapon.name }));
+          continue;
+        }
+        usedWeapons.add(weaponId);
+
+        if (group.isPrimary) {
+          this._validatePrimaryWeapon(weapon, weaponType, weaponSize, primarySlot, errors);
+        }
+
+        if ((weapon.system.weaponCategory ?? "ranged") === "melee") {
+          continue;
+        }
+
+        const match = hardpointState.find(hp => !hp.occupiedBy
+          && hp.type === weaponType
+          && hp.size === weaponSize);
+        if (!match) {
+          errors.push(game.i18n.format(ANARCHY.mwd.loadout.errors.hardpointUnavailable, {
+            weapon: weapon.name,
+            type: game.i18n.localize(ANARCHY.mwd.hardpointType[weaponType] ?? weaponType),
+            size: game.i18n.localize(ANARCHY.mwd.hardpointSize[weaponSize] ?? weaponSize),
+          }));
+        }
+        else {
+          match.occupiedBy = group.id;
+          match.occupiedByName = group.name;
+        }
+      }
+    }
+
+    if (primaryGroup && (!primaryGroup.weaponIds || primaryGroup.weaponIds.length === 0)) {
+      errors.push(game.i18n.localize(ANARCHY.mwd.loadout.errors.primaryWithoutWeapon));
+    }
+
+    const meleeState = this._computeMeleeState(errors);
+
+    return {
+      mountPoints: {
+        total: mountPointTotal,
+        used: usedMountPoints,
+        remaining: Math.max(0, mountPointTotal - usedMountPoints),
+      },
+      weightClass,
+      hardpoints: hardpointState,
+      weaponGroups: groups,
+      primaryGroupId: primaryGroup?.id,
+      errors,
+      warnings,
+      meleeProfiles: meleeState.profiles,
+      meleeLimit: meleeState.limit,
+    };
+  }
+
+  _normalizeWeaponGroups() {
+    return (this.mwd.weaponGroups ?? []).map((group, index) => ({
+      id: group.id ?? `group-${index + 1}`,
+      name: group.name || game.i18n.format(ANARCHY.common.newName, { type: game.i18n.localize(ANARCHY.itemType.singular.weapon) }),
+      weaponIds: this._asArray(group.weaponIds),
+      isPrimary: group.isPrimary ?? false,
+    }));
+  }
+
+  _normalizeHardpoints() {
+    return (this.mwd.hardpoints ?? []).map((hp, index) => ({
+      id: hp.id ?? `hardpoint-${index + 1}`,
+      type: hp.type ?? "energy",
+      size: hp.size ?? "small",
+      location: hp.location ?? "arm",
+    }));
+  }
+
+  _primarySlot() {
+    const slot = foundry.utils.mergeObject(foundry.utils.duplicate(DEFAULT_PRIMARY_SLOT), this.mwd.primarySlot ?? {});
+    slot.allowedWeaponIds = this._asArray(slot.allowedWeaponIds);
+    return slot;
+  }
+
+  _computeMeleeState(errors) {
+    const meleeConfig = foundry.utils.mergeObject(foundry.utils.duplicate(DEFAULT_MELEE), this.mwd.melee ?? {});
+    const meleeWeapons = this._getWeapons(it => (it.system.weaponCategory ?? "ranged") === "melee");
+    const profiles = [];
+    const limit = Number(meleeConfig.maxWeapons ?? 0);
+
+    if (meleeWeapons.length > limit) {
+      errors.push(game.i18n.format(ANARCHY.mwd.loadout.errors.meleeLimitExceeded, {
+        equipped: meleeWeapons.length,
+        limit,
+      }));
+    }
+
+    const allowedLocations = this._asArray(meleeConfig.allowedLocations);
+    profiles.push({
+      name: meleeConfig.baseProfile?.name || game.i18n.localize(ANARCHY.mwd.melee.baseProfile),
+      damage: meleeConfig.baseProfile?.damage ?? "",
+      notes: meleeConfig.baseProfile?.notes ?? "",
+    });
+
+    meleeWeapons.forEach(weapon => {
+      if (allowedLocations.length > 0 && weapon.system.mountLocation && !allowedLocations.includes(weapon.system.mountLocation)) {
+        errors.push(game.i18n.format(ANARCHY.mwd.loadout.errors.meleeLocationRestricted, {
+          weapon: weapon.name,
+          location: game.i18n.localize(ANARCHY.mwd.meleeLocation[weapon.system.mountLocation] ?? weapon.system.mountLocation),
+        }));
+      }
+      profiles.push({
+        name: weapon.name,
+        damage: weapon.getDamageCode(),
+        notes: weapon.system.references?.description ?? "",
+      });
+    });
+
+    return { profiles, limit };
+  }
+
+  _validatePrimaryWeapon(weapon, weaponType, weaponSize, primarySlot, errors) {
+    if (primarySlot.mode === "converted") {
+      if (primarySlot.allowedWeaponIds?.length > 0 && !primarySlot.allowedWeaponIds.includes(weapon.id)) {
+        errors.push(game.i18n.format(ANARCHY.mwd.loadout.errors.primaryNotAllowedWeapon, { weapon: weapon.name }));
+      }
+      if (primarySlot.typeRestriction && weaponType !== primarySlot.typeRestriction) {
+        errors.push(game.i18n.format(ANARCHY.mwd.loadout.errors.primaryTypeRestriction, {
+          weapon: weapon.name,
+          type: game.i18n.localize(ANARCHY.mwd.hardpointType[primarySlot.typeRestriction] ?? primarySlot.typeRestriction),
+        }));
+      }
+    }
+    else if (weaponSize !== "large") {
+      errors.push(game.i18n.format(ANARCHY.mwd.loadout.errors.primaryNeedsLarge, { weapon: weapon.name }));
+    }
+  }
+
+  _getWeapons(filter) {
+    return this.actor.items
+      .filter(it => it.type === "weapon")
+      .filter(filter);
+  }
+
+  _asArray(value) {
+    if (Array.isArray(value)) {
+      return value;
+    }
+    if (value === undefined || value === null || value === "") {
+      return [];
+    }
+    return [value];
+  }
+}

--- a/style.css
+++ b/style.css
@@ -1630,4 +1630,47 @@
   font-weight: 600;
 }
 
+.battlemech-loadout .loadout-summary {
+  gap: 0.5rem;
+}
+
+.battlemech-loadout .loadout-columns {
+  gap: 0.75rem;
+}
+
+.battlemech-loadout .loadout-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.35rem;
+}
+
+.battlemech-loadout select[multiple] {
+  min-width: 12rem;
+  min-height: 5rem;
+}
+
+.battlemech-loadout .loadout-column-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.battlemech-loadout .loadout-feedback {
+  margin-top: 0.5rem;
+}
+
+.battlemech-loadout .loadout-errors {
+  color: var(--anarchy-color-error, #b22222);
+}
+
+.battlemech-loadout .loadout-warnings {
+  color: var(--anarchy-color-warning, #b8860b);
+}
+
+.battlemech-loadout .melee-profile-list {
+  margin: 0;
+  padding-left: 1rem;
+}
+
 /*# sourceMappingURL=style.css.map */

--- a/system.json
+++ b/system.json
@@ -1,6 +1,6 @@
 {
   "id": "mwd",
-  "version": "13.2.2",
+  "version": "13.2.3",
   "manifest": "https://raw.githubusercontent.com/acemb-rso/MWD/main/system.json",
   "download": "https://github.com/acemb-rso/MWD/archive/refs/heads/main.zip",
   "url": "https://github.com/acemb-rso/MWD",

--- a/template.json
+++ b/template.json
@@ -180,6 +180,23 @@
             "effectiveCount": 1,
             "injuryLevel": 0,
             "bailedOut": false
+          },
+          "weightClass": "medium",
+          "hardpoints": [],
+          "weaponGroups": [],
+          "primarySlot": {
+            "mode": "normal",
+            "allowedWeaponIds": [],
+            "typeRestriction": ""
+          },
+          "melee": {
+            "baseProfile": {
+              "name": "Unarmed",
+              "damage": "",
+              "notes": ""
+            },
+            "maxWeapons": 0,
+            "allowedLocations": []
           }
         }
       }
@@ -398,11 +415,15 @@
       "capacity": "mundane",
       "level": 1
     },
-    "weapon": {
-      "templates": ["modifiers", "inactive", "references"],
-      "skill": "",
-      "specialization": "",
-      "strength": true,
+      "weapon": {
+        "templates": ["modifiers", "inactive", "references"],
+        "weaponCategory": "ranged",
+        "hardpointType": "energy",
+        "hardpointSize": "small",
+        "mountLocation": "",
+        "skill": "",
+        "specialization": "",
+        "strength": true,
       "damage": 0,
       "damageAttribute": "",
       "noArmor": false,

--- a/templates/actor/battlemech.hbs
+++ b/templates/actor/battlemech.hbs
@@ -81,6 +81,9 @@
     {{> "systems/mwd/templates/actor/npc-parts/skills.hbs"}}
     </div>
     <div class="section-group items-group">
+      {{> "systems/mwd/templates/actor/parts/battlemech-loadout.hbs"}}
+    </div>
+    <div class="section-group items-group">
     {{> "systems/mwd/templates/actor/npc-parts/shadowamps.hbs"}}
     </div>
     <div class="section-group items-group">

--- a/templates/actor/parts/battlemech-loadout.hbs
+++ b/templates/actor/parts/battlemech-loadout.hbs
@@ -1,0 +1,159 @@
+<div class="anarchy-block battlemech-loadout">
+  <h3 class="section-group-header">{{localize 'ANARCHY.mwd.loadout.title'}}</h3>
+  <div class="flexrow loadout-summary">
+    <div class="flexcol">
+      <label>{{localize 'ANARCHY.mwd.weightClass.label'}}</label>
+      <select name="system.mwd.weightClass">
+        {{#select system.mwd.weightClass}}
+          {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.mwdWeightClasses}}
+        {{/select}}
+      </select>
+    </div>
+    <div class="flexcol">
+      <label>{{localize 'ANARCHY.mwd.loadout.mountPoints'}}</label>
+      <span>{{system.mwd.loadout.mountPoints.used}} / {{system.mwd.loadout.mountPoints.total}}</span>
+    </div>
+    <div class="flexcol">
+      <label>{{localize 'ANARCHY.mwd.loadout.primarySlot.label'}}</label>
+      <div class="flexrow">
+        <select name="system.mwd.primarySlot.mode">
+          {{#select system.mwd.primarySlot.mode}}
+            {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.mwdPrimaryModes}}
+          {{/select}}
+        </select>
+        <select name="system.mwd.primarySlot.typeRestriction">
+          {{#select system.mwd.primarySlot.typeRestriction}}
+            <option value="">{{localize 'ANARCHY.mwd.loadout.primarySlot.noRestriction'}}</option>
+            {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.mwdHardpointTypes}}
+          {{/select}}
+        </select>
+      </div>
+      <label class="small-label">{{localize 'ANARCHY.mwd.loadout.primarySlot.allowedWeapons'}}</label>
+      <select name="system.mwd.primarySlot.allowedWeaponIds" multiple>
+        {{#each items.weapon as |weapon|}}
+          {{#if (ne weapon.system.weaponCategory 'melee')}}
+          <option value="{{weapon._id}}" {{#if (includes ../system.mwd.primarySlot.allowedWeaponIds weapon._id)}}selected{{/if}}>{{weapon.name}}</option>
+          {{/if}}
+        {{/each}}
+      </select>
+    </div>
+  </div>
+  <div class="flexrow loadout-columns">
+    <div class="flexcol loadout-column">
+      <div class="loadout-column-header">
+        <h4>{{localize 'ANARCHY.mwd.loadout.hardpoints'}}</h4>
+        <a class="click-add-hardpoint"><i class="fa-solid fa-plus"></i></a>
+      </div>
+      <div class="loadout-list">
+        {{#each system.mwd.hardpoints as |hardpoint idx|}}
+          <div class="loadout-row">
+            <select name="system.mwd.hardpoints.{{idx}}.type">
+              {{#select hardpoint.type}}
+                {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=../../ENUMS.mwdHardpointTypes}}
+              {{/select}}
+            </select>
+            <select name="system.mwd.hardpoints.{{idx}}.size">
+              {{#select hardpoint.size}}
+                {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=../../ENUMS.mwdHardpointSizes}}
+              {{/select}}
+            </select>
+            <select name="system.mwd.hardpoints.{{idx}}.location">
+              {{#select hardpoint.location}}
+                {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=../../ENUMS.mwdHardpointLocations}}
+              {{/select}}
+            </select>
+            <span class="loadout-occupant">
+              {{#if (lookup ../system.mwd.loadout.hardpoints idx)}}
+                {{#with (lookup ../system.mwd.loadout.hardpoints idx)}}
+                  {{#if occupiedByName}}
+                    {{localize 'ANARCHY.mwd.loadout.occupied' weaponGroup=occupiedByName}}
+                  {{else}}
+                    {{localize 'ANARCHY.mwd.loadout.emptyHardpoint'}}
+                  {{/if}}
+                {{/with}}
+              {{/if}}
+            </span>
+            <a class="click-delete-hardpoint" data-index="{{idx}}"><i class="fa-solid fa-trash"></i></a>
+          </div>
+        {{/each}}
+      </div>
+    </div>
+    <div class="flexcol loadout-column">
+      <div class="loadout-column-header">
+        <h4>{{localize 'ANARCHY.mwd.loadout.weaponGroups'}}</h4>
+        <a class="click-add-weapon-group"><i class="fa-solid fa-plus"></i></a>
+      </div>
+      <div class="loadout-list">
+        {{#each system.mwd.weaponGroups as |group idx|}}
+          <div class="loadout-row">
+            <input type="text" name="system.mwd.weaponGroups.{{idx}}.name" value="{{group.name}}" />
+            <label>
+              <input class="input-primary-group" data-index="{{idx}}" type="checkbox" name="system.mwd.weaponGroups.{{idx}}.isPrimary" {{checked group.isPrimary}} />
+              {{localize 'ANARCHY.mwd.loadout.primaryTag'}}
+            </label>
+            <select name="system.mwd.weaponGroups.{{idx}}.weaponIds" multiple>
+              {{#each ../../items.weapon as |weapon|}}
+                {{#if (ne weapon.system.weaponCategory 'melee')}}
+                <option value="{{weapon._id}}" {{#if (includes ../group.weaponIds weapon._id)}}selected{{/if}}>{{weapon.name}}</option>
+                {{/if}}
+              {{/each}}
+            </select>
+            <a class="click-delete-weapon-group" data-index="{{idx}}"><i class="fa-solid fa-trash"></i></a>
+          </div>
+        {{/each}}
+      </div>
+    </div>
+  </div>
+  <div class="flexrow loadout-columns">
+    <div class="flexcol loadout-column">
+      <h4>{{localize 'ANARCHY.mwd.melee.title'}}</h4>
+      <label>{{localize 'ANARCHY.mwd.melee.baseProfileLabel'}}</label>
+      <input type="text" name="system.mwd.melee.baseProfile.name" value="{{system.mwd.melee.baseProfile.name}}" />
+      <input type="text" name="system.mwd.melee.baseProfile.damage" value="{{system.mwd.melee.baseProfile.damage}}" placeholder="{{localize 'ANARCHY.mwd.melee.damagePlaceholder'}}" />
+      <textarea name="system.mwd.melee.baseProfile.notes" rows="2" placeholder="{{localize 'ANARCHY.mwd.melee.notesPlaceholder'}}">{{system.mwd.melee.baseProfile.notes}}</textarea>
+      <label>{{localize 'ANARCHY.mwd.melee.maxWeapons'}}</label>
+      <input type="number" name="system.mwd.melee.maxWeapons" data-dtype="Number" value="{{system.mwd.melee.maxWeapons}}" />
+      <label>{{localize 'ANARCHY.mwd.melee.allowedLocations'}}</label>
+      <select name="system.mwd.melee.allowedLocations" multiple>
+        {{#each ENUMS.mwdMeleeLocations as |location|}}
+          <option value="{{location.value}}" {{#if (includes ../system.mwd.melee.allowedLocations location.value)}}selected{{/if}}>{{localize location.labelkey}}</option>
+        {{/each}}
+      </select>
+    </div>
+    <div class="flexcol loadout-column">
+      <h4>{{localize 'ANARCHY.mwd.melee.availableProfiles'}} ({{length system.mwd.loadout.meleeProfiles}})</h4>
+      <ul class="melee-profile-list">
+        {{#each system.mwd.loadout.meleeProfiles as |profile|}}
+          <li>
+            <strong>{{profile.name}}</strong>: {{profile.damage}}
+            {{#if profile.notes}}
+              <span class="profile-notes">{{profile.notes}}</span>
+            {{/if}}
+          </li>
+        {{/each}}
+      </ul>
+    </div>
+  </div>
+  <div class="loadout-feedback">
+    {{#if system.mwd.loadout.errors.length}}
+      <div class="loadout-errors">
+        <strong>{{localize 'ANARCHY.mwd.loadout.errors.label'}}</strong>
+        <ul>
+          {{#each system.mwd.loadout.errors as |error|}}
+            <li>{{error}}</li>
+          {{/each}}
+        </ul>
+      </div>
+    {{/if}}
+    {{#if system.mwd.loadout.warnings.length}}
+      <div class="loadout-warnings">
+        <strong>{{localize 'ANARCHY.mwd.loadout.warnings.label'}}</strong>
+        <ul>
+          {{#each system.mwd.loadout.warnings as |warning|}}
+            <li>{{warning}}</li>
+          {{/each}}
+        </ul>
+      </div>
+    {{/if}}
+  </div>
+</div>

--- a/templates/item/weapon.hbs
+++ b/templates/item/weapon.hbs
@@ -27,6 +27,38 @@
             {{/select}}
         </select>
       </div>
+      <div class="form-group">
+        <label for="system.weaponCategory">{{localize 'ANARCHY.item.weapon.category'}}</label>
+        <select name="system.weaponCategory">
+          {{#select system.weaponCategory}}
+            {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.mwdWeaponCategories}}
+          {{/select}}
+        </select>
+      </div>
+      <div class="form-group">
+        <label>{{localize 'ANARCHY.item.weapon.hardpoint'}}</label>
+        <div class="flexrow">
+          <select name="system.hardpointType">
+            {{#select system.hardpointType}}
+              {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.mwdHardpointTypes}}
+            {{/select}}
+          </select>
+          <select name="system.hardpointSize">
+            {{#select system.hardpointSize}}
+              {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.mwdHardpointSizes}}
+            {{/select}}
+          </select>
+        </div>
+      </div>
+      <div class="form-group">
+        <label>{{localize 'ANARCHY.item.weapon.mountLocation'}}</label>
+        <select name="system.mountLocation">
+          {{#select system.mountLocation}}
+            <option value="">{{localize 'ANARCHY.mwd.melee.locationAny'}}</option>
+            {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.mwdMeleeLocations}}
+          {{/select}}
+        </select>
+      </div>
       {{#if hasDrain}}
       <div class="form-group">
         <label for="system.drain">{{localize 'ANARCHY.item.weapon.drain'}} </label>


### PR DESCRIPTION
## Summary
- add battlemech loadout validation covering mount points, hardpoints, primary rules, and melee profiles
- extend the battlemech sheet with loadout editors, styling, and helper templates for weapon groups and hardpoints
- expand weapon data and migrations to carry hardpoint metadata, new enums/translations, and bump the system version

## Testing
- node -e "JSON.parse(require('fs').readFileSync('lang/en.json','utf8')); console.log('lang ok');"
- node -e "JSON.parse(require('fs').readFileSync('template.json','utf8')); console.log('template ok');"

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c9b106440832d80102560a8813f02)