### PR TITLE
Add mech and personal weapon item types

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -7,12 +7,12 @@
     },
     "Item": {
       "contact": "Contact",
-      "cyberdeck": "Cyberdeck",
       "gear": "Gear",
       "quality": "Trait",
       "shadowamp": "Shadowamp",
       "skill": "Skill",
-      "weapon": "Weapon"
+      "mechWeapon": "Mech-Scale Weapon",
+      "personalWeapon": "Personal Weapon"
     }
   },
   "ANARCHY": {
@@ -70,7 +70,7 @@
       "rollDice": {
         "title": "Roll Destiny dice",
         "instruction": "Number of dice to roll: ",
-        "error": "Veuillez entrer un nombre valide de dés.",
+        "error": "Veuillez entrer un nombre valide de d\u00e9s.",
         "result": "Roll of {count}d6, {success} success! {ones} dice with a value of 1"
       }
     },
@@ -214,8 +214,8 @@
           "rumor": "Rumor"
         }
       },
-        "monitors": {
-          "conditionMonitors": "Condition monitors",
+      "monitors": {
+        "conditionMonitors": "Condition monitors",
         "overflow": "{actor}: Overflow of {monitor} condition monitor, transfering {overflow} to {overflowMonitor} condition monitor",
         "physical": "Physical",
         "fatigue": "Fatigue",
@@ -223,55 +223,55 @@
         "structure": "Structure",
         "heat": "Heat",
         "resistance": "Resistance"
-        },
+      },
       "vehicle": {
         "moves": "Moves",
         "attacks": "Attacks",
         "stealth": "Stealth",
         "category": "Category",
         "skill": "Skill",
-    "heatDissipation": "Heat dissipation",
-    "criticalTrack": "Criticals",
-    "locationFront": "Front effects",
-    "locationSide": "Side effects",
-    "locationRear": "Rear effects",
-    "locationCore": "Core effects",
-    "quickActions": {
-      "title": "Quick Actions",
-      "rangedAttack": "Ranged Attack",
-      "meleeAttack": "Melee Attack",
-      "dodgeCheck": "Dodge Check",
-      "pilotingCheck": "Piloting Check",
-      "sensorSweep": "Sensor Sweep",
-      "emergencyRepair": "Emergency Repair",
-      "primaryWeapons": "Primary Weapons",
-      "allWeapons": "All Weapons",
-      "primaryLabel": "Primary",
-      "unarmed": "Unarmed (Punch/Kick)",
-      "unarmedNotes": "Basic unarmed strike.",
-      "selectWeaponGroup": "Select Weapon Group",
-      "selectMeleeProfile": "Select Melee Profile",
-      "selectSensorSkill": "Select Sensor Sweep Skill",
-      "weaponGroup": "Weapon Group",
-      "weaponsUsed": "Weapons",
-      "meleeProfile": "Melee Profile",
-      "meleeDamage": "Damage",
-      "skillUsed": "Skill",
-      "tooltips": {
-        "ranged": "Roll an attack using any Weapon Group or Primary Weapon",
-        "melee": "Roll a melee attack using fists, kicks, or installed melee weapons",
-        "dodge": "Piloting roll to evade incoming fire or avoid danger",
-        "piloting": "Piloting roll for movement, jumping, stability, or hazard checks",
-        "sensorSweep": "Perception/Tech roll using sensors or Active Probe",
-        "emergencyRepair": "Technician roll to stabilize or fix a system during battle"
+        "heatDissipation": "Heat dissipation",
+        "criticalTrack": "Criticals",
+        "locationFront": "Front effects",
+        "locationSide": "Side effects",
+        "locationRear": "Rear effects",
+        "locationCore": "Core effects",
+        "quickActions": {
+          "title": "Quick Actions",
+          "rangedAttack": "Ranged Attack",
+          "meleeAttack": "Melee Attack",
+          "dodgeCheck": "Dodge Check",
+          "pilotingCheck": "Piloting Check",
+          "sensorSweep": "Sensor Sweep",
+          "emergencyRepair": "Emergency Repair",
+          "primaryWeapons": "Primary Weapons",
+          "allWeapons": "All Weapons",
+          "primaryLabel": "Primary",
+          "unarmed": "Unarmed (Punch/Kick)",
+          "unarmedNotes": "Basic unarmed strike.",
+          "selectWeaponGroup": "Select Weapon Group",
+          "selectMeleeProfile": "Select Melee Profile",
+          "selectSensorSkill": "Select Sensor Sweep Skill",
+          "weaponGroup": "Weapon Group",
+          "weaponsUsed": "Weapons",
+          "meleeProfile": "Melee Profile",
+          "meleeDamage": "Damage",
+          "skillUsed": "Skill",
+          "tooltips": {
+            "ranged": "Roll an attack using any Weapon Group or Primary Weapon",
+            "melee": "Roll a melee attack using fists, kicks, or installed melee weapons",
+            "dodge": "Piloting roll to evade incoming fire or avoid danger",
+            "piloting": "Piloting roll for movement, jumping, stability, or hazard checks",
+            "sensorSweep": "Perception/Tech roll using sensors or Active Probe",
+            "emergencyRepair": "Technician roll to stabilize or fix a system during battle"
+          },
+          "errors": {
+            "noRanged": "No weapon groups available for ranged attack.",
+            "noMelee": "No melee attacks available.",
+            "noSensorSweep": "Sensor sweep requires Perception or Technician."
+          }
+        }
       },
-      "errors": {
-        "noRanged": "No weapon groups available for ranged attack.",
-        "noMelee": "No melee attacks available.",
-        "noSensorSweep": "Sensor sweep requires Perception or Technician."
-      }
-    }
-  },
       "ownership": {
         "owner": "Owner",
         "unknown": "Unknown",
@@ -313,30 +313,35 @@
         "level": "Level",
         "levelShort": "Lvl"
       },
