### PR TITLE
Add vehicle pilot partial to Handlebars preload

### DIFF
--- a/src/modules/handlebars-manager.js
+++ b/src/modules/handlebars-manager.js
@@ -113,6 +113,7 @@ const HBS_PARTIAL_TEMPLATES = [
   // Vehicles
   'systems/mwd/templates/actor/vehicle/vehicle-attributes.hbs',
   'systems/mwd/templates/actor/vehicle/vehicle-category.hbs',
+  'systems/mwd/templates/actor/vehicle/vehicle-pilot.hbs',
   'systems/mwd/templates/actor/vehicle/vehicle-skill.hbs',
   // item
   'systems/mwd/templates/item/parts/inactive.hbs',


### PR DESCRIPTION
## Summary
- preload the vehicle pilot partial so battlemech and vehicle sheets can render

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ce1e70f24832d9efbbd58dc6d1fbd)