### PR TITLE
Handle missing weapon items when rolling

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -168,6 +168,7 @@
         "noTargetSelected": "No valid target is selected, consider selecting a valid target before using this {weapon}",
         "maxTargetsExceedeed": "{weapon} has a {area} area of effect, with a maximum of {max} targets. You are currently targetting {count} targets",
         "noDefenseOnWeapon": "No defense configured for {actor} weapon: {weapon}.<br>Configure defense against this weapon to be able to attack with it.",
+        "weaponNotFound": "No weapon could be found for this roll.",
         "noTokenActor": "Token is not attached to an Actor!",
         "noValidPilotForVehicle": "No valid pilot found for {vehicle} among selected tokens, your main character, and vehicle owner",
         "cannotUseEdgeAnymore": "Too late to use edge. A defender already rolled his defense!",

--- a/src/modules/actor/anarchy-actor-sheet.js
+++ b/src/modules/actor/anarchy-actor-sheet.js
@@ -151,7 +151,12 @@ export class AnarchyActorSheet extends foundry.appv1.sheets.ActorSheet {
 
     html.find('.click-weapon-roll').click(async event => {
       event.stopPropagation();
-      this.actor.rollWeapon(this.getEventItem(event));
+      const weapon = this.getEventItem(event);
+      if (!weapon) {
+        ui.notifications.warn(game.i18n.localize('ANARCHY.common.errors.weaponNotFound'));
+        return;
+      }
+      this.actor.rollWeapon(weapon);
     });
   }
 
@@ -160,7 +165,8 @@ export class AnarchyActorSheet extends foundry.appv1.sheets.ActorSheet {
   }
 
   getEventItem(event) {
-    const itemId = $(event.currentTarget).closest('.item').attr('data-item-id');
+    const itemId = $(event.currentTarget).closest('[data-item-id]').attr('data-item-id')
+      ?? $(event.currentTarget).attr('data-item-id');
     return this.actor.items.get(itemId);
   }
 


### PR DESCRIPTION
## Summary
- Warn the user when a weapon roll is triggered without a valid item
- Improve weapon click item lookup to handle missing data-item-id anchors
- Add a localized message for missing weapon roll targets

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ceae4f624832db0713174ba4b65a0)