-      "weapon": {
-        "skill": "Skill",
-        "drain": "Drain",
-        "category": "Weapon category",
+      "mechWeapon": {
+        "category": "Weapon Category",
         "hardpoint": "Hardpoint",
-        "mountLocation": "Mount location",
-        "damage": "Damages",
-        "strength": "+ strength",
-        "defense": "Defense",
+        "damage": "Damage Value",
+        "damageType": "Damage Type",
+        "heat": "Heat",
         "area": "Area of effect",
-        "withArmor": "Armor protects",
-        "noArmor": "Armor avoidance",
-        "damageShort": "DV",
-        "areaShort": "Area",
-        "noArmorShort": "(AA)",
-        "weaponWithoutActor": "No Actor",
         "range": {
           "max": "Maximum range"
         }
       },
-      "cyberdeck": {
-        "programs": "Programs",
-        "processing": "Processing power",
-        "processingHelp": "re-rolls on matrix rolls"
+      "personalWeapon": {
+        "skill": "Skill",
+        "category": "Weapon Category",
+        "damageCategory": "Damage Category",
+        "damage": "Damage Value",
+        "damageType": "Damage Type",
+        "defense": "Defense",
+        "area": "Area of effect",
+        "damageShort": "DV",
+        "areaShort": "Area",
+        "weaponWithoutActor": "No Actor",
+        "armorAvoidance": "Armor avoidance",
+        "armorAvoidanceHelp": "Ignore armor on this attack",
+        "range": {
+          "max": "Maximum range"
+        },
+        "noArmor": "Armor avoidance",
+        "withArmor": "Armor protects"
       }
     },
     "itemType": {
@@ -344,21 +349,21 @@
         "skill": "Skill",
         "quality": "Trait",
         "shadowamp": "Shadow Amp",
-        "weapon": "Weapon",
         "gear": "Gear",
-        "cyberdeck": "Cyberdeck",
-        "contact": "Contact"
+        "contact": "Contact",
+        "mechWeapon": "Mech-Scale Weapon",
+        "personalWeapon": "Personal Weapon"
       },
       "plural": {
         "skill": "Skills",
         "quality": "Qualities",
         "shadowamp": "Shadow Amps",
-        "weapon": "Weapons",
         "gear": "Gears",
-        "cyberdeck": "Cyberdecks",
         "contact": "Contacts",
         "action": "Actions",
-        "monitor": "Monitors"
+        "monitor": "Monitors",
+        "mechWeapon": "Mech-Scale Weapons",
+        "personalWeapon": "Personal Weapons"
       }
     },
     "capacity": {
@@ -488,10 +493,11 @@
       },
       "hardpoint": {
         "type": {
-          "energy": "Energy",
           "ballistic": "Ballistic",
+          "energy": "Energy",
           "missile": "Missile",
-          "support": "Support"
+          "special": "Special",
+          "melee": "Melee"
         },
         "size": {
           "small": "Small",
@@ -563,6 +569,29 @@
           "weaponMissing": "Weapon with id {weapon} is missing."
         },
         "newGroup": "New weapon group"
+      },
+      "weapon": {
+        "damageType": {
+          "energy": "Energy",
+          "kinetic": "Kinetic",
+          "explosive": "Explosive",
+          "plasma": "Plasma",
+          "none": "None"
+        }
+      },
+      "personalWeapon": {
+        "damageType": {
+          "energy": "Energy",
+          "kinetic": "Kinetic",
+          "explosive": "Explosive",
+          "plasma": "Plasma",
+          "corrosive": "Corrosive",
+          "poison": "Poison"
+        },
+        "damageCategory": {
+          "physical": "Physical",
+          "fatigue": "Fatigue"
+        }
       }
     },
     "modifier": {

--- a/src/modules/actor/anarchy-actor-sheet.js
+++ b/src/modules/actor/anarchy-actor-sheet.js
@@ -48,6 +48,10 @@ export class AnarchyActorSheet extends foundry.appv1.sheets.ActorSheet {
     hbsData.system = this.actor.system;
 
     Misc.classifyInto(hbsData.items, this.actor.items);
+    hbsData.items.weapon = [
+      ...(hbsData.items.mechWeapon ?? []),
+      ...(hbsData.items.personalWeapon ?? []),
+    ];
     return hbsData;
   }
 
@@ -186,6 +190,11 @@ export class AnarchyActorSheet extends foundry.appv1.sheets.ActorSheet {
   }
 
   async createNewItem(itemType) {
+    if (itemType === 'weapon') {
+      itemType = this.actor.type === TEMPLATE.actorTypes.battlemech
+        ? TEMPLATE.itemType.mechWeapon
+        : TEMPLATE.itemType.personalWeapon;
+    }
     const name = game.i18n.format(ANARCHY.common.newName, { type: game.i18n.localize(ANARCHY.itemType.singular[itemType]) });
     await this.actor.createEmbeddedDocuments('Item', [{ name: name, type: itemType }], { renderSheet: true });
   }
@@ -196,7 +205,8 @@ export class AnarchyActorSheet extends foundry.appv1.sheets.ActorSheet {
       await this.actor.switchFavorite(newState, TEMPLATE.itemType.skill, options.skillId, options.specialization);
     }
     else if (options.weaponId) {
-      await this.actor.switchFavorite(newState, TEMPLATE.itemType.weapon, options.weaponId);
+      const weapon = this.actor.items.get(options.weaponId);
+      await this.actor.switchFavorite(newState, weapon?.type ?? TEMPLATE.itemType.personalWeapon, options.weaponId);
     }
     else if (options.attributeAction) {
       await this.actor.switchFavorite(newState, 'attributeAction', options.attributeAction);

--- a/src/modules/actor/battlemech-actor.js
+++ b/src/modules/actor/battlemech-actor.js
@@ -137,12 +137,12 @@ export class BattlemechActor extends VehicleActor {
   }
 
   _prepareWeaponGroups() {
-    const weapons = this.items.filter(it => it.type === TEMPLATE.itemType.weapon && it.isActive());
+    const weapons = this.items.filter(it => it.type === TEMPLATE.itemType.mechWeapon && it.isActive());
     if (weapons.length === 0) {
       return [];
     }
 
-    const favoriteWeapons = weapons.filter(it => this.hasFavorite(TEMPLATE.itemType.weapon, it.id));
+    const favoriteWeapons = weapons.filter(it => this.hasFavorite(TEMPLATE.itemType.mechWeapon, it.id));
     const groups = [];
     if (favoriteWeapons.length > 0) {
       groups.push({
@@ -173,7 +173,7 @@ export class BattlemechActor extends VehicleActor {
     }];
 
     const meleeWeapons = this.items.filter(it =>
-      it.type === TEMPLATE.itemType.weapon
+      it.type === TEMPLATE.itemType.mechWeapon
       && it.isActive()
       && it.system.skill === 'meleeCombat');
 

--- a/src/modules/anarchy-system.js
+++ b/src/modules/anarchy-system.js
@@ -23,10 +23,8 @@ import { VehicleSheet } from './actor/vehicle-sheet.js';
 import { BattlemechSheet } from './actor/battlemech-sheet.js';
 import { CharacterNPCSheet } from './actor/character-npc-sheet.js';
 import { SkillItem } from './item/skill-item.js';
-import { CyberdeckItem } from './item/cyberdeck-item.js';
 import { WeaponItem } from './item/weapon-item.js';
 import { ContactItemSheet } from './item/contact-item-sheet.js';
-import { CyberdeckItemSheet } from './item/cyberdeck-item-sheet.js';
 import { GearItemSheet } from './item/gear-item-sheet.js';
 import { QualityItemSheet } from './item/quality-item-sheet.js';
 import { ShadowampItemSheet } from './item/shadowamp-item-sheet.js';
@@ -76,12 +74,12 @@ export class AnarchySystem {
     }
     this.itemClasses = {
       contact: ContactItem,
-      cyberdeck: CyberdeckItem,
       gear: GearItem,
       quality: QualityItem,
       shadowamp: ShadowampItem,
       skill: SkillItem,
-      weapon: WeaponItem
+      mechWeapon: WeaponItem,
+      personalWeapon: WeaponItem
     }
 
     this.hooks = new HooksManager();
@@ -173,12 +171,11 @@ export class AnarchySystem {
     const { Items } = foundry.documents.collections;
     Items.unregisterSheet('core', foundry.appv1.sheets.ItemSheet);
     Items.registerSheet(SYSTEM_NAME, ContactItemSheet, { types: ["contact"], makeDefault: true });
-    Items.registerSheet(SYSTEM_NAME, CyberdeckItemSheet, { types: ["cyberdeck"], makeDefault: true });
     Items.registerSheet(SYSTEM_NAME, GearItemSheet, { types: ["gear"], makeDefault: true });
     Items.registerSheet(SYSTEM_NAME, QualityItemSheet, { types: ["quality"], makeDefault: true });
     Items.registerSheet(SYSTEM_NAME, ShadowampItemSheet, { types: ["shadowamp"], makeDefault: true });
     Items.registerSheet(SYSTEM_NAME, SkillItemSheet, { types: ["skill"], makeDefault: true });
-    Items.registerSheet(SYSTEM_NAME, WeaponItemSheet, { types: ["weapon"], makeDefault: true });
+    Items.registerSheet(SYSTEM_NAME, WeaponItemSheet, { types: ["mechWeapon", "personalWeapon"], makeDefault: true });
   }
 
 }

--- a/src/modules/config.js
+++ b/src/modules/config.js
@@ -8,12 +8,12 @@ export const ANARCHY = {
         },
         Item: {
             contact: "TYPES.Item.contact",
-            cyberdeck: "TYPES.Item.cyberdeck",
             gear: "TYPES.Item.gear",
             quality: "TYPES.Item.quality",
             shadowamp: "TYPES.Item.shadowamp",
             skill: "TYPES.Item.skill",
-            weapon: "TYPES.Item.weapon"
+            mechWeapon: "TYPES.Item.mechWeapon",
+            personalWeapon: "TYPES.Item.personalWeapon"
         }
     },
     settings: {
@@ -258,26 +258,28 @@ export const ANARCHY = {
             level: 'ANARCHY.item.shadowamp.level',
             levelShort: 'ANARCHY.item.shadowamp.levelShort',
         },
-        weapon: {
-            skill: 'ANARCHY.item.weapon.skill',
-            damage: 'ANARCHY.item.weapon.damage',
-            strength: 'ANARCHY.item.weapon.strength',
-            defense: 'ANARCHY.item.weapon.defense',
-            area: 'ANARCHY.item.weapon.area',
-            noArmor: 'ANARCHY.item.weapon.noArmor',
-            withArmor: 'ANARCHY.item.weapon.withArmor',
-            damageShort: 'ANARCHY.item.weapon.damageShort',
-            areaShort: 'ANARCHY.item.weapon.areaShort',
-            noArmorShort: 'ANARCHY.item.weapon.noArmorShort',
-            weaponWithoutActor: 'ANARCHY.item.weapon.weaponWithoutActor',
+        mechWeapon: {
+            damage: 'ANARCHY.item.mechWeapon.damage',
+            heat: 'ANARCHY.item.mechWeapon.heat',
+            area: 'ANARCHY.item.mechWeapon.area',
             range: {
-                max: 'ANARCHY.item.weapon.range.max'
+                max: 'ANARCHY.item.mechWeapon.range.max'
             }
         },
-        cyberdeck: {
-            programs: 'ANARCHY.item.cyberdeck.programs',
-            processing: 'ANARCHY.item.cyberdeck.processing',
-            processingHelp: 'ANARCHY.item.cyberdeck.processingHelp',
+        personalWeapon: {
+            skill: 'ANARCHY.item.personalWeapon.skill',
+            weaponCategory: 'ANARCHY.item.personalWeapon.category',
+            damageCategory: 'ANARCHY.item.personalWeapon.damageCategory',
+            damage: 'ANARCHY.item.personalWeapon.damage',
+            defense: 'ANARCHY.item.personalWeapon.defense',
+            area: 'ANARCHY.item.personalWeapon.area',
+            armorAvoidance: 'ANARCHY.item.personalWeapon.armorAvoidance',
+            damageShort: 'ANARCHY.item.personalWeapon.damageShort',
+            areaShort: 'ANARCHY.item.personalWeapon.areaShort',
+            weaponWithoutActor: 'ANARCHY.item.personalWeapon.weaponWithoutActor',
+            range: {
+                max: 'ANARCHY.item.personalWeapon.range.max'
+            }
         }
     },
     itemType: {
@@ -285,18 +287,18 @@ export const ANARCHY = {
             skill: 'ANARCHY.itemType.singular.skill',
             quality: 'ANARCHY.itemType.singular.quality',
             shadowamp: 'ANARCHY.itemType.singular.shadowamp',
-            weapon: 'ANARCHY.itemType.singular.weapon',
+            mechWeapon: 'ANARCHY.itemType.singular.mechWeapon',
+            personalWeapon: 'ANARCHY.itemType.singular.personalWeapon',
             gear: 'ANARCHY.itemType.singular.gear',
-            cyberdeck: 'ANARCHY.itemType.singular.cyberdeck',
             contact: 'ANARCHY.itemType.singular.contact'
         },
         plural: {
             skill: 'ANARCHY.itemType.plural.skill',
             quality: 'ANARCHY.itemType.plural.quality',
             shadowamp: 'ANARCHY.itemType.plural.shadowamp',
-            weapon: 'ANARCHY.itemType.plural.weapon',
+            mechWeapon: 'ANARCHY.itemType.plural.mechWeapon',
+            personalWeapon: 'ANARCHY.itemType.plural.personalWeapon',
             gear: 'ANARCHY.itemType.plural.gear',
-            cyberdeck: 'ANARCHY.itemType.plural.cyberdeck',
             contact: 'ANARCHY.itemType.plural.contact'
         }
     },
@@ -425,10 +427,11 @@ export const ANARCHY = {
             assault: 'ANARCHY.mwd.weightClass.assault',
         },
         hardpointType: {
-            energy: 'ANARCHY.mwd.hardpoint.type.energy',
             ballistic: 'ANARCHY.mwd.hardpoint.type.ballistic',
+            energy: 'ANARCHY.mwd.hardpoint.type.energy',
             missile: 'ANARCHY.mwd.hardpoint.type.missile',
-            support: 'ANARCHY.mwd.hardpoint.type.support',
+            special: 'ANARCHY.mwd.hardpoint.type.special',
+            melee: 'ANARCHY.mwd.hardpoint.type.melee',
         },
         hardpointSize: {
             small: 'ANARCHY.mwd.hardpoint.size.small',
@@ -448,6 +451,25 @@ export const ANARCHY = {
         weaponCategory: {
             ranged: 'ANARCHY.mwd.weaponCategory.ranged',
             melee: 'ANARCHY.mwd.weaponCategory.melee',
+        },
+        weaponDamageType: {
+            energy: 'ANARCHY.mwd.weapon.damageType.energy',
+            kinetic: 'ANARCHY.mwd.weapon.damageType.kinetic',
+            explosive: 'ANARCHY.mwd.weapon.damageType.explosive',
+            plasma: 'ANARCHY.mwd.weapon.damageType.plasma',
+            none: 'ANARCHY.mwd.weapon.damageType.none'
+        },
+        personalDamageType: {
+            energy: 'ANARCHY.personal.weapon.damageType.energy',
+            kinetic: 'ANARCHY.personal.weapon.damageType.kinetic',
+            explosive: 'ANARCHY.personal.weapon.damageType.explosive',
+            plasma: 'ANARCHY.personal.weapon.damageType.plasma',
+            corrosive: 'ANARCHY.personal.weapon.damageType.corrosive',
+            poison: 'ANARCHY.personal.weapon.damageType.poison'
+        },
+        personalDamageCategory: {
+            physical: 'ANARCHY.personal.weapon.damageCategory.physical',
+            fatigue: 'ANARCHY.personal.weapon.damageCategory.fatigue'
         },
         meleeLocation: {
             head: 'ANARCHY.mwd.melee.location.head',

--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -33,9 +33,9 @@ export const TEMPLATE = {
     skill: 'skill',
     quality: 'quality',
     shadowamp: 'shadowamp',
-    weapon: 'weapon',
+    mechWeapon: 'mechWeapon',
+    personalWeapon: 'personalWeapon',
     gear: 'gear',
-    cyberdeck: 'cyberdeck',
     contact: 'contact',
   },
   attributes: {

--- a/src/modules/enums.js
+++ b/src/modules/enums.js
@@ -23,6 +23,9 @@ export class Enums {
   static hbsMwdHardpointLocations;
   static hbsMwdPrimaryModes;
   static hbsMwdWeaponCategories;
+  static hbsMwdWeaponDamageTypes;
+  static hbsPersonalWeaponDamageTypes;
+  static hbsPersonalWeaponDamageCategories;
   static hbsMwdMeleeLocations;
 
   static sortedAttributeKeys;
@@ -45,6 +48,9 @@ export class Enums {
     Enums.hbsMwdHardpointLocations = Enums.mapObjetToKeyValue(ANARCHY.mwd.hardpointLocation);
     Enums.hbsMwdPrimaryModes = Enums.mapObjetToKeyValue(ANARCHY.mwd.primarySlotMode);
     Enums.hbsMwdWeaponCategories = Enums.mapObjetToKeyValue(ANARCHY.mwd.weaponCategory);
+    Enums.hbsMwdWeaponDamageTypes = Enums.mapObjetToKeyValue(ANARCHY.mwd.weaponDamageType);
+    Enums.hbsPersonalWeaponDamageTypes = Enums.mapObjetToKeyValue(ANARCHY.mwd.personalDamageType);
+    Enums.hbsPersonalWeaponDamageCategories = Enums.mapObjetToKeyValue(ANARCHY.mwd.personalDamageCategory);
     Enums.hbsMwdMeleeLocations = Enums.mapObjetToKeyValue(ANARCHY.mwd.meleeLocation);
 
     Enums.sortedAttributeKeys = Object.keys(ANARCHY.attributes);
@@ -74,6 +80,9 @@ export class Enums {
       mwdHardpointLocations: Enums.hbsMwdHardpointLocations,
       mwdPrimaryModes: Enums.hbsMwdPrimaryModes,
       mwdWeaponCategories: Enums.hbsMwdWeaponCategories,
+      mwdWeaponDamageTypes: Enums.hbsMwdWeaponDamageTypes,
+      personalWeaponDamageTypes: Enums.hbsPersonalWeaponDamageTypes,
+      personalWeaponDamageCategories: Enums.hbsPersonalWeaponDamageCategories,
       mwdMeleeLocations: Enums.hbsMwdMeleeLocations,
     };
   }

--- a/src/modules/error-manager.js
+++ b/src/modules/error-manager.js
@@ -57,7 +57,7 @@ export class ErrorManager {
 
   static checkWeaponDefense(weapon, actor) {
     const defense = weapon.getDefense();
-    if (!defense) {
+    if (weapon.type === TEMPLATE.itemType.personalWeapon && !defense) {
       const error = game.i18n.format(ANARCHY.common.errors.noDefenseOnWeapon, { actor: actor.name, weapon: weapon.name });
       ui.notifications.error(error);
       throw error;

--- a/src/modules/item/anarchy-base-item.js
+++ b/src/modules/item/anarchy-base-item.js
@@ -55,8 +55,8 @@ export class AnarchyBaseItem extends Item {
     return await this.update({ [checkbarPath]: value })
   }
 
-  isCyberdeck() { return this.type == TEMPLATE.itemType.cyberdeck; }
-  isWeapon() { return this.type == TEMPLATE.itemType.weapon; }
+  isCyberdeck() { return false; }
+  isWeapon() { return this.type == TEMPLATE.itemType.mechWeapon || this.type == TEMPLATE.itemType.personalWeapon; }
 
   isActive() { return !this.system.inactive; }
 

--- a/src/modules/item/weapon-item.js
+++ b/src/modules/item/weapon-item.js
@@ -109,6 +109,9 @@ export class WeaponItem extends AnarchyBaseItem {
   }
 
   getDefense() {
+    if (this.type !== TEMPLATE.itemType.personalWeapon) {
+      return this.system.defense ? AttributeActions.fixedDefenseCode(this.system.defense) : undefined;
+    }
     return AttributeActions.fixedDefenseCode(this.system.defense);
   }
 
@@ -116,19 +119,20 @@ export class WeaponItem extends AnarchyBaseItem {
     if (!this.parent) {
       return undefined;
     }
+    const monitor = this._getMonitor();
     const damageAttributeValue = this.system.damageAttribute
       ? (this.parent.getAttributeValue(this.system.damageAttribute) ?? 0)
       : 0;
     return {
       value: WeaponItem.damageValue(
-        this.system.monitor,
+        monitor,
         this.system.damage,
         this.system.damageAttribute,
         damageAttributeValue
       ),
-      monitor: this.system.monitor,
-      noArmor: this.system.noArmor,
-      armorMode: WeaponItem.armorMode(this.system.monitor, this.system.noArmor)
+      monitor: monitor,
+      noArmor: this.system.noArmor ?? this.system.armorAvoidance,
+      armorMode: WeaponItem.armorMode(monitor, this.system.noArmor ?? this.system.armorAvoidance)
     }
   }
 
@@ -140,7 +144,7 @@ export class WeaponItem extends AnarchyBaseItem {
       }
       else {
         console.warn('Weapon not attached to an actor');
-        return game.i18n.localize(ANARCHY.item.weapon.weaponWithoutActor);
+        return game.i18n.localize(ANARCHY.item.personalWeapon.weaponWithoutActor);
       }
     }
     return damage;
@@ -148,7 +152,7 @@ export class WeaponItem extends AnarchyBaseItem {
 
   getDamageCode() {
     return WeaponItem.damageCode(
-      this.system.monitor,
+      this._getMonitor(),
       this.system.damage,
       this.system.damageAttribute,
     );
@@ -254,5 +258,14 @@ export class WeaponItem extends AnarchyBaseItem {
       return TEMPLATE.area.none;
     }
     return this.system.area ?? TEMPLATE.area.none;
+  }
+
+  _getMonitor() {
+    if (this.type === TEMPLATE.itemType.personalWeapon) {
+      return this.system.damageCategory === 'fatigue'
+        ? TEMPLATE.monitors.fatigue
+        : TEMPLATE.monitors.physical;
+    }
+    return this.system.monitor || TEMPLATE.monitors.physical;
   }
 }

--- a/src/modules/migrations.js
+++ b/src/modules/migrations.js
@@ -62,7 +62,7 @@ class _0_3_8_MigrateWeaponDamage extends Migration {
 
   async migrate() {
 
-    const isStrengthDamageItem = it => it.type == TEMPLATE.itemType.weapon && it.system.strength;
+    const isStrengthDamageItem = it => it.isWeapon?.() && it.system.strength;
     const fixItemDamage = it => {
       return {
         _id: it.id,
@@ -294,7 +294,7 @@ class _12_0_4_MigrateWeaponDrain extends Migration {
   get version() { return '12.0.2' }
   get code() { return 'migrate-weapon-drain' }
   async migrate() {
-    this.applyItemsUpdates(items => items.filter(it => it.type = TEMPLATE.itemType.weapon)
+    this.applyItemsUpdates(items => items.filter(it => it.isWeapon?.())
       .filter(it => it.hasDrain)
       .map(it => {
         return {
@@ -457,7 +457,7 @@ class _13_2_3_AddBattlemechLoadout extends Migration {
       }
     }
 
-    const worldWeapons = game.items.filter(it => it.type === TEMPLATE.itemType.weapon);
+    const worldWeapons = game.items.filter(it => it.isWeapon?.());
     for (const weapon of worldWeapons) {
       const updates = this._collectWeaponUpdates(weapon);
       if (Object.keys(updates).length > 0) {
@@ -467,7 +467,7 @@ class _13_2_3_AddBattlemechLoadout extends Migration {
 
     for (const actor of game.actors) {
       const updates = actor.items
-        .filter(it => it.type === TEMPLATE.itemType.weapon)
+        .filter(it => it.isWeapon?.())
         .map(it => ({ _id: it.id, ...this._collectWeaponUpdates(it) }))
         .filter(update => Object.keys(update).length > 1);
       if (updates.length > 0) {

--- a/src/modules/modifiers/modifiers.js
+++ b/src/modules/modifiers/modifiers.js
@@ -4,7 +4,11 @@ import { TEMPLATE } from "../constants.js";
 import { Enums } from "../enums.js";
 import { Misc } from "../misc.js";
 
-const SHADOWAMP_TYPES = [TEMPLATE.itemType.shadowamp, TEMPLATE.itemType.weapon, TEMPLATE.itemType.cyberdeck];
+const SHADOWAMP_TYPES = [
+  TEMPLATE.itemType.shadowamp,
+  TEMPLATE.itemType.mechWeapon,
+  TEMPLATE.itemType.personalWeapon,
+];
 /**
  * Modifier: {group, effect, category, subCategory, value, condition, id}
  */

--- a/src/modules/roll/roll-parameters.js
+++ b/src/modules/roll/roll-parameters.js
@@ -496,7 +496,7 @@ export class RollParameters {
   }
 
   static computeRollModifiers(effect, context) {
-    const itemsFilter = it => it.type != TEMPLATE.itemType.weapon || (context.weapon && it.id == context.weapon.id)
+    const itemsFilter = it => !it.isWeapon?.() || (context.weapon && it.id == context.weapon.id)
     const items = context.actor.items.filter(itemsFilter)
     return Modifiers.computeRollModifiers(items, context, effect);
   }

--- a/template.json
+++ b/template.json
@@ -369,12 +369,12 @@
   "Item": {
     "types": [
       "contact",
-      "cyberdeck",
       "gear",
       "quality",
       "shadowamp",
       "skill",
-      "weapon"
+      "mechWeapon",
+      "personalWeapon"
     ],
     "templates": {
       "modifiers": {
@@ -421,22 +421,16 @@
       "capacity": "mundane",
       "level": 1
     },
-      "weapon": {
-        "templates": ["modifiers", "inactive", "references"],
-        "weaponCategory": "ranged",
-        "hardpointType": "energy",
-        "hardpointSize": "small",
-        "mountLocation": "",
-        "skill": "",
-        "specialization": "",
-        "strength": true,
+    "mechWeapon": {
+      "templates": ["modifiers", "inactive", "references"],
+      "weaponCategory": "ranged",
+      "hardpointType": "energy",
+      "hardpointSize": "small",
+      "mountLocation": "",
       "damage": 0,
-      "damageAttribute": "",
-      "noArmor": false,
-      "monitor": "fatigue",
-      "defense": "",
-      "area": "",
-      "drain": 0,
+      "damageType": "kinetic",
+      "heat": 0,
+      "area": "none",
       "range": {
         "max": "contact",
         "contact": 0,
@@ -446,25 +440,25 @@
         "extreme": 0
       }
     },
-    "cyberdeck": {
+    "personalWeapon": {
       "templates": ["modifiers", "inactive", "references"],
-      "attributes": {
-        "firewall": {
-          "value": 1
-        }
-      },
-      "monitors": {
-        "matrix": {
-          "canMark": true,
-          "marks": [],
-          "value": 0,
-          "max": 6,
-          "resistance": 0
-        }
-      },
-      "programs": 1,
-      "processing": 1,
-      "connectionMode": "disconnected"
+      "skill": "",
+      "weaponCategory": "ranged",
+      "damageCategory": "physical",
+      "damage": 0,
+      "damageAttribute": "",
+      "damageType": "kinetic",
+      "defense": "physicalDefense",
+      "armorAvoidance": false,
+      "area": "none",
+      "range": {
+        "max": "contact",
+        "contact": 0,
+        "short": 0,
+        "medium": 0,
+        "far": 0,
+        "extreme": 0
+      }
     },
     "gear": {
       "templates": [

--- a/templates/actor/character-enhanced/damage-armor.hbs
+++ b/templates/actor/character-enhanced/damage-armor.hbs
@@ -1,5 +1,5 @@
 {{#if (eq armor 'avoidArmor')}}
-    <span data-tooltip="{{localize 'ANARCHY.item.weapon.noArmor'}}">{{{iconFA 'fas fa-user-times'}}}</span>
+    <span data-tooltip="{{localize 'ANARCHY.item.personalWeapon.noArmor'}}">{{{iconFA 'fas fa-user-times'}}}</span>
 {{else if (eq armor 'withArmor')}}
-    <span data-tooltip="{{localize 'ANARCHY.item.weapon.withArmor'}}">{{{iconFA 'fas fa-user-shield'}}}</span>
+    <span data-tooltip="{{localize 'ANARCHY.item.personalWeapon.withArmor'}}">{{{iconFA 'fas fa-user-shield'}}}</span>
 {{/if}}

--- a/templates/actor/character-enhanced/weapon.hbs
+++ b/templates/actor/character-enhanced/weapon.hbs
@@ -33,17 +33,17 @@
           this)
           damage=system.damage
           monitor=system.monitor
-          armor=(weaponArmorMode system.monitor system.noArmor)
+          armor=(weaponArmorMode system.monitor system.armorAvoidance)
           }}
           </span>
           {{!-- <div>
             {{localize (concat 'ANARCHY.area.' (either system.area 'none'))}}
           </div> --}}
-          {{#if hasDrain}}
+          {{#if (eq type 'mechWeapon')}}
           <spam class="weapon-drain">
-            {{localize 'ANARCHY.item.weapon.drain'}}:
+            {{localize 'ANARCHY.item.mechWeapon.heat'}}:
           </spam>
-          {{system.drain}}
+          {{system.heat}}
           {{/if}}
         </div>
         <div class="weapon-range">

--- a/templates/actor/character-enhanced/weapons.hbs
+++ b/templates/actor/character-enhanced/weapons.hbs
@@ -1,6 +1,6 @@
 <div class="define-item-type" data-item-type="weapon">
   <h2 class="title">
-    {{localize 'ANARCHY.itemType.plural.weapon'}}
+    {{localize 'ANARCHY.itemType.plural.personalWeapon'}}
     {{> 'systems/mwd/templates/common/item-control-add.hbs' itemType='weapon'}}
   </h2>
   <div class="weapon-list">

--- a/templates/actor/npc-parts/weapon.hbs
+++ b/templates/actor/npc-parts/weapon.hbs
@@ -1,5 +1,5 @@
 <li class="item anarchy-weapon {{#if system.inactive}}inactive{{/if}}" draggable="true"
-    data-item-id="{{_id}}" data-item-type="weapon">
+    data-item-id="{{_id}}" data-item-type="{{type}}">
   <div class="weapon-column weapon-summary">
     <a class="click-weapon-roll">
       {{name}},
@@ -8,10 +8,10 @@
         actorAttribute=(actorAttribute system.damageAttribute @root.actor this)
         damage=system.damage
         monitor=system.monitor
-        armor=(weaponArmorMode system.monitor system.noArmor)
+        armor=(weaponArmorMode system.monitor system.armorAvoidance)
       }},
       {{> 'systems/mwd/templates/actor/parts/weapon-range.hbs'}}
-      {{#if hasDrain}}, {{localize 'ANARCHY.item.weapon.drain'}}: {{system.drain}}{{/if}}
+      {{#if (eq type 'mechWeapon')}}, {{localize 'ANARCHY.item.mechWeapon.heat'}}: {{system.heat}}{{/if}}
     </a>
   </div>
   <div class="item-controls weapon-column weapon-controls">

--- a/templates/actor/npc-parts/weapons.hbs
+++ b/templates/actor/npc-parts/weapons.hbs
@@ -1,6 +1,6 @@
 <div class="define-item-type" data-item-type="weapon">
   <h2 class="section-group-header">
-    {{localize 'ANARCHY.itemType.plural.weapon'}}
+    {{localize 'ANARCHY.itemType.plural.personalWeapon'}}
     {{> 'systems/mwd/templates/common/item-control-add.hbs' itemType='weapon'}}
   </h2>
   <ul class="weapon-list">

--- a/templates/actor/parts/weapon.hbs
+++ b/templates/actor/parts/weapon.hbs
@@ -15,7 +15,7 @@
       actorAttribute=(actorAttribute system.damageAttribute @root.actor this)
       damage=system.damage
       monitor=system.monitor
-      armor=(weaponArmorMode system.monitor system.noArmor)
+      armor=(weaponArmorMode system.monitor system.armorAvoidance)
     }}
   </div>
   <div class="weapon-column weapon-stat">

--- a/templates/actor/parts/weapons.hbs
+++ b/templates/actor/parts/weapons.hbs
@@ -1,20 +1,19 @@
 <div class="define-item-type" data-item-type="weapon">
   <h2 class="section-group-header">
-    {{localize 'ANARCHY.itemType.plural.weapon'}}
+    {{localize 'ANARCHY.itemType.plural.personalWeapon'}}
     {{> 'systems/mwd/templates/common/item-control-add.hbs' itemType='weapon'}}
   </h2>
   <ul class="weapon-list">
     <div class="weapon-header">
       <span class="weapon-column weapon-img"></span>
-      <span class="weapon-column weapon-txt">{{localize 'ANARCHY.itemType.singular.weapon'}}</span>
-      <span class="weapon-column weapon-dmg">{{localize 'ANARCHY.item.weapon.damageShort'}}</span>
-      <span class="weapon-column weapon-stat">{{localize 'ANARCHY.item.weapon.areaShort'}}</span>
+      <span class="weapon-column weapon-txt">{{localize 'ANARCHY.itemType.singular.personalWeapon'}}</span>
+      <span class="weapon-column weapon-dmg">{{localize 'ANARCHY.item.personalWeapon.damageShort'}}</span>
+      <span class="weapon-column weapon-stat">{{localize 'ANARCHY.item.personalWeapon.areaShort'}}</span>
       <span class="weapon-column weapon-stat">{{localize 'ANARCHY.range.contact'}}</span>
       <span class="weapon-column weapon-stat">{{localize 'ANARCHY.range.short'}}</span>
       <span class="weapon-column weapon-stat">{{localize 'ANARCHY.range.medium'}}</span>
       <span class="weapon-column weapon-stat">{{localize 'ANARCHY.range.far'}}</span>
       <span class="weapon-column weapon-stat">{{localize 'ANARCHY.range.extreme'}}</span>
-      <span class="weapon-column weapon-stat">{{localize 'ANARCHY.item.weapon.drain'}}</span>
       <span class="weapon-column weapon-controls">{{{iconFA 'fas fa-pen hide-fontawesome'}}}</span>
     </div>
 

--- a/templates/chat/parts/result-mode-weapon.hbs
+++ b/templates/chat/parts/result-mode-weapon.hbs
@@ -1,9 +1,9 @@
 <br>
-{{localize 'ANARCHY.item.weapon.damage'}}
+{{localize 'ANARCHY.item.personalWeapon.damage'}}
 {{> 'systems/mwd/templates/common/damage-code.hbs'
     damageAttribute=weapon.system.damageAttribute
     actorAttribute=(actorAttribute weapon.system.damageAttribute actor)
     damage=weapon.system.damage
     monitor=weapon.system.monitor
-    armor=(weaponArmorMode weapon.system.monitor weapon.system.noArmor)
+    armor=(weaponArmorMode weapon.system.monitor weapon.system.armorAvoidance)
 }}

--- a/templates/common/damage-armor.hbs
+++ b/templates/common/damage-armor.hbs
@@ -1,5 +1,5 @@
 {{#if (eq armor 'avoidArmor')}}
-<span data-tooltip="{{localize 'ANARCHY.item.weapon.noArmor'}}">{{{iconFA 'fas fa-user-times'}}}</span>
+<span data-tooltip="{{localize 'ANARCHY.item.personalWeapon.noArmor'}}">{{{iconFA 'fas fa-user-times'}}}</span>
 {{else if (eq armor 'withArmor')}}
-<span data-tooltip="{{localize 'ANARCHY.item.weapon.withArmor'}}">{{{iconFA 'fas fa-user-shield'}}}</span>
+<span data-tooltip="{{localize 'ANARCHY.item.personalWeapon.withArmor'}}">{{{iconFA 'fas fa-user-shield'}}}</span>
 {{/if}}

--- a/templates/item/weapon.hbs
+++ b/templates/item/weapon.hbs
@@ -2,8 +2,8 @@
   <header class="sheet-header">
     <img class="anarchy-img profile-img" src="{{data.img}}" data-edit="img" data-tooltip="{{data.name}}"/>
     {{> 'systems/mwd/templates/item/parts/itemname.hbs'
-      labelkey='ANARCHY.itemType.singular.weapon'
-      type="weapon"
+      labelkey=(concat 'ANARCHY.itemType.singular.' type)
+      type=type
     }}
   </header>
 
@@ -19,94 +19,111 @@
 
   <section class="sheet-body">
     <div class="tab section-group" data-group="primary" data-tab="main">
-      <div class="form-group">
-        <label for="system.skill">{{localize 'ANARCHY.item.weapon.skill'}} </label>
-        <select class="select-weapon-skill" name="system.skill" data-dtype="String">
+      {{#if (eq type 'mechWeapon')}}
+        <div class="form-group">
+          <label for="system.weaponCategory">{{localize 'ANARCHY.item.mechWeapon.category'}}</label>
+          <select name="system.weaponCategory">
+            {{#select system.weaponCategory}}
+              {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.mwdWeaponCategories}}
+            {{/select}}
+          </select>
+        </div>
+        <div class="form-group">
+          <label>{{localize 'ANARCHY.item.mechWeapon.hardpoint'}}</label>
+          <div class="flexrow">
+            <select name="system.hardpointType">
+              {{#select system.hardpointType}}
+                {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.mwdHardpointTypes}}
+              {{/select}}
+            </select>
+            <select name="system.hardpointSize">
+              {{#select system.hardpointSize}}
+                {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.mwdHardpointSizes}}
+              {{/select}}
+            </select>
+          </div>
+        </div>
+        <div class="form-group">
+          <label for="system.damage">{{localize 'ANARCHY.item.mechWeapon.damage'}}</label>
+          <input class="type-numeric" type="number" data-dtype="Number" name="system.damage" value="{{system.damage}}" />
+        </div>
+        <div class="form-group">
+          <label for="system.damageType">{{localize 'ANARCHY.item.mechWeapon.damageType'}}</label>
+          <select name="system.damageType">
+            {{#select system.damageType}}
+              {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.mwdWeaponDamageTypes}}
+            {{/select}}
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="system.heat">{{localize 'ANARCHY.item.mechWeapon.heat'}}</label>
+          <input class="type-numeric" type="number" data-dtype="Number" name="system.heat" value="{{system.heat}}" />
+        </div>
+      {{else}}
+        <div class="form-group">
+          <label for="system.skill">{{localize 'ANARCHY.item.personalWeapon.skill'}} </label>
+          <select class="select-weapon-skill" name="system.skill" data-dtype="String">
             {{#select system.skill}}
             {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.skills}}
             {{/select}}
-        </select>
-      </div>
-      <div class="form-group">
-        <label for="system.weaponCategory">{{localize 'ANARCHY.item.weapon.category'}}</label>
-        <select name="system.weaponCategory">
-          {{#select system.weaponCategory}}
-            {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.mwdWeaponCategories}}
-          {{/select}}
-        </select>
-      </div>
-      <div class="form-group">
-        <label>{{localize 'ANARCHY.item.weapon.hardpoint'}}</label>
-        <div class="flexrow">
-          <select name="system.hardpointType">
-            {{#select system.hardpointType}}
-              {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.mwdHardpointTypes}}
-            {{/select}}
           </select>
-          <select name="system.hardpointSize">
-            {{#select system.hardpointSize}}
-              {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.mwdHardpointSizes}}
+        </div>
+        <div class="form-group">
+          <label for="system.weaponCategory">{{localize 'ANARCHY.item.personalWeapon.category'}}</label>
+          <select name="system.weaponCategory">
+            {{#select system.weaponCategory}}
+              {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.mwdWeaponCategories}}
             {{/select}}
           </select>
         </div>
-      </div>
-      <div class="form-group">
-        <label>{{localize 'ANARCHY.item.weapon.mountLocation'}}</label>
-        <select name="system.mountLocation">
-          {{#select system.mountLocation}}
-            <option value="">{{localize 'ANARCHY.mwd.melee.locationAny'}}</option>
-            {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.mwdMeleeLocations}}
-          {{/select}}
-        </select>
-      </div>
-      {{#if hasDrain}}
-      <div class="form-group">
-        <label for="system.drain">{{localize 'ANARCHY.item.weapon.drain'}} </label>
-          <input class="type-numeric" type="number" data-dtype="Number"
-            name="system.drain" value="{{system.drain}}"
-          />
-      </div>
-      {{/if}}
-      <div class="form-group">
-        <label for="system.damage">
-          {{localize 'ANARCHY.item.weapon.damage'}}
-        </label>
-        <div class="flexrow flex-wrap">
-          <input class="type-numeric" type="number" data-dtype="Number"
-            name="system.damage" value="{{system.damage}}"
-          />
-          <span>+
-          <select name="system.damageAttribute" data-dtype="String">
-              {{#select system.damageAttribute}}
-              {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.attributes}}
-              {{/select}}
-          </select>
-          /2</span>
-        </div>
-      </div>
-      <div class="form-group">
-        <label>
-          {{> 'systems/mwd/templates/common/damage-code.hbs'
-              strength=system.strength
-              damage=system.damage
-              monitor=system.monitor
-              armor=(weaponArmorMode system.monitor system.noArmor)
-          }}
-        </label>
-        <div>
-          <select name="system.monitor" data-dtype="String">
-            {{#select system.monitor}}
-            {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.monitors}}
+        <div class="form-group">
+          <label for="system.damageCategory">{{localize 'ANARCHY.item.personalWeapon.damageCategory'}}</label>
+          <select name="system.damageCategory">
+            {{#select system.damageCategory}}
+              {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.personalWeaponDamageCategories}}
             {{/select}}
           </select>
-
-          <input class="item-field-value" name="system.noArmor" type="checkbox" {{checked system.noArmor}}>
-            <label>{{localize 'ANARCHY.item.weapon.noArmor'}}</label>
+        </div>
+        <div class="form-group">
+          <label for="system.damage">{{localize 'ANARCHY.item.personalWeapon.damage'}}</label>
+          <div class="flexrow flex-wrap">
+            <input class="type-numeric" type="number" data-dtype="Number" name="system.damage" value="{{system.damage}}" />
+            {{#if (eq system.weaponCategory 'melee')}}
+              <span>+
+              <select name="system.damageAttribute" data-dtype="String">
+                  {{#select system.damageAttribute}}
+                  {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.attributes}}
+                  {{/select}}
+              </select>
+              /2</span>
+            {{/if}}
+          </div>
+        </div>
+        <div class="form-group">
+          <label for="system.damageType">{{localize 'ANARCHY.item.personalWeapon.damageType'}}</label>
+          <select name="system.damageType">
+            {{#select system.damageType}}
+              {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.personalWeaponDamageTypes}}
+            {{/select}}
+          </select>
+        </div>
+        <div class="form-group">
+            <label for="system.defense" >{{localize 'ANARCHY.item.personalWeapon.defense'}} </label>
+            <select name="system.defense">
+              {{selectOptions ENUMS.defenses selected=(fixedDefenseCode system.defense)
+              nameAttr="code" labelAttr="labelkey" localize=true blank=''}}
+            </select>
+        </div>
+        <div class="form-group">
+          <label>{{localize 'ANARCHY.item.personalWeapon.armorAvoidance'}}</label>
+          <input class="item-field-value" name="system.armorAvoidance" type="checkbox" {{checked system.armorAvoidance}}>
+            <label>{{localize 'ANARCHY.item.personalWeapon.armorAvoidanceHelp'}}
+          </label>
           </input>
         </div>
-      </div>
+      {{/if}}
       <div class="form-group">
-        <label for="system.area" >{{localize 'ANARCHY.item.weapon.area'}} </label>
+        <label for="system.area" >{{localize (concat 'ANARCHY.item.' type '.area')}} </label>
         <select name="system.area" data-dtype="String">
           {{#select system.area}}
           {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.areas}}
@@ -114,14 +131,7 @@
         </select>
       </div>
       <div class="form-group">
-          <label for="system.defense" >{{localize 'ANARCHY.item.weapon.defense'}} </label>
-          <select name="system.defense">
-            {{selectOptions ENUMS.defenses selected=(fixedDefenseCode system.defense)
-            nameAttr="code" labelAttr="labelkey" localize=true blank=''}}
-          </select>
-      </div>
-      <div class="form-group">
-          <label for="system.range.max" >{{localize 'ANARCHY.item.weapon.range.max'}} </label>
+          <label for="system.range.max" >{{localize (concat 'ANARCHY.item.' type '.range.max')}} </label>
           <select name="system.range.max">
             {{#select system.range.max}}
             {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.ranges}}


### PR DESCRIPTION
## Summary
- add new mech-scale and personal weapon item types with updated schemas and UI fields
- adjust weapon logic, enums, and translations for new damage, range, and hardpoint options while retiring the old cyberdeck/weapon types
- refresh weapon-related templates to display new attributes and armor handling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cb199571c832db5f66985cba43e3e)