### PR TITLE
Add pilot assignment and skill inheritance to vehicles

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -236,6 +236,17 @@
         "locationSide": "Side effects",
         "locationRear": "Rear effects",
         "locationCore": "Core effects",
+        "pilot": {
+          "label": "Pilot",
+          "none": "No pilot selected",
+          "selectActor": "Select Pilot",
+          "selectToken": "Use Selected Token",
+          "tokenTag": "Token ({{scene}})",
+          "errors": {
+            "noActors": "No valid actors available to pilot this vehicle.",
+            "noTokens": "Select a token with permission to pilot as the vehicle's pilot."
+          }
+        },
         "quickActions": {
           "title": "Quick Actions",
           "rangedAttack": "Ranged Attack",

--- a/src/modules/actor/base-actor.js
+++ b/src/modules/actor/base-actor.js
@@ -416,7 +416,10 @@ export class AnarchyBaseActor extends Actor {
   }
 
   getSkillValue(skillId, specialization = undefined) {
-    const skill = this.items.get(skillId);
+    const skill = typeof skillId === 'string' ? this.items.get(skillId) : skillId;
+    if (!skill) {
+      return 0;
+    }
     const attribute = this.getAttributeValue(skill.system.attribute);
     return skill.system.value + attribute + (specialization && skill.system.specialization ? 2 : 0);
   }

--- a/src/modules/actor/vehicle-sheet.js
+++ b/src/modules/actor/vehicle-sheet.js
@@ -1,3 +1,5 @@
+import { ANARCHY } from "../config.js";
+import { SelectActor } from "../dialog/select-actor.js";
 import { AnarchyActorSheet } from "./anarchy-actor-sheet.js";
 
 export class VehicleSheet extends AnarchyActorSheet {
@@ -12,12 +14,52 @@ export class VehicleSheet extends AnarchyActorSheet {
   getData(options) {
     let hbsData = foundry.utils.mergeObject(
       super.getData(options), {
+        pilot: this.actor.getPilotReference()
     });
     return hbsData;
   }
 
   activateListeners(html) {
     super.activateListeners(html);
+
+    html.find('.click-select-pilot').click(async event => {
+      event.stopPropagation();
+      await this.selectPilotFromActor();
+    });
+
+    html.find('.click-select-pilot-token').click(async event => {
+      event.stopPropagation();
+      await this.selectPilotFromToken();
+    });
+
+    html.find('.click-clear-pilot').click(async event => {
+      event.stopPropagation();
+      await this.actor.update({ 'system.pilot.uuid': '' });
+      this.render();
+    });
+  }
+
+  async selectPilotFromActor() {
+    const candidates = game.actors.filter(actor => actor.canPilotVehicle());
+    if (candidates.length === 0) {
+      ui.notifications.warn(game.i18n.localize(ANARCHY.actor.vehicle.pilot.errors.noActors));
+      return;
+    }
+
+    const title = game.i18n.localize(ANARCHY.actor.vehicle.pilot.selectActor);
+    await SelectActor.selectActor(title, candidates,
+      async actor => await this.actor.update({ 'system.pilot.uuid': actor.uuid }));
+  }
+
+  async selectPilotFromToken() {
+    const selectedToken = canvas?.tokens?.controlled?.find(token => token.actor?.canPilotVehicle());
+    if (!selectedToken) {
+      ui.notifications.warn(game.i18n.localize(ANARCHY.actor.vehicle.pilot.errors.noTokens));
+      return;
+    }
+
+    await this.actor.update({ 'system.pilot.uuid': selectedToken.document.uuid });
+    this.render();
   }
 
 }

--- a/template.json
+++ b/template.json
@@ -135,6 +135,9 @@
           "chassis": { "value": 3 },
           "condition": { "value": 3 }
         },
+        "pilot": {
+          "uuid": ""
+        },
         "mwd": {
           "unitType": "vehicle",
           "locations": {
@@ -162,6 +165,9 @@
           "system": { "value": 3 },
           "chassis": { "value": 4 },
           "condition": { "value": 3 }
+        },
+        "pilot": {
+          "uuid": ""
         },
         "mwd": {
           "unitType": "mech",

--- a/templates/actor/battlemech.hbs
+++ b/templates/actor/battlemech.hbs
@@ -12,6 +12,7 @@
           <div class="passport-detail">
             {{> 'systems/mwd/templates/actor/parts/ownership.hbs'}}
           </div>
+          {{> "systems/mwd/templates/actor/vehicle/vehicle-pilot.hbs"}}
         </div>
         <div class="passport-action-row">
         </div>

--- a/templates/actor/vehicle.hbs
+++ b/templates/actor/vehicle.hbs
@@ -18,6 +18,7 @@
           <div class="passport-detail">
             {{> 'systems/mwd/templates/actor/parts/ownership.hbs'}}
           </div>
+          {{> "systems/mwd/templates/actor/vehicle/vehicle-pilot.hbs"}}
         </div>
         <div class="passport-action-row">
           <div class="passport-action">

--- a/templates/actor/vehicle/vehicle-pilot.hbs
+++ b/templates/actor/vehicle/vehicle-pilot.hbs
@@ -1,0 +1,22 @@
+<div class="passport-detail vehicle-pilot">
+  <label class="info-label">{{localize ANARCHY.actor.vehicle.pilot.label}}</label>
+  <div class="pilot-details">
+    {{#if pilot}}
+      <div class="pilot-reference">
+        {{> 'systems/mwd/templates/common/actor-reference.hbs' pilot}}
+        {{#if pilot.isToken}}
+          <span class="tag">{{localize ANARCHY.actor.vehicle.pilot.tokenTag scene=pilot.scene}}</span>
+        {{/if}}
+        <a class="item-control click-clear-pilot" data-tooltip="{{localize ANARCHY.common.del}}">
+          {{{iconFA 'fas fa-trash'}}}
+        </a>
+      </div>
+    {{else}}
+      <span class="pilot-placeholder">{{localize ANARCHY.actor.vehicle.pilot.none}}</span>
+    {{/if}}
+  </div>
+  <div class="pilot-actions">
+    <a class="anarchy-button click-select-pilot" data-tooltip="{{localize ANARCHY.actor.vehicle.pilot.selectActor}}">{{localize ANARCHY.actor.vehicle.pilot.selectActor}}</a>
+    <a class="anarchy-button click-select-pilot-token" data-tooltip="{{localize ANARCHY.actor.vehicle.pilot.selectToken}}">{{localize ANARCHY.actor.vehicle.pilot.selectToken}}</a>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- add UI and data model to pick a pilot for vehicles or battlemechs from actors or selected tokens
- have vehicle rolls draw skill values from the assigned pilot when available
- surface new pilot strings and template defaults for vehicles

## Testing
- not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cbae4bb74832dafb60c6deda7a618)