### PR TITLE
Improve GM manager dialog sizing

### DIFF
--- a/style/anarchy.css
+++ b/style/anarchy.css
@@ -127,6 +127,9 @@ img.anarchy-img.item-img {
 
 #gm-manager {
   min-width: 300px;
+  max-width: min(480px, 95vw);
+  max-height: 85vh;
+  overflow: auto;
 }
 
 #gm-manager div.header {
@@ -140,8 +143,9 @@ img.anarchy-img.item-img {
   flex-direction: row;
   flex-wrap: wrap;
   width: 100%;
-  max-width: max-content;
+  max-width: 100%;
   align-items: flex-start;
+  gap: 4px;
 }
 
 #gm-manager div {


### PR DESCRIPTION
## Summary
- add viewport-aware max dimensions and scrolling to the GM manager window
- keep GM manager bars wrapping within the available width with spacing between controls

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d281ca994832d9d75838f6f29774a)