### PR TITLE
Handle legacy items and stabilize skill initialization

### DIFF
--- a/src/modules/config.js
+++ b/src/modules/config.js
@@ -215,7 +215,42 @@ export const ANARCHY = {
             attacks: 'ANARCHY.actor.vehicle.attacks',
             stealth: 'ANARCHY.actor.vehicle.stealth',
             category: 'ANARCHY.actor.vehicle.category',
-            skill: 'ANARCHY.actor.vehicle.skill'
+            skill: 'ANARCHY.actor.vehicle.skill',
+            quickActions: {
+                title: 'ANARCHY.actor.vehicle.quickActions.title',
+                rangedAttack: 'ANARCHY.actor.vehicle.quickActions.rangedAttack',
+                meleeAttack: 'ANARCHY.actor.vehicle.quickActions.meleeAttack',
+                dodgeCheck: 'ANARCHY.actor.vehicle.quickActions.dodgeCheck',
+                pilotingCheck: 'ANARCHY.actor.vehicle.quickActions.pilotingCheck',
+                sensorSweep: 'ANARCHY.actor.vehicle.quickActions.sensorSweep',
+                emergencyRepair: 'ANARCHY.actor.vehicle.quickActions.emergencyRepair',
+                primaryWeapons: 'ANARCHY.actor.vehicle.quickActions.primaryWeapons',
+                allWeapons: 'ANARCHY.actor.vehicle.quickActions.allWeapons',
+                primaryLabel: 'ANARCHY.actor.vehicle.quickActions.primaryLabel',
+                unarmed: 'ANARCHY.actor.vehicle.quickActions.unarmed',
+                unarmedNotes: 'ANARCHY.actor.vehicle.quickActions.unarmedNotes',
+                selectWeaponGroup: 'ANARCHY.actor.vehicle.quickActions.selectWeaponGroup',
+                selectMeleeProfile: 'ANARCHY.actor.vehicle.quickActions.selectMeleeProfile',
+                selectSensorSkill: 'ANARCHY.actor.vehicle.quickActions.selectSensorSkill',
+                weaponGroup: 'ANARCHY.actor.vehicle.quickActions.weaponGroup',
+                weaponsUsed: 'ANARCHY.actor.vehicle.quickActions.weaponsUsed',
+                meleeProfile: 'ANARCHY.actor.vehicle.quickActions.meleeProfile',
+                meleeDamage: 'ANARCHY.actor.vehicle.quickActions.meleeDamage',
+                skillUsed: 'ANARCHY.actor.vehicle.quickActions.skillUsed',
+                tooltips: {
+                    ranged: 'ANARCHY.actor.vehicle.quickActions.tooltips.ranged',
+                    melee: 'ANARCHY.actor.vehicle.quickActions.tooltips.melee',
+                    dodge: 'ANARCHY.actor.vehicle.quickActions.tooltips.dodge',
+                    piloting: 'ANARCHY.actor.vehicle.quickActions.tooltips.piloting',
+                    sensorSweep: 'ANARCHY.actor.vehicle.quickActions.tooltips.sensorSweep',
+                    emergencyRepair: 'ANARCHY.actor.vehicle.quickActions.tooltips.emergencyRepair',
+                },
+                errors: {
+                    noRanged: 'ANARCHY.actor.vehicle.quickActions.errors.noRanged',
+                    noMelee: 'ANARCHY.actor.vehicle.quickActions.errors.noMelee',
+                    noSensorSweep: 'ANARCHY.actor.vehicle.quickActions.errors.noSensorSweep',
+                }
+            }
         },
         ownership: {
             owner: 'ANARCHY.actor.ownership.owner',

--- a/src/modules/item/anarchy-base-item.js
+++ b/src/modules/item/anarchy-base-item.js
@@ -13,6 +13,9 @@ export class AnarchyBaseItem extends Item {
   }
 
   constructor(docData, context = {}) {
+    const legacyTypeMap = { weapon: TEMPLATE.itemType.personalWeapon };
+    docData.type = legacyTypeMap[docData.type] ?? docData.type;
+
     if (!context.anarchy?.ready) {
       foundry.utils.mergeObject(context, { anarchy: { ready: true } });
       const ItemConstructor = game.system.anarchy.itemClasses[docData.type];

--- a/src/modules/skills.js
+++ b/src/modules/skills.js
@@ -61,6 +61,7 @@ export class Skills {
 
   constructor() {
     this.skillSets = {};
+    this.selectedSkills = DEFAULT_SKILLSET_ANARCHY;
     HooksManager.register(ANARCHY_HOOKS.PROVIDE_SKILL_SET);
     Hooks.on(ANARCHY_HOOKS.PROVIDE_SKILL_SET, provide =>
       provide(DEFAULT_SKILLSET_ANARCHY, 'Shadowrun Anarchy', ANARCHY_SKILLS, { lang: 'en' })
@@ -111,7 +112,7 @@ export class Skills {
 
   $getConfiguredSkills() {
     const skillSet = this.skillSets[this.selectedSkills] ?? this.skillSets[DEFAULT_SKILLSET_ANARCHY];
-    return skillSet.skills;
+    return skillSet?.skills ?? [];
   }
 
 


### PR DESCRIPTION
## Summary
- map legacy weapon items to the supported personal weapon type during construction
- default the skill service to a known skillset and guard against missing configurations
- expose vehicle quick action localization keys used by battlemech quick actions

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cbb30bb40832da3a456b8009dc3b3)