### PR TITLE
Restyle mech quick actions

### DIFF
--- a/src/modules/actor/battlemech-sheet.js
+++ b/src/modules/actor/battlemech-sheet.js
@@ -66,6 +66,7 @@ export class BattlemechSheet extends VehicleSheet {
 
     html.find('[data-quick-actions] .quick-action-button').click(async event => {
       event.stopPropagation();
+      if (event.currentTarget.dataset.disabled === "true") return;
       const action = event.currentTarget.dataset.action;
       switch (action) {
         case 'ranged':

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -136,23 +136,18 @@
 .mech-quick-actions {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.5rem;
-    align-items: stretch;
+    gap: 0.25rem;
+    align-items: center;
 
     .quick-action-button {
         display: inline-flex;
         align-items: center;
         gap: 0.35rem;
-        border: 1px solid var(--color-border-dark-primary);
-        background: var(--color-border-light-primary);
-        padding: 0.4rem 0.6rem;
-        border-radius: 4px;
-        font-size: var(--font-size-14);
-        cursor: pointer;
 
-        &:disabled {
+        &[data-disabled="true"] {
             opacity: 0.5;
             cursor: not-allowed;
+            pointer-events: none;
         }
     }
 }

--- a/templates/actor/parts/mech-quick-actions.hbs
+++ b/templates/actor/parts/mech-quick-actions.hbs
@@ -1,26 +1,26 @@
 <div class="mech-quick-actions" data-quick-actions>
-  <button type="button" class="quick-action-button" data-action="ranged" {{#unless system.weaponGroups.length}}disabled{{/unless}} data-tooltip="{{localize 'ANARCHY.actor.vehicle.quickActions.tooltips.ranged'}}">
+  <a class="anarchy-button quick-action-button" data-action="ranged" {{#unless system.weaponGroups.length}}data-disabled="true"{{/unless}} data-tooltip="{{localize 'ANARCHY.actor.vehicle.quickActions.tooltips.ranged'}}">
     <span class="quick-action-icon">🔫</span>
-    <span>{{localize 'ANARCHY.actor.vehicle.quickActions.rangedAttack'}}</span>
-  </button>
-  <button type="button" class="quick-action-button" data-action="melee" {{#unless system.meleeProfiles.length}}disabled{{/unless}} data-tooltip="{{localize 'ANARCHY.actor.vehicle.quickActions.tooltips.melee'}}">
+    <label>{{localize 'ANARCHY.actor.vehicle.quickActions.rangedAttack'}}</label>
+  </a>
+  <a class="anarchy-button quick-action-button" data-action="melee" {{#unless system.meleeProfiles.length}}data-disabled="true"{{/unless}} data-tooltip="{{localize 'ANARCHY.actor.vehicle.quickActions.tooltips.melee'}}">
     <span class="quick-action-icon">⚔️</span>
-    <span>{{localize 'ANARCHY.actor.vehicle.quickActions.meleeAttack'}}</span>
-  </button>
-  <button type="button" class="quick-action-button" data-action="dodge" data-tooltip="{{localize 'ANARCHY.actor.vehicle.quickActions.tooltips.dodge'}}">
+    <label>{{localize 'ANARCHY.actor.vehicle.quickActions.meleeAttack'}}</label>
+  </a>
+  <a class="anarchy-button quick-action-button" data-action="dodge" data-tooltip="{{localize 'ANARCHY.actor.vehicle.quickActions.tooltips.dodge'}}">
     <span class="quick-action-icon">🛡️</span>
-    <span>{{localize 'ANARCHY.actor.vehicle.quickActions.dodgeCheck'}}</span>
-  </button>
-  <button type="button" class="quick-action-button" data-action="piloting" data-tooltip="{{localize 'ANARCHY.actor.vehicle.quickActions.tooltips.piloting'}}">
+    <label>{{localize 'ANARCHY.actor.vehicle.quickActions.dodgeCheck'}}</label>
+  </a>
+  <a class="anarchy-button quick-action-button" data-action="piloting" data-tooltip="{{localize 'ANARCHY.actor.vehicle.quickActions.tooltips.piloting'}}">
     <span class="quick-action-icon">🌀</span>
-    <span>{{localize 'ANARCHY.actor.vehicle.quickActions.pilotingCheck'}}</span>
-  </button>
-  <button type="button" class="quick-action-button" data-action="sensor" {{#unless system.quickActions.hasSensorSweep}}disabled{{/unless}} data-tooltip="{{localize 'ANARCHY.actor.vehicle.quickActions.tooltips.sensorSweep'}}">
+    <label>{{localize 'ANARCHY.actor.vehicle.quickActions.pilotingCheck'}}</label>
+  </a>
+  <a class="anarchy-button quick-action-button" data-action="sensor" {{#unless system.quickActions.hasSensorSweep}}data-disabled="true"{{/unless}} data-tooltip="{{localize 'ANARCHY.actor.vehicle.quickActions.tooltips.sensorSweep'}}">
     <span class="quick-action-icon">📡</span>
-    <span>{{localize 'ANARCHY.actor.vehicle.quickActions.sensorSweep'}}</span>
-  </button>
-  <button type="button" class="quick-action-button" data-action="repair" data-tooltip="{{localize 'ANARCHY.actor.vehicle.quickActions.tooltips.emergencyRepair'}}">
+    <label>{{localize 'ANARCHY.actor.vehicle.quickActions.sensorSweep'}}</label>
+  </a>
+  <a class="anarchy-button quick-action-button" data-action="repair" data-tooltip="{{localize 'ANARCHY.actor.vehicle.quickActions.tooltips.emergencyRepair'}}">
     <span class="quick-action-icon">🔧</span>
-    <span>{{localize 'ANARCHY.actor.vehicle.quickActions.emergencyRepair'}}</span>
-  </button>
+    <label>{{localize 'ANARCHY.actor.vehicle.quickActions.emergencyRepair'}}</label>
+  </a>
 </div>


### PR DESCRIPTION
## Summary
- restyle mech quick action buttons to match anarchy-style badges instead of large rectangular buttons
- ensure disabled quick actions are non-interactive now that buttons use anchor styling
- tighten quick action layout spacing to align with header asides

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cb176f8b8832dbcbabda3e0f6e291)