### PR TITLE
Add skills compendium

### DIFF
--- a/src/packs/skills/items_Acting_d08fb8e380b285e6.yml
+++ b/src/packs/skills/items_Acting_d08fb8e380b285e6.yml
@@ -1,0 +1,28 @@
+{
+  "_id": "d08fb8e380b285e6",
+  "name": "Acting",
+  "type": "skill",
+  "img": "systems/mwd/icons/skills/con-art.svg",
+  "effects": [],
+  "folder": null,
+  "sort": 2500000,
+  "flags": {},
+  "system": {
+    "inactive": false,
+    "sourceReference": "",
+    "description": "",
+    "gmnotes": "",
+    "code": "acting",
+    "attribute": "charisma",
+    "value": 0,
+    "specialization": "",
+    "hasDrain": false,
+    "hasConvergence": false,
+    "isSocial": true,
+    "listspecialization": []
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!items!d08fb8e380b285e6"
+}

--- a/src/packs/skills/items_Animal_Handling_8886ef216e5de449.yml
+++ b/src/packs/skills/items_Animal_Handling_8886ef216e5de449.yml
@@ -1,0 +1,28 @@
+{
+  "_id": "8886ef216e5de449",
+  "name": "Animal Handling",
+  "type": "skill",
+  "img": "systems/mwd/icons/skills/animals.svg",
+  "effects": [],
+  "folder": null,
+  "sort": 2300000,
+  "flags": {},
+  "system": {
+    "inactive": false,
+    "sourceReference": "",
+    "description": "",
+    "gmnotes": "",
+    "code": "animalHandling",
+    "attribute": "willpower",
+    "value": 0,
+    "specialization": "",
+    "hasDrain": false,
+    "hasConvergence": false,
+    "isSocial": false,
+    "listspecialization": []
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!items!8886ef216e5de449"
+}

--- a/src/packs/skills/items_Art_b399367a8d40d87b.yml
+++ b/src/packs/skills/items_Art_b399367a8d40d87b.yml
@@ -1,0 +1,28 @@
+{
+  "_id": "b399367a8d40d87b",
+  "name": "Art",
+  "type": "skill",
+  "img": "systems/mwd/icons/skills/art.svg",
+  "effects": [],
+  "folder": null,
+  "sort": 1000000,
+  "flags": {},
+  "system": {
+    "inactive": false,
+    "sourceReference": "",
+    "description": "",
+    "gmnotes": "",
+    "code": "art",
+    "attribute": "logic",
+    "value": 0,
+    "specialization": "",
+    "hasDrain": false,
+    "hasConvergence": false,
+    "isSocial": false,
+    "listspecialization": []
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!items!b399367a8d40d87b"
+}

--- a/src/packs/skills/items_Artillery_2dcbfd05b8e8a725.yml
+++ b/src/packs/skills/items_Artillery_2dcbfd05b8e8a725.yml
@@ -1,0 +1,28 @@
+{
+  "_id": "2dcbfd05b8e8a725",
+  "name": "Artillery",
+  "type": "skill",
+  "img": "systems/mwd/icons/skills/artillery.svg",
+  "effects": [],
+  "folder": null,
+  "sort": 1100000,
+  "flags": {},
+  "system": {
+    "inactive": false,
+    "sourceReference": "",
+    "description": "",
+    "gmnotes": "",
+    "code": "artillery",
+    "attribute": "logic",
+    "value": 0,
+    "specialization": "",
+    "hasDrain": false,
+    "hasConvergence": false,
+    "isSocial": false,
+    "listspecialization": []
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!items!2dcbfd05b8e8a725"
+}

--- a/src/packs/skills/items_Athletics_99e1303406ba52ad.yml
+++ b/src/packs/skills/items_Athletics_99e1303406ba52ad.yml
@@ -1,0 +1,28 @@
+{
+  "_id": "99e1303406ba52ad",
+  "name": "Athletics",
+  "type": "skill",
+  "img": "systems/mwd/icons/skills/athletics.svg",
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "flags": {},
+  "system": {
+    "inactive": false,
+    "sourceReference": "",
+    "description": "",
+    "gmnotes": "",
+    "code": "athletics",
+    "attribute": "strength",
+    "value": 0,
+    "specialization": "",
+    "hasDrain": false,
+    "hasConvergence": false,
+    "isSocial": false,
+    "listspecialization": []
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!items!99e1303406ba52ad"
+}

--- a/src/packs/skills/items_Communications_48bc64b712df81c1.yml
+++ b/src/packs/skills/items_Communications_48bc64b712df81c1.yml
@@ -1,0 +1,28 @@
+{
+  "_id": "48bc64b712df81c1",
+  "name": "Communications",
+  "type": "skill",
+  "img": "systems/mwd/icons/skills/networking.svg",
+  "effects": [],
+  "folder": null,
+  "sort": 1200000,
+  "flags": {},
+  "system": {
+    "inactive": false,
+    "sourceReference": "",
+    "description": "",
+    "gmnotes": "",
+    "code": "communications",
+    "attribute": "logic",
+    "value": 0,
+    "specialization": "",
+    "hasDrain": false,
+    "hasConvergence": false,
+    "isSocial": false,
+    "listspecialization": []
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!items!48bc64b712df81c1"
+}

--- a/src/packs/skills/items_Computers_eea9ceddf58b91e5.yml
+++ b/src/packs/skills/items_Computers_eea9ceddf58b91e5.yml
@@ -1,0 +1,28 @@
+{
+  "_id": "eea9ceddf58b91e5",
+  "name": "Computers",
+  "type": "skill",
+  "img": "systems/mwd/icons/skills/hacking.svg",
+  "effects": [],
+  "folder": null,
+  "sort": 1300000,
+  "flags": {},
+  "system": {
+    "inactive": false,
+    "sourceReference": "",
+    "description": "",
+    "gmnotes": "",
+    "code": "computers",
+    "attribute": "logic",
+    "value": 0,
+    "specialization": "",
+    "hasDrain": false,
+    "hasConvergence": false,
+    "isSocial": false,
+    "listspecialization": []
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!items!eea9ceddf58b91e5"
+}

--- a/src/packs/skills/items_Demolitions_d9338c2c8a187f6f.yml
+++ b/src/packs/skills/items_Demolitions_d9338c2c8a187f6f.yml
@@ -1,0 +1,28 @@
+{
+  "_id": "d9338c2c8a187f6f",
+  "name": "Demolitions",
+  "type": "skill",
+  "img": "systems/mwd/icons/skills/demolition.svg",
+  "effects": [],
+  "folder": null,
+  "sort": 1400000,
+  "flags": {},
+  "system": {
+    "inactive": false,
+    "sourceReference": "",
+    "description": "",
+    "gmnotes": "",
+    "code": "demolitions",
+    "attribute": "logic",
+    "value": 0,
+    "specialization": "",
+    "hasDrain": false,
+    "hasConvergence": false,
+    "isSocial": false,
+    "listspecialization": []
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!items!d9338c2c8a187f6f"
+}

--- a/src/packs/skills/items_Disguise_b8baefd676d33f0c.yml
+++ b/src/packs/skills/items_Disguise_b8baefd676d33f0c.yml
@@ -1,0 +1,28 @@
+{
+  "_id": "b8baefd676d33f0c",
+  "name": "Disguise",
+  "type": "skill",
+  "img": "systems/mwd/icons/skills/disguise.svg",
+  "effects": [],
+  "folder": null,
+  "sort": 2600000,
+  "flags": {},
+  "system": {
+    "inactive": false,
+    "sourceReference": "",
+    "description": "",
+    "gmnotes": "",
+    "code": "disguise",
+    "attribute": "charisma",
+    "value": 0,
+    "specialization": "",
+    "hasDrain": false,
+    "hasConvergence": false,
+    "isSocial": false,
+    "listspecialization": []
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!items!b8baefd676d33f0c"
+}

--- a/src/packs/skills/items_Escape_Artist_73752f54838d45e8.yml
+++ b/src/packs/skills/items_Escape_Artist_73752f54838d45e8.yml
@@ -1,0 +1,28 @@
+{
+  "_id": "73752f54838d45e8",
+  "name": "Escape Artist",
+  "type": "skill",
+  "img": "systems/mwd/icons/skills/escape-artist.svg",
+  "effects": [],
+  "folder": null,
+  "sort": 200000,
+  "flags": {},
+  "system": {
+    "inactive": false,
+    "sourceReference": "",
+    "description": "",
+    "gmnotes": "",
+    "code": "escapeArtist",
+    "attribute": "agility",
+    "value": 0,
+    "specialization": "",
+    "hasDrain": false,
+    "hasConvergence": false,
+    "isSocial": false,
+    "listspecialization": []
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!items!73752f54838d45e8"
+}

--- a/src/packs/skills/items_Etiquette_d07f84838c15421e.yml
+++ b/src/packs/skills/items_Etiquette_d07f84838c15421e.yml
@@ -1,0 +1,28 @@
+{
+  "_id": "d07f84838c15421e",
+  "name": "Etiquette",
+  "type": "skill",
+  "img": "systems/mwd/icons/skills/etiquette.svg",
+  "effects": [],
+  "folder": null,
+  "sort": 2900000,
+  "flags": {},
+  "system": {
+    "inactive": false,
+    "sourceReference": "",
+    "description": "",
+    "gmnotes": "",
+    "code": "etiquette",
+    "attribute": "charisma",
+    "value": 0,
+    "specialization": "",
+    "hasDrain": false,
+    "hasConvergence": false,
+    "isSocial": true,
+    "listspecialization": []
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!items!d07f84838c15421e"
+}

--- a/src/packs/skills/items_Firearms_7e9c7f520768fb26.yml
+++ b/src/packs/skills/items_Firearms_7e9c7f520768fb26.yml
@@ -1,0 +1,28 @@
+{
+  "_id": "7e9c7f520768fb26",
+  "name": "Firearms",
+  "type": "skill",
+  "img": "systems/mwd/icons/skills/firearms.svg",
+  "effects": [],
+  "folder": null,
+  "sort": 700000,
+  "flags": {},
+  "system": {
+    "inactive": false,
+    "sourceReference": "",
+    "description": "",
+    "gmnotes": "",
+    "code": "firearms",
+    "attribute": "agility",
+    "value": 0,
+    "specialization": "",
+    "hasDrain": false,
+    "hasConvergence": false,
+    "isSocial": false,
+    "listspecialization": []
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!items!7e9c7f520768fb26"
+}

--- a/src/packs/skills/items_Gunnery_38939aca025e7466.yml
+++ b/src/packs/skills/items_Gunnery_38939aca025e7466.yml
@@ -1,0 +1,28 @@
+{
+  "_id": "38939aca025e7466",
+  "name": "Gunnery",
+  "type": "skill",
+  "img": "systems/mwd/icons/skills/vehicle-weapons.svg",
+  "effects": [],
+  "folder": null,
+  "sort": 300000,
+  "flags": {},
+  "system": {
+    "inactive": false,
+    "sourceReference": "",
+    "description": "",
+    "gmnotes": "",
+    "code": "gunnery",
+    "attribute": "agility",
+    "value": 0,
+    "specialization": "",
+    "hasDrain": false,
+    "hasConvergence": false,
+    "isSocial": false,
+    "listspecialization": []
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!items!38939aca025e7466"
+}

--- a/src/packs/skills/items_Heavy_Weapons_8618e0d5ecdc12d9.yml
+++ b/src/packs/skills/items_Heavy_Weapons_8618e0d5ecdc12d9.yml
@@ -1,0 +1,28 @@
+{
+  "_id": "8618e0d5ecdc12d9",
+  "name": "Heavy Weapons",
+  "type": "skill",
+  "img": "systems/mwd/icons/skills/heavy-weapons.svg",
+  "effects": [],
+  "folder": null,
+  "sort": 100000,
+  "flags": {},
+  "system": {
+    "inactive": false,
+    "sourceReference": "",
+    "description": "",
+    "gmnotes": "",
+    "code": "heavyWeapons",
+    "attribute": "strength",
+    "value": 0,
+    "specialization": "",
+    "hasDrain": false,
+    "hasConvergence": false,
+    "isSocial": false,
+    "listspecialization": []
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!items!8618e0d5ecdc12d9"
+}

--- a/src/packs/skills/items_Intimidation_ac9b0855d0e18d57.yml
+++ b/src/packs/skills/items_Intimidation_ac9b0855d0e18d57.yml
@@ -1,0 +1,28 @@
+{
+  "_id": "ac9b0855d0e18d57",
+  "name": "Intimidation",
+  "type": "skill",
+  "img": "systems/mwd/icons/skills/intimidation.svg",
+  "effects": [],
+  "folder": null,
+  "sort": 3100000,
+  "flags": {},
+  "system": {
+    "inactive": false,
+    "sourceReference": "",
+    "description": "",
+    "gmnotes": "",
+    "code": "intimidation",
+    "attribute": "charisma",
+    "value": 0,
+    "specialization": "",
+    "hasDrain": false,
+    "hasConvergence": false,
+    "isSocial": true,
+    "listspecialization": []
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!items!ac9b0855d0e18d57"
+}

--- a/src/packs/skills/items_Knowledge_4883becbd3abf19f.yml
+++ b/src/packs/skills/items_Knowledge_4883becbd3abf19f.yml
@@ -1,0 +1,28 @@
+{
+  "_id": "4883becbd3abf19f",
+  "name": "Knowledge",
+  "type": "skill",
+  "img": "systems/mwd/icons/skills/knowledge.svg",
+  "effects": [],
+  "folder": null,
+  "sort": 1500000,
+  "flags": {},
+  "system": {
+    "inactive": false,
+    "sourceReference": "",
+    "description": "",
+    "gmnotes": "",
+    "code": "knowledge",
+    "attribute": "knowledge",
+    "value": 0,
+    "specialization": "",
+    "hasDrain": false,
+    "hasConvergence": false,
+    "isSocial": false,
+    "listspecialization": []
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!items!4883becbd3abf19f"
+}

--- a/src/packs/skills/items_Leadership_65259c97405494f6.yml
+++ b/src/packs/skills/items_Leadership_65259c97405494f6.yml
@@ -1,0 +1,28 @@
+{
+  "_id": "65259c97405494f6",
+  "name": "Leadership",
+  "type": "skill",
+  "img": "systems/mwd/icons/skills/skills.svg",
+  "effects": [],
+  "folder": null,
+  "sort": 2700000,
+  "flags": {},
+  "system": {
+    "inactive": false,
+    "sourceReference": "",
+    "description": "",
+    "gmnotes": "",
+    "code": "leadership",
+    "attribute": "charisma",
+    "value": 0,
+    "specialization": "",
+    "hasDrain": false,
+    "hasConvergence": false,
+    "isSocial": true,
+    "listspecialization": []
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!items!65259c97405494f6"
+}

--- a/src/packs/skills/items_MedTech_e8c267554d5f54eb.yml
+++ b/src/packs/skills/items_MedTech_e8c267554d5f54eb.yml
@@ -1,0 +1,28 @@
+{
+  "_id": "e8c267554d5f54eb",
+  "name": "MedTech",
+  "type": "skill",
+  "img": "systems/mwd/icons/skills/biotech.svg",
+  "effects": [],
+  "folder": null,
+  "sort": 1600000,
+  "flags": {},
+  "system": {
+    "inactive": false,
+    "sourceReference": "",
+    "description": "",
+    "gmnotes": "",
+    "code": "medTech",
+    "attribute": "logic",
+    "value": 0,
+    "specialization": "",
+    "hasDrain": false,
+    "hasConvergence": false,
+    "isSocial": false,
+    "listspecialization": []
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!items!e8c267554d5f54eb"
+}

--- a/src/packs/skills/items_Melee_Combat_6d01691fbe81df32.yml
+++ b/src/packs/skills/items_Melee_Combat_6d01691fbe81df32.yml
@@ -1,0 +1,28 @@
+{
+  "_id": "6d01691fbe81df32",
+  "name": "Melee Combat",
+  "type": "skill",
+  "img": "systems/mwd/icons/skills/close-combat.svg",
+  "effects": [],
+  "folder": null,
+  "sort": 400000,
+  "flags": {},
+  "system": {
+    "inactive": false,
+    "sourceReference": "",
+    "description": "",
+    "gmnotes": "",
+    "code": "meleeCombat",
+    "attribute": "agility",
+    "value": 0,
+    "specialization": "",
+    "hasDrain": false,
+    "hasConvergence": false,
+    "isSocial": false,
+    "listspecialization": []
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!items!6d01691fbe81df32"
+}

--- a/src/packs/skills/items_Navigation_35ce36f704ffae5f.yml
+++ b/src/packs/skills/items_Navigation_35ce36f704ffae5f.yml
@@ -1,0 +1,28 @@
+{
+  "_id": "35ce36f704ffae5f",
+  "name": "Navigation",
+  "type": "skill",
+  "img": "systems/mwd/icons/skills/piloting-other.svg",
+  "effects": [],
+  "folder": null,
+  "sort": 2200000,
+  "flags": {},
+  "system": {
+    "inactive": false,
+    "sourceReference": "",
+    "description": "",
+    "gmnotes": "",
+    "code": "navigation",
+    "attribute": "logic",
+    "value": 0,
+    "specialization": "",
+    "hasDrain": false,
+    "hasConvergence": false,
+    "isSocial": false,
+    "listspecialization": []
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!items!35ce36f704ffae5f"
+}

--- a/src/packs/skills/items_Negotiation_d47c36665da78b79.yml
+++ b/src/packs/skills/items_Negotiation_d47c36665da78b79.yml
@@ -1,0 +1,28 @@
+{
+  "_id": "d47c36665da78b79",
+  "name": "Negotiation",
+  "type": "skill",
+  "img": "systems/mwd/icons/skills/negotiation.svg",
+  "effects": [],
+  "folder": null,
+  "sort": 2800000,
+  "flags": {},
+  "system": {
+    "inactive": false,
+    "sourceReference": "",
+    "description": "",
+    "gmnotes": "",
+    "code": "negotiation",
+    "attribute": "charisma",
+    "value": 0,
+    "specialization": "",
+    "hasDrain": false,
+    "hasConvergence": false,
+    "isSocial": true,
+    "listspecialization": []
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!items!d47c36665da78b79"
+}

--- a/src/packs/skills/items_Perception_b1b0a9c6f717dae5.yml
+++ b/src/packs/skills/items_Perception_b1b0a9c6f717dae5.yml
@@ -1,0 +1,28 @@
+{
+  "_id": "b1b0a9c6f717dae5",
+  "name": "Perception",
+  "type": "skill",
+  "img": "systems/mwd/icons/skills/skills.svg",
+  "effects": [],
+  "folder": null,
+  "sort": 1800000,
+  "flags": {},
+  "system": {
+    "inactive": false,
+    "sourceReference": "",
+    "description": "",
+    "gmnotes": "",
+    "code": "perception",
+    "attribute": "logic",
+    "value": 0,
+    "specialization": "",
+    "hasDrain": false,
+    "hasConvergence": false,
+    "isSocial": false,
+    "listspecialization": []
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!items!b1b0a9c6f717dae5"
+}

--- a/src/packs/skills/items_Piloting_b0f1c48c0ddd7bdd.yml
+++ b/src/packs/skills/items_Piloting_b0f1c48c0ddd7bdd.yml
@@ -1,0 +1,28 @@
+{
+  "_id": "b0f1c48c0ddd7bdd",
+  "name": "Piloting",
+  "type": "skill",
+  "img": "systems/mwd/icons/skills/piloting-ground-steering-wheel.svg",
+  "effects": [],
+  "folder": null,
+  "sort": 500000,
+  "flags": {},
+  "system": {
+    "inactive": false,
+    "sourceReference": "",
+    "description": "",
+    "gmnotes": "",
+    "code": "piloting",
+    "attribute": "agility",
+    "value": 0,
+    "specialization": "",
+    "hasDrain": false,
+    "hasConvergence": false,
+    "isSocial": false,
+    "listspecialization": []
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!items!b0f1c48c0ddd7bdd"
+}

--- a/src/packs/skills/items_Projectile_Weapons_d3c17fd37c5a4594.yml
+++ b/src/packs/skills/items_Projectile_Weapons_d3c17fd37c5a4594.yml
@@ -1,0 +1,28 @@
+{
+  "_id": "d3c17fd37c5a4594",
+  "name": "Projectile Weapons",
+  "type": "skill",
+  "img": "systems/mwd/icons/skills/projectile-weapons.svg",
+  "effects": [],
+  "folder": null,
+  "sort": 600000,
+  "flags": {},
+  "system": {
+    "inactive": false,
+    "sourceReference": "",
+    "description": "",
+    "gmnotes": "",
+    "code": "projectileWeapons",
+    "attribute": "agility",
+    "value": 0,
+    "specialization": "",
+    "hasDrain": false,
+    "hasConvergence": false,
+    "isSocial": false,
+    "listspecialization": []
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!items!d3c17fd37c5a4594"
+}

--- a/src/packs/skills/items_Science_6df0910f851e2dad.yml
+++ b/src/packs/skills/items_Science_6df0910f851e2dad.yml
@@ -1,0 +1,28 @@
+{
+  "_id": "6df0910f851e2dad",
+  "name": "Science",
+  "type": "skill",
+  "img": "systems/mwd/icons/skills/skills.svg",
+  "effects": [],
+  "folder": null,
+  "sort": 1700000,
+  "flags": {},
+  "system": {
+    "inactive": false,
+    "sourceReference": "",
+    "description": "",
+    "gmnotes": "",
+    "code": "science",
+    "attribute": "logic",
+    "value": 0,
+    "specialization": "",
+    "hasDrain": false,
+    "hasConvergence": false,
+    "isSocial": false,
+    "listspecialization": []
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!items!6df0910f851e2dad"
+}

--- a/src/packs/skills/items_Stealth_947c46d0d0bdb8e5.yml
+++ b/src/packs/skills/items_Stealth_947c46d0d0bdb8e5.yml
@@ -1,0 +1,28 @@
+{
+  "_id": "947c46d0d0bdb8e5",
+  "name": "Stealth",
+  "type": "skill",
+  "img": "systems/mwd/icons/skills/stealth.svg",
+  "effects": [],
+  "folder": null,
+  "sort": 800000,
+  "flags": {},
+  "system": {
+    "inactive": false,
+    "sourceReference": "",
+    "description": "",
+    "gmnotes": "",
+    "code": "stealth",
+    "attribute": "agility",
+    "value": 0,
+    "specialization": "",
+    "hasDrain": false,
+    "hasConvergence": false,
+    "isSocial": false,
+    "listspecialization": []
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!items!947c46d0d0bdb8e5"
+}

--- a/src/packs/skills/items_Streetwise_59f5ba41485b8bc2.yml
+++ b/src/packs/skills/items_Streetwise_59f5ba41485b8bc2.yml
@@ -1,0 +1,28 @@
+{
+  "_id": "59f5ba41485b8bc2",
+  "name": "Streetwise",
+  "type": "skill",
+  "img": "systems/mwd/icons/skills/etiquette2.svg",
+  "effects": [],
+  "folder": null,
+  "sort": 3000000,
+  "flags": {},
+  "system": {
+    "inactive": false,
+    "sourceReference": "",
+    "description": "",
+    "gmnotes": "",
+    "code": "streetwise",
+    "attribute": "charisma",
+    "value": 0,
+    "specialization": "",
+    "hasDrain": false,
+    "hasConvergence": false,
+    "isSocial": true,
+    "listspecialization": []
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!items!59f5ba41485b8bc2"
+}

--- a/src/packs/skills/items_Survival_adcc2d4dd5544833.yml
+++ b/src/packs/skills/items_Survival_adcc2d4dd5544833.yml
@@ -1,0 +1,28 @@
+{
+  "_id": "adcc2d4dd5544833",
+  "name": "Survival",
+  "type": "skill",
+  "img": "systems/mwd/icons/skills/survival.svg",
+  "effects": [],
+  "folder": null,
+  "sort": 2400000,
+  "flags": {},
+  "system": {
+    "inactive": false,
+    "sourceReference": "",
+    "description": "",
+    "gmnotes": "",
+    "code": "survival",
+    "attribute": "willpower",
+    "value": 0,
+    "specialization": "",
+    "hasDrain": false,
+    "hasConvergence": false,
+    "isSocial": false,
+    "listspecialization": []
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!items!adcc2d4dd5544833"
+}

--- a/src/packs/skills/items_Tactics_6031f0b271aa2bb4.yml
+++ b/src/packs/skills/items_Tactics_6031f0b271aa2bb4.yml
@@ -1,0 +1,28 @@
+{
+  "_id": "6031f0b271aa2bb4",
+  "name": "Tactics",
+  "type": "skill",
+  "img": "systems/mwd/icons/skills/skills.svg",
+  "effects": [],
+  "folder": null,
+  "sort": 1900000,
+  "flags": {},
+  "system": {
+    "inactive": false,
+    "sourceReference": "",
+    "description": "",
+    "gmnotes": "",
+    "code": "tactics",
+    "attribute": "logic",
+    "value": 0,
+    "specialization": "",
+    "hasDrain": false,
+    "hasConvergence": false,
+    "isSocial": false,
+    "listspecialization": []
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!items!6031f0b271aa2bb4"
+}

--- a/src/packs/skills/items_Technician_947ba455f9be18f6.yml
+++ b/src/packs/skills/items_Technician_947ba455f9be18f6.yml
@@ -1,0 +1,28 @@
+{
+  "_id": "947ba455f9be18f6",
+  "name": "Technician",
+  "type": "skill",
+  "img": "systems/mwd/icons/skills/engineering.svg",
+  "effects": [],
+  "folder": null,
+  "sort": 2000000,
+  "flags": {},
+  "system": {
+    "inactive": false,
+    "sourceReference": "",
+    "description": "",
+    "gmnotes": "",
+    "code": "technician",
+    "attribute": "logic",
+    "value": 0,
+    "specialization": "",
+    "hasDrain": false,
+    "hasConvergence": false,
+    "isSocial": false,
+    "listspecialization": []
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!items!947ba455f9be18f6"
+}

--- a/src/packs/skills/items_Tracking_8a10120c68dceb1e.yml
+++ b/src/packs/skills/items_Tracking_8a10120c68dceb1e.yml
@@ -1,0 +1,28 @@
+{
+  "_id": "8a10120c68dceb1e",
+  "name": "Tracking",
+  "type": "skill",
+  "img": "systems/mwd/icons/skills/tracking.svg",
+  "effects": [],
+  "folder": null,
+  "sort": 2100000,
+  "flags": {},
+  "system": {
+    "inactive": false,
+    "sourceReference": "",
+    "description": "",
+    "gmnotes": "",
+    "code": "tracking",
+    "attribute": "logic",
+    "value": 0,
+    "specialization": "",
+    "hasDrain": false,
+    "hasConvergence": false,
+    "isSocial": false,
+    "listspecialization": []
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!items!8a10120c68dceb1e"
+}

--- a/src/packs/skills/items_Zero-G_Operations_28fa5496ff3afc21.yml
+++ b/src/packs/skills/items_Zero-G_Operations_28fa5496ff3afc21.yml
@@ -1,0 +1,28 @@
+{
+  "_id": "28fa5496ff3afc21",
+  "name": "Zero-G Operations",
+  "type": "skill",
+  "img": "systems/mwd/icons/skills/free-fall.svg",
+  "effects": [],
+  "folder": null,
+  "sort": 900000,
+  "flags": {},
+  "system": {
+    "inactive": false,
+    "sourceReference": "",
+    "description": "",
+    "gmnotes": "",
+    "code": "zeroGOperations",
+    "attribute": "agility",
+    "value": 0,
+    "specialization": "",
+    "hasDrain": false,
+    "hasConvergence": false,
+    "isSocial": false,
+    "listspecialization": []
+  },
+  "ownership": {
+    "default": 0
+  },
+  "_key": "!items!28fa5496ff3afc21"
+}

--- a/system.json
+++ b/system.json
@@ -75,6 +75,16 @@
         "PLAYER": "NONE",
         "ASSISTANT": "OWNER"
       }
+    },
+    {
+      "name": "skills",
+      "label": "Skills",
+      "type": "Item",
+      "system": "mwd",
+      "ownership": {
+        "PLAYER": "OBSERVER",
+        "ASSISTANT": "OWNER"
+      }
     }
   ],
   "media": [


### PR DESCRIPTION
## Summary
- add a new Skills compendium pack populated with all default skill items
- register the compendium in the system manifest so it is available in-game

## Testing
- not run (data-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cb6c03f58832db646f27a70481648)