### PR TITLE
Replace deprecated Handlebars select helper

### DIFF
--- a/templates/actor/parts/battlemech-loadout.hbs
+++ b/templates/actor/parts/battlemech-loadout.hbs
@@ -4,9 +4,7 @@
     <div class="flexcol">
       <label>{{localize 'ANARCHY.mwd.weightClass.label'}}</label>
       <select name="system.mwd.weightClass">
-        {{#select system.mwd.weightClass}}
-          {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.mwdWeightClasses}}
-        {{/select}}
+        {{selectOptions ENUMS.mwdWeightClasses selected=system.mwd.weightClass labelAttr="labelkey" localize=true blank=''}}
       </select>
     </div>
     <div class="flexcol">
@@ -17,15 +15,11 @@
       <label>{{localize 'ANARCHY.mwd.loadout.primarySlot.label'}}</label>
       <div class="flexrow">
         <select name="system.mwd.primarySlot.mode">
-          {{#select system.mwd.primarySlot.mode}}
-            {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.mwdPrimaryModes}}
-          {{/select}}
+          {{selectOptions ENUMS.mwdPrimaryModes selected=system.mwd.primarySlot.mode labelAttr="labelkey" localize=true blank=''}}
         </select>
         <select name="system.mwd.primarySlot.typeRestriction">
-          {{#select system.mwd.primarySlot.typeRestriction}}
-            <option value="">{{localize 'ANARCHY.mwd.loadout.primarySlot.noRestriction'}}</option>
-            {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.mwdHardpointTypes}}
-          {{/select}}
+          <option value="" {{#unless system.mwd.primarySlot.typeRestriction}}selected{{/unless}}>{{localize 'ANARCHY.mwd.loadout.primarySlot.noRestriction'}}</option>
+          {{selectOptions ENUMS.mwdHardpointTypes selected=system.mwd.primarySlot.typeRestriction labelAttr="labelkey" localize=true}}
         </select>
       </div>
       <label class="small-label">{{localize 'ANARCHY.mwd.loadout.primarySlot.allowedWeapons'}}</label>
@@ -48,19 +42,13 @@
         {{#each system.mwd.hardpoints as |hardpoint idx|}}
           <div class="loadout-row">
             <select name="system.mwd.hardpoints.{{idx}}.type">
-              {{#select hardpoint.type}}
-                {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=../../ENUMS.mwdHardpointTypes}}
-              {{/select}}
+              {{selectOptions ../../ENUMS.mwdHardpointTypes selected=hardpoint.type labelAttr="labelkey" localize=true blank=''}}
             </select>
             <select name="system.mwd.hardpoints.{{idx}}.size">
-              {{#select hardpoint.size}}
-                {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=../../ENUMS.mwdHardpointSizes}}
-              {{/select}}
+              {{selectOptions ../../ENUMS.mwdHardpointSizes selected=hardpoint.size labelAttr="labelkey" localize=true blank=''}}
             </select>
             <select name="system.mwd.hardpoints.{{idx}}.location">
-              {{#select hardpoint.location}}
-                {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=../../ENUMS.mwdHardpointLocations}}
-              {{/select}}
+              {{selectOptions ../../ENUMS.mwdHardpointLocations selected=hardpoint.location labelAttr="labelkey" localize=true blank=''}}
             </select>
             <span class="loadout-occupant">
               {{#if (lookup ../system.mwd.loadout.hardpoints idx)}}

--- a/templates/actor/vehicle/vehicle-category.hbs
+++ b/templates/actor/vehicle/vehicle-category.hbs
@@ -1,5 +1,3 @@
 <select class="info-value" name="system.category">
-  {{#select system.category}}
-  {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.vehicleCategories  noEmpty=true}}
-  {{/select}}
+  {{selectOptions ENUMS.vehicleCategories selected=system.category labelAttr="labelkey" localize=true}}
 </select>

--- a/templates/actor/vehicle/vehicle-skill.hbs
+++ b/templates/actor/vehicle/vehicle-skill.hbs
@@ -1,5 +1,3 @@
 <select class="info-value" name="system.skill" data-dtype="String">
-    {{#select system.skill}}
-    {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.skills  noEmpty=true}}
-    {{/select}}
+    {{selectOptions ENUMS.skills selected=system.skill labelAttr="label" localize=false}}
 </select>

--- a/templates/dialog/roll-modifier.hbs
+++ b/templates/dialog/roll-modifier.hbs
@@ -21,9 +21,7 @@
         {{#if options}}
           <select name="select.range" class="select-option-modifier" data-dtype="String"
             data-modifier="{{type}}">
-          {{#select value}}
-          {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=options noEmpty=true}}
-          {{/select}}
+          {{selectOptions options selected=value labelAttr="labelkey" localize=true}}
           </select>
           <label class="selected-option-modifier-value">{{numberFormat value decimals=0 sign=false}}</label>
         {{else}}

--- a/templates/item/shadowamp.hbs
+++ b/templates/item/shadowamp.hbs
@@ -22,17 +22,13 @@
       <div class="form-group">
         <label for="system.category">{{localize 'ANARCHY.item.shadowamp.category'}} </label>
         <select name="system.category" data-dtype="String">
-            {{#select system.category}}
-            {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.shadowampCategories}}
-            {{/select}}
+            {{selectOptions ENUMS.shadowampCategories selected=system.category labelAttr="labelkey" localize=true blank=''}}
         </select>
       </div>
       <div class="form-group">
         <label for="system.capacity">{{localize 'ANARCHY.item.shadowamp.capacity'}} </label>
         <select name="system.capacity" data-dtype="String">
-            {{#select system.capacity}}
-            {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.capacities}}
-            {{/select}}
+            {{selectOptions ENUMS.capacities selected=system.capacity labelAttr="labelkey" localize=true blank=''}}
         </select>
       </div>
       <div class="form-group">

--- a/templates/item/skill.hbs
+++ b/templates/item/skill.hbs
@@ -25,9 +25,7 @@
     <div class="form-group">
       <label for="system.attribute">{{localize 'ANARCHY.item.skill.attribute'}} </label>
       <select class="item-field-value" name="system.attribute" data-dtype="String">
-        {{#select system.attribute}}
-        {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.attributes}}
-        {{/select}}
+        {{selectOptions ENUMS.attributes selected=system.attribute labelAttr="labelkey" localize=true blank=''}}
       </select>
     </div>
     <div class="form-group">

--- a/templates/item/weapon.hbs
+++ b/templates/item/weapon.hbs
@@ -23,23 +23,17 @@
         <div class="form-group">
           <label for="system.weaponCategory">{{localize 'ANARCHY.item.mechWeapon.category'}}</label>
           <select name="system.weaponCategory">
-            {{#select system.weaponCategory}}
-              {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.mwdWeaponCategories}}
-            {{/select}}
+            {{selectOptions ENUMS.mwdWeaponCategories selected=system.weaponCategory labelAttr="labelkey" localize=true blank=''}}
           </select>
         </div>
         <div class="form-group">
           <label>{{localize 'ANARCHY.item.mechWeapon.hardpoint'}}</label>
           <div class="flexrow">
             <select name="system.hardpointType">
-              {{#select system.hardpointType}}
-                {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.mwdHardpointTypes}}
-              {{/select}}
+              {{selectOptions ENUMS.mwdHardpointTypes selected=system.hardpointType labelAttr="labelkey" localize=true blank=''}}
             </select>
             <select name="system.hardpointSize">
-              {{#select system.hardpointSize}}
-                {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.mwdHardpointSizes}}
-              {{/select}}
+              {{selectOptions ENUMS.mwdHardpointSizes selected=system.hardpointSize labelAttr="labelkey" localize=true blank=''}}
             </select>
           </div>
         </div>
@@ -50,9 +44,7 @@
         <div class="form-group">
           <label for="system.damageType">{{localize 'ANARCHY.item.mechWeapon.damageType'}}</label>
           <select name="system.damageType">
-            {{#select system.damageType}}
-              {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.mwdWeaponDamageTypes}}
-            {{/select}}
+            {{selectOptions ENUMS.mwdWeaponDamageTypes selected=system.damageType labelAttr="labelkey" localize=true blank=''}}
           </select>
         </div>
         <div class="form-group">
@@ -63,25 +55,19 @@
         <div class="form-group">
           <label for="system.skill">{{localize 'ANARCHY.item.personalWeapon.skill'}} </label>
           <select class="select-weapon-skill" name="system.skill" data-dtype="String">
-            {{#select system.skill}}
-            {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.skills}}
-            {{/select}}
+            {{selectOptions ENUMS.skills selected=system.skill labelAttr="label" localize=false}}
           </select>
         </div>
         <div class="form-group">
           <label for="system.weaponCategory">{{localize 'ANARCHY.item.personalWeapon.category'}}</label>
           <select name="system.weaponCategory">
-            {{#select system.weaponCategory}}
-              {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.mwdWeaponCategories}}
-            {{/select}}
+            {{selectOptions ENUMS.mwdWeaponCategories selected=system.weaponCategory labelAttr="labelkey" localize=true blank=''}}
           </select>
         </div>
         <div class="form-group">
           <label for="system.damageCategory">{{localize 'ANARCHY.item.personalWeapon.damageCategory'}}</label>
           <select name="system.damageCategory">
-            {{#select system.damageCategory}}
-              {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.personalWeaponDamageCategories}}
-            {{/select}}
+            {{selectOptions ENUMS.personalWeaponDamageCategories selected=system.damageCategory labelAttr="labelkey" localize=true blank=''}}
           </select>
         </div>
         <div class="form-group">
@@ -91,9 +77,7 @@
             {{#if (eq system.weaponCategory 'melee')}}
               <span>+
               <select name="system.damageAttribute" data-dtype="String">
-                  {{#select system.damageAttribute}}
-                  {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.attributes}}
-                  {{/select}}
+                  {{selectOptions ENUMS.attributes selected=system.damageAttribute labelAttr="labelkey" localize=true blank=''}}
               </select>
               /2</span>
             {{/if}}
@@ -102,9 +86,7 @@
         <div class="form-group">
           <label for="system.damageType">{{localize 'ANARCHY.item.personalWeapon.damageType'}}</label>
           <select name="system.damageType">
-            {{#select system.damageType}}
-              {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.personalWeaponDamageTypes}}
-            {{/select}}
+            {{selectOptions ENUMS.personalWeaponDamageTypes selected=system.damageType labelAttr="labelkey" localize=true blank=''}}
           </select>
         </div>
         <div class="form-group">
@@ -125,17 +107,13 @@
       <div class="form-group">
         <label for="system.area" >{{localize (concat 'ANARCHY.item.' type '.area')}} </label>
         <select name="system.area" data-dtype="String">
-          {{#select system.area}}
-          {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.areas}}
-          {{/select}}
+          {{selectOptions ENUMS.areas selected=system.area labelAttr="labelkey" localize=true blank=''}}
         </select>
       </div>
       <div class="form-group">
           <label for="system.range.max" >{{localize (concat 'ANARCHY.item.' type '.range.max')}} </label>
           <select name="system.range.max">
-            {{#select system.range.max}}
-            {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=ENUMS.ranges}}
-            {{/select}}
+            {{selectOptions ENUMS.ranges selected=system.range.max labelAttr="labelkey" localize=true blank=''}}
           </select>
       </div>
       {{#each (weaponRangeList system.range)}}

--- a/templates/roll/parts/select-attribute.hbs
+++ b/templates/roll/parts/select-attribute.hbs
@@ -1,9 +1,7 @@
 {{#if flags.editable}}
 <span class="parameter-label info-value">
   <select name="select-{{code}}" class="select-attribute-parameter info-value" data-dtype="String">
-    {{#select selected}}
-    {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=choices}}
-    {{/select}}
+    {{selectOptions choices selected=selected labelAttr="labelkey" localize=true blank=''}}
   </select>
 </span>
 {{else}}

--- a/templates/roll/parts/select-option.hbs
+++ b/templates/roll/parts/select-option.hbs
@@ -6,9 +6,7 @@
 {{#if flags.editable}}
 <span class="parameter-selection info-value">
   <select name="select-{{code}}" class="select-option-parameter info-value" data-dtype="String">
-    {{#select selected}}
-    {{> 'systems/mwd/templates/common/enum-value-label.hbs' entries=choices noEmpty=true}}
-    {{/select}}
+    {{selectOptions choices selected=selected labelAttr="labelkey" localize=true}}
   </select>
 </span>
 {{/if}}


### PR DESCRIPTION
## Summary
- replace deprecated `{{select}}` helper usages with `selectOptions` across weapon, shadowamp, and skill item templates
- update actor loadout, vehicle, and roll modifier templates to build selects without the deprecated helper while preserving localization
- refresh roll parameter selects to use `selectOptions` directly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d1dc1a114832d85287956b26b7d27)