### PR TITLE
Introduce edge-based pools

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -103,6 +103,7 @@
         "attribute2": "Second attribute",
         "modifiers": {
           "edge": "Use edge",
+          "edgePool": "Spend from",
           "specialization": "Specialization",
           "poolModifiers": "Shadowamps",
           "social": {
@@ -190,8 +191,17 @@
       "characterNPCSheet": "NPC sheet",
       "actorName": "Name",
       "genre": "Genre",
-      "celebrity": "Celebrity",
+      "celebrity": "Legend",
       "famous": "Fame",
+      "edgePools": {
+        "title": "Edge Pools",
+        "grit": "Grit",
+        "insight": "Insight",
+        "rumor": "Rumor",
+        "legend": "Legend",
+        "credibility": "Credibility",
+        "chaos": "Chaos"
+      },
       "tabs": {
         "main": "Character",
         "equipment": "Equipment",
@@ -208,8 +218,16 @@
         "xpTotal": "Lifetime XP",
         "edge": "Edge",
         "anarchy": "Anarchy",
-        "sceneAnarchy": "Scene Anarchy",
+        "sceneAnarchy": "Chaos",
         "plot": "Plot",
+        "edgePools": {
+          "grit": "Grit",
+          "insight": "Insight",
+          "rumor": "Rumor",
+          "legend": "Legend",
+          "credibility": "Credibility",
+          "chaos": "Chaos"
+        },
         "social": {
           "credibility": "Credibility",
           "rumor": "Rumor"
@@ -223,6 +241,12 @@
         "armor": "Armor",
         "structure": "Structure",
         "heat": "Heat",
+        "grit": "Grit",
+        "insight": "Insight",
+        "rumor": "Rumor",
+        "legend": "Legend",
+        "credibility": "Credibility",
+        "chaos": "Chaos",
         "resistance": "Resistance"
       },
       "vehicle": {
@@ -653,10 +677,10 @@
         "effect": {
           "ignoreWounds": "Ignore wounds",
           "damageArmor": "Damage to armor",
-          "sceneAnarchy": "Scene Anarchy",
+          "sceneAnarchy": "Chaos",
           "locationAnarchy": "Location anarchy",
           "initiative": "Initiative bonus",
-          "celebrity": "Adjust celebrity"
+          "celebrity": "Adjust legend"
         },
         "category": {}
       },

--- a/src/modules/actor/character-actor.js
+++ b/src/modules/actor/character-actor.js
@@ -122,13 +122,13 @@ export class CharacterActor extends AnarchyBaseActor {
   }
 
   getCelebrityValue() {
-    return this.system.counters.social.celebrity.value;
+    return this.getEdgePoolValue(TEMPLATE.counters.social.legend);
   }
   getCredibilityValue() {
-    return this.system.counters.social.credibility.value;
+    return this.getEdgePoolValue(TEMPLATE.counters.social.credibility);
   }
   getRumorValue() {
-    return this.system.counters.social.rumor.value;
+    return this.getEdgePoolValue(TEMPLATE.counters.social.rumor);
   }
 
   getAnarchy() {
@@ -143,7 +143,7 @@ export class CharacterActor extends AnarchyBaseActor {
   }
 
   getAnarchyScene() {
-    return this.system.counters.sceneAnarchy.value ?? 0;
+    return this.getEdgePoolValue(TEMPLATE.counters.edgePools.chaos);
   }
 
   async spendAnarchy(count) {

--- a/src/modules/common/checkbars.js
+++ b/src/modules/common/checkbars.js
@@ -82,50 +82,75 @@ export const DEFAULT_CHECKBARS = {
     resource: COUNTERS.anarchy
   },
   sceneAnarchy: {
-    path: 'system.counters.sceneAnarchy.value',
+    path: 'system.counters.edgePools.chaos.value',
     monitor: it => {
-      const value = it.system.counters.sceneAnarchy.value;
-      return { value: value, max: 3 };
+      const value = it.system.counters.edgePools?.chaos?.value ?? 0;
+      const max = it.getAttributeValue(TEMPLATE.attributes.edge);
+      return { value: value, max: max };
     },
-    iconChecked: Icons.iconSystemPath('anarchy-point-scene.webp', 'checkbar-img'),
-    iconUnchecked: Icons.iconSystemPath('anarchy-point-off.webp', 'checkbar-img'),
-    resource: COUNTERS.sceneAnarchy
+    iconChecked: Icons.iconPath('systems/mwd/icons/default/explosion.svg', 'checkbar-img'),
+    iconUnchecked: Icons.iconPath('systems/mwd/icons/default/explosion.svg', 'checkbar-img'),
+    resource: COUNTERS.edgePools.chaos
   },
-  edge: {
-    path: 'system.counters.edge.value',
+  grit: {
+    path: 'system.counters.edgePools.grit.value',
     monitor: it => {
       return {
-        value: it.system.counters.edge.value,
+        value: it.system.counters.edgePools?.grit?.value ?? 0,
         max: it.getAttributeValue(TEMPLATE.attributes.edge)
       };
     },
-    iconChecked: Icons.fontAwesome('fas fa-star'),
-    iconUnchecked: Icons.fontAwesome('far fa-star'),
-    resource: COUNTERS.edge
+    iconChecked: Icons.iconPath('systems/mwd/icons/default/shield.svg', 'checkbar-img'),
+    iconUnchecked: Icons.iconPath('systems/mwd/icons/default/shield.svg', 'checkbar-img'),
+    resource: COUNTERS.edgePools.grit
+  },
+  insight: {
+    path: 'system.counters.edgePools.insight.value',
+    monitor: it => {
+      return {
+        value: it.system.counters.edgePools?.insight?.value ?? 0,
+        max: it.getAttributeValue(TEMPLATE.attributes.edge)
+      };
+    },
+    iconChecked: Icons.iconPath('systems/mwd/icons/default/eye.svg', 'checkbar-img'),
+    iconUnchecked: Icons.iconPath('systems/mwd/icons/default/eye.svg', 'checkbar-img'),
+    resource: COUNTERS.edgePools.insight
+  },
+  legend: {
+    path: 'system.counters.edgePools.legend.value',
+    monitor: it => {
+      return {
+        value: it.system.counters.edgePools?.legend?.value ?? 0,
+        max: it.getAttributeValue(TEMPLATE.attributes.edge)
+      };
+    },
+    iconChecked: Icons.iconPath('systems/mwd/icons/default/tower-flag.svg', 'checkbar-img'),
+    iconUnchecked: Icons.iconPath('systems/mwd/icons/default/tower-flag.svg', 'checkbar-img'),
+    resource: COUNTERS.edgePools.legend
   },
   credibility: {
-    path: 'system.counters.social.credibility.value',
+    path: 'system.counters.edgePools.credibility.value',
     monitor: it => {
       return {
-        value: it.system.counters.social.credibility.value,
-        max: it.system.counters.social.credibility.max
+        value: it.system.counters.edgePools?.credibility?.value ?? 0,
+        max: it.getAttributeValue(TEMPLATE.attributes.edge)
       };
     },
-    iconChecked: Icons.fontAwesome('fas fa-handshake'),
-    iconUnchecked: Icons.fontAwesome('far fa-handshake'),
-    resource: COUNTERS.social.credibility
+    iconChecked: Icons.iconPath('systems/mwd/icons/misc/hand.svg', 'checkbar-img'),
+    iconUnchecked: Icons.iconPath('systems/mwd/icons/misc/hand.svg', 'checkbar-img'),
+    resource: COUNTERS.edgePools.credibility
   },
   rumor: {
-    path: 'system.counters.social.rumor.value',
+    path: 'system.counters.edgePools.rumor.value',
     monitor: it => {
       return {
-        value: it.system.counters.social.rumor.value,
-        max: it.system.counters.social.rumor.max
+        value: it.system.counters.edgePools?.rumor?.value ?? 0,
+        max: it.getAttributeValue(TEMPLATE.attributes.edge)
       };
     },
-    iconChecked: Icons.fontAwesome('fas fa-grimace'),
-    iconUnchecked: Icons.fontAwesome('far fa-grimace'),
-    resource: COUNTERS.social.rumor
+    iconChecked: Icons.iconPath('systems/mwd/icons/default/mystery-man.svg', 'checkbar-img'),
+    iconUnchecked: Icons.iconPath('systems/mwd/icons/default/mystery-man.svg', 'checkbar-img'),
+    resource: COUNTERS.edgePools.rumor
   },
 }
 export const CHECKBARS = foundry.utils.mergeObject(DEFAULT_CHECKBARS, {});

--- a/src/modules/config.js
+++ b/src/modules/config.js
@@ -177,7 +177,7 @@ export const ANARCHY = {
         characterNPCSheet: 'ANARCHY.actor.characterNPCSheet',
         actorName: 'ANARCHY.actor.actorName',
         genre: 'ANARCHY.actor.genre',
-        celebrity: 'ANARCHY.actor.celebrity',
+        celebrity: 'ANARCHY.actor.counters.edgePools.legend',
         tabs: {
             main: 'ANARCHY.actor.tabs.main',
             equipment: 'ANARCHY.actor.tabs.equipment',
@@ -195,6 +195,15 @@ export const ANARCHY = {
             anarchy: 'ANARCHY.actor.counters.anarchy',
             sceneAnarchy: 'ANARCHY.actor.counters.sceneAnarchy',
             plot: 'ANARCHY.actor.counters.plot',
+            edgePools: {
+                title: 'ANARCHY.actor.counters.edgePools.title',
+                grit: 'ANARCHY.actor.counters.edgePools.grit',
+                insight: 'ANARCHY.actor.counters.edgePools.insight',
+                rumor: 'ANARCHY.actor.counters.edgePools.rumor',
+                legend: 'ANARCHY.actor.counters.edgePools.legend',
+                credibility: 'ANARCHY.actor.counters.edgePools.credibility',
+                chaos: 'ANARCHY.actor.counters.edgePools.chaos',
+            },
             social: {
                 credibility: 'ANARCHY.actor.counters.social.credibility',
                 rumor: 'ANARCHY.actor.counters.social.rumor',

--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -67,12 +67,21 @@ export const TEMPLATE = {
     sceneAnarchy: 'sceneAnarchy',
   },
   counters: {
-    edge: 'edge',
+    anarchy: 'anarchy',
+    edgePools: {
+      grit: 'grit',
+      insight: 'insight',
+      rumor: 'rumor',
+      legend: 'legend',
+      credibility: 'credibility',
+      chaos: 'chaos',
+    },
     social: {
-      celebrity: 'celebrity',
+      legend: 'legend',
       credibility: 'credibility',
       rumor: 'rumor'
-    }
+    },
+    chaos: 'chaos'
   },
   area: {
     none: 'none',

--- a/src/modules/dialog/roll-celebrity.js
+++ b/src/modules/dialog/roll-celebrity.js
@@ -13,7 +13,7 @@ export class RollCelebrity extends Dialog {
     const rollData = {
       actor: actor,
       celebrity: {
-        labelkey: ANARCHY.actor.celebrity,
+        labelkey: ANARCHY.actor.counters.edgePools.legend,
         value: actor.getCelebrityValue(),
       },
       modifiers: foundry.utils.mergeObject(

--- a/src/modules/handlebars-manager.js
+++ b/src/modules/handlebars-manager.js
@@ -20,6 +20,7 @@ const HBS_PARTIAL_TEMPLATES = [
   'systems/mwd/templates/monitors/social-rumor.hbs',
   'systems/mwd/templates/monitors/structure.hbs',
   'systems/mwd/templates/monitors/fatigue.hbs',
+  'systems/mwd/templates/monitors/edge-pool.hbs',
   'systems/mwd/templates/actor/character/name.hbs',
 
   // character

--- a/src/modules/migrations.js
+++ b/src/modules/migrations.js
@@ -525,6 +525,36 @@ class _13_3_3_SimplifyPersonalVehicles extends Migration {
   }
 }
 
+class _13_4_0_MigrateEdgePools extends Migration {
+  get version() { return '13.4.0' }
+  get code() { return 'edge-pools' }
+
+  async migrate() {
+    for (const actor of game.actors) {
+      if (actor.type !== TEMPLATE.actorTypes.character) {
+        continue;
+      }
+      const updates = {};
+      const pools = actor.system?.counters?.edgePools ?? {};
+      const oldSocial = actor.system?.counters?.social ?? {};
+      const edgeValue = actor.system?.counters?.edge?.value ?? pools?.grit?.value ?? 0;
+
+      updates['system.counters.edgePools.grit.value'] = pools?.grit?.value ?? edgeValue ?? 0;
+      updates['system.counters.edgePools.insight.value'] = pools?.insight?.value ?? 0;
+      updates['system.counters.edgePools.legend.value'] = pools?.legend?.value ?? oldSocial?.celebrity?.value ?? 0;
+      updates['system.counters.edgePools.credibility.value'] = pools?.credibility?.value ?? oldSocial?.credibility?.value ?? 0;
+      updates['system.counters.edgePools.rumor.value'] = pools?.rumor?.value ?? oldSocial?.rumor?.value ?? 0;
+      updates['system.counters.edgePools.chaos.value'] = pools?.chaos?.value ?? actor.system?.counters?.sceneAnarchy?.value ?? 0;
+
+      updates['system.counters.-=edge'] = null;
+      updates['system.counters.-=social'] = null;
+      updates['system.counters.-=sceneAnarchy'] = null;
+
+      await actor.update(updates);
+    }
+  }
+}
+
 export class Migrations {
   constructor() {
     HooksManager.register(ANARCHY_HOOKS.DECLARE_MIGRATIONS);
@@ -545,6 +575,7 @@ export class Migrations {
       new _13_2_2_AddMwdVehicleModel(),
       new _13_2_3_AddBattlemechLoadout(),
       new _13_3_3_SimplifyPersonalVehicles(),
+      new _13_4_0_MigrateEdgePools(),
     ));
 
     game.settings.register(SYSTEM_NAME, SYSTEM_MIGRATION_CURRENT_VERSION, {

--- a/src/modules/roll/roll-dialog.js
+++ b/src/modules/roll/roll-dialog.js
@@ -169,6 +169,10 @@ export class RollDialog extends Dialog {
       if (parameter.category == ROLL_PARAMETER_CATEGORY.pool) {
         await this._updateParameterValue(parameter, parameter.value)
       }
+      if (parameter.code == 'edge') {
+        this.html.find(`.parameter[data-parameter-code='${parameter.code}'] .edge-pool-select`)
+          .prop('disabled', !parameter.used);
+      }
     });
 
     this.activateDiceParameterClick();
@@ -184,6 +188,11 @@ export class RollDialog extends Dialog {
       const selected = event.currentTarget.value;
       const value = Number.parseInt(selected);
       await this._setParameterSelectedOption(parameter, selected, value);
+    });
+
+    this.html.find('.edge-pool-select').change(async event => {
+      const parameter = this._getRollParameter(event);
+      parameter.pool = event.currentTarget.value;
     });
   }
 

--- a/src/modules/roll/roll-parameters.js
+++ b/src/modules/roll/roll-parameters.js
@@ -121,7 +121,7 @@ const DEFAULT_ROLL_PARAMETERS = [
     factory: context => {
       return {
         min: 0,
-        max: Math.min(context.actor.getCredibilityValue(), 3),
+        max: context.actor.getCredibilityValue(),
       }
     }
   },
@@ -241,7 +241,12 @@ const DEFAULT_ROLL_PARAMETERS = [
       hbsTemplateChat: `${TEMPLATES_PATH}/chat/parts/glitch.hbs`,
       min: 0, max: 1,
     },
-    condition: context => context.skill?.system.isSocial && context.actor.getRumorValue() > 0
+    condition: context => context.skill?.system.isSocial && context.actor.getRumorValue() > 0,
+    factory: context => {
+      return {
+        max: context.actor.getRumorValue()
+      }
+    }
   },
   // rerolls
   {
@@ -342,6 +347,30 @@ const DEFAULT_ROLL_PARAMETERS = [
       p.used = checked;
       p.value = checked ? 1 : 0;
     },
+    factory: context => {
+      const pools = context.actor.getEdgePools();
+      const poolOrder = [
+        TEMPLATE.counters.edgePools.grit,
+        TEMPLATE.counters.edgePools.insight,
+        TEMPLATE.counters.edgePools.rumor,
+        TEMPLATE.counters.edgePools.legend,
+        TEMPLATE.counters.edgePools.credibility,
+        TEMPLATE.counters.edgePools.chaos,
+      ];
+      const edgePools = poolOrder.map(code => {
+        const value = pools?.[code]?.value ?? 0;
+        return {
+          code: code,
+          label: ANARCHY.actor.counters.edgePools[code] ?? code,
+          value: value
+        }
+      });
+      const availablePool = edgePools.find(it => it.value > 0)?.code ?? TEMPLATE.counters.edgePools.grit;
+      return {
+        edgePools: edgePools,
+        pool: availablePool,
+      };
+    }
   },
   // reduce opponent pool
   {

--- a/style/anarchy-dark.css
+++ b/style/anarchy-dark.css
@@ -245,9 +245,12 @@
   color: var(--dark-color-controls-disconnected);
 }
 
-.style-dark :is(div.checkbar-root[data-monitor-code='edge'],
+.style-dark :is(div.checkbar-root[data-monitor-code='grit'],
+  div.checkbar-root[data-monitor-code='insight'],
+  div.checkbar-root[data-monitor-code='legend'],
   div.checkbar-root[data-monitor-code='credibility'],
-  div.checkbar-root[data-monitor-code='rumor']) a.click-checkbar-element[data-checked=true] i {
+  div.checkbar-root[data-monitor-code='rumor'],
+  div.checkbar-root[data-monitor-code='chaos']) a.click-checkbar-element[data-checked=true] i {
   color: var(--dark-color-resource-checked);
 }
 
@@ -257,6 +260,16 @@
 
 .style-dark a.click-checkbar-element[data-checked=false] i {
   color: var(--dark-color-unchecked);
+}
+
+.style-dark a.click-checkbar-element[data-checked="false"] img.checkbar-img {
+  filter: grayscale(100%);
+  opacity: 0.5;
+}
+
+.style-dark a.click-checkbar-element[data-checked="true"] img.checkbar-img {
+  filter: none;
+  opacity: 1;
 }
 
 .style-dark .roll-dialog div.roll-parameters div.parameter :is(select, input) {

--- a/style/anarchy-darkglass.css
+++ b/style/anarchy-darkglass.css
@@ -314,9 +314,12 @@
   color: var(--darkglass-color-controls-disconnected);
 }
 
-.style-darkglass :is(div.checkbar-root[data-monitor-code='edge'],
+.style-darkglass :is(div.checkbar-root[data-monitor-code='grit'],
+  div.checkbar-root[data-monitor-code='insight'],
+  div.checkbar-root[data-monitor-code='legend'],
   div.checkbar-root[data-monitor-code='credibility'],
-  div.checkbar-root[data-monitor-code='rumor']) a.click-checkbar-element[data-checked=true] i {
+  div.checkbar-root[data-monitor-code='rumor'],
+  div.checkbar-root[data-monitor-code='chaos']) a.click-checkbar-element[data-checked=true] i {
   color: var(--darkglass-color-resource-checked);
 }
 
@@ -326,6 +329,16 @@
 
 .style-darkglass a.click-checkbar-element[data-checked=false] i {
   color: var(--darkglass-color-unchecked);
+}
+
+.style-darkglass a.click-checkbar-element[data-checked="false"] img.checkbar-img {
+  filter: grayscale(100%);
+  opacity: 0.5;
+}
+
+.style-darkglass a.click-checkbar-element[data-checked="true"] img.checkbar-img {
+  filter: none;
+  opacity: 1;
 }
 
 .style-darkglass .roll-dialog div.roll-parameters div.parameter :is(select, input) {

--- a/style/anarchy-shadowrun.css
+++ b/style/anarchy-shadowrun.css
@@ -234,9 +234,12 @@
   color: var(--anarchy-color-controls-disconnected);
 }
 
-.style-anarchy-shadowrun :is(div.checkbar-root[data-monitor-code='edge'],
+.style-anarchy-shadowrun :is(div.checkbar-root[data-monitor-code='grit'],
+  div.checkbar-root[data-monitor-code='insight'],
+  div.checkbar-root[data-monitor-code='legend'],
   div.checkbar-root[data-monitor-code='credibility'],
-  div.checkbar-root[data-monitor-code='rumor']) a.click-checkbar-element[data-checked=true] i {
+  div.checkbar-root[data-monitor-code='rumor'],
+  div.checkbar-root[data-monitor-code='chaos']) a.click-checkbar-element[data-checked=true] i {
   color: var(--anarchy-color-resource-checked);
 }
 
@@ -246,6 +249,16 @@
 
 .style-anarchy-shadowrun a.click-checkbar-element[data-checked=false] i {
   color: var(--anarchy-color-unchecked);
+}
+
+.style-anarchy-shadowrun a.click-checkbar-element[data-checked="false"] img.checkbar-img {
+  filter: grayscale(100%);
+  opacity: 0.5;
+}
+
+.style-anarchy-shadowrun a.click-checkbar-element[data-checked="true"] img.checkbar-img {
+  filter: none;
+  opacity: 1;
 }
 
 .style-anarchy-shadowrun .roll-dialog div.roll-parameters div.parameter :is(select, input):disabled {

--- a/style/anarchy.css
+++ b/style/anarchy.css
@@ -405,6 +405,16 @@ img.checkbar-img:active {
   top: 1px;
 }
 
+a.click-checkbar-element[data-checked="false"] img.checkbar-img {
+  filter: grayscale(100%);
+  opacity: 0.5;
+}
+
+a.click-checkbar-element[data-checked="true"] img.checkbar-img {
+  filter: none;
+  opacity: 1;
+}
+
 :is(.actor-character, .item-sheet) nav.sheet-tabs {
   flex-flow: nowrap;
   font-size: 0.65rem;
@@ -901,9 +911,12 @@ div.risk-glitch.risk-glitch-prowess {
   background: var(--border-medium);
 }
 
-:is(div.checkbar-root[data-monitor-code='edge'],
+:is(div.checkbar-root[data-monitor-code='grit'],
+  div.checkbar-root[data-monitor-code='insight'],
+  div.checkbar-root[data-monitor-code='legend'],
   div.checkbar-root[data-monitor-code='credibility'],
-  div.checkbar-root[data-monitor-code='rumor']) a.click-checkbar-element[data-checked=true] i {
+  div.checkbar-root[data-monitor-code='rumor'],
+  div.checkbar-root[data-monitor-code='chaos']) a.click-checkbar-element[data-checked=true] i {
   color: orange;
 }
 

--- a/system.json
+++ b/system.json
@@ -1,6 +1,6 @@
 {
   "id": "mwd",
-  "version": "13.3.4",
+  "version": "13.4.0",
   "manifest": "https://raw.githubusercontent.com/acemb-rso/MWD/main/system.json",
   "download": "https://github.com/acemb-rso/MWD/archive/refs/heads/main.zip",
   "url": "https://github.com/acemb-rso/MWD",

--- a/template.json
+++ b/template.json
@@ -71,8 +71,13 @@
           }
         },
         "counters": {
-          "edge": {
-            "value": 1
+          "edgePools": {
+            "grit": { "value": 1 },
+            "insight": { "value": 0 },
+            "rumor": { "value": 0 },
+            "legend": { "value": 0 },
+            "credibility": { "value": 0 },
+            "chaos": { "value": 0 }
           }
         }
       },
@@ -222,22 +227,13 @@
           "value": 3,
           "max": 6
         },
-        "sceneAnarchy": {
-          "value": 0,
-          "max": 3
-        },
-        "social": {
-          "celebrity": {
-            "value": 0
-          },
-          "credibility": {
-            "value": 0,
-            "max": 1
-          },
-          "rumor": {
-            "value": 0,
-            "max": 1
-          }
+        "edgePools": {
+          "grit": { "value": 1 },
+          "insight": { "value": 0 },
+          "rumor": { "value": 0 },
+          "legend": { "value": 0 },
+          "credibility": { "value": 0 },
+          "chaos": { "value": 0 }
         }
       },
       "style": "",

--- a/templates/actor/character-enhanced/anarchy-actor.hbs
+++ b/templates/actor/character-enhanced/anarchy-actor.hbs
@@ -19,5 +19,5 @@
       labelkey='ANARCHY.actor.counters.sceneAnarchy'
       rowlength=6
       value=anarchy.scene
-      max=anarchy.scene
+      max=(actorAttribute 'edge' @root.actor)
   }}

--- a/templates/actor/character-enhanced/edge.hbs
+++ b/templates/actor/character-enhanced/edge.hbs
@@ -1,10 +1,10 @@
 <label class="title">
-  {{localize (concat 'ANARCHY.actor.counters.edge')}}
+  {{localize (concat 'ANARCHY.actor.counters.edgePools.grit')}}
 </label>
 {{> "systems/mwd/templates/common/checkbar.hbs"
-  code='edge'
-  labelkey='ANARCHY.actor.counters.edge'
-  value=system.counters.edge.value
+  code='grit'
+  labelkey='ANARCHY.actor.counters.edgePools.grit'
+  value=system.counters.edgePools.grit.value
   max=(actorAttribute 'edge' @root.actor)
   rowlength=6
 }}

--- a/templates/actor/character-enhanced/monitors.hbs
+++ b/templates/actor/character-enhanced/monitors.hbs
@@ -23,24 +23,42 @@
                     {{>
                     "systems/mwd/templates/actor/character-enhanced/hexabox.hbs"}}
                     <div class="content">
-                        {{>
-                        "systems/mwd/templates/actor/character-enhanced/edge.hbs"}}
+                        {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='grit'}}
+                    </div>
+                </div>
+                <div class="edge wrapper-hexabox">
+                    {{>
+                    "systems/mwd/templates/actor/character-enhanced/hexabox.hbs"}}
+                    <div class="content">
+                        {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='insight'}}
                     </div>
                 </div>
                 <div class="credibility wrapper-hexabox">
                     {{>
                     "systems/mwd/templates/actor/character-enhanced/hexabox.hbs"}}
                     <div class="content">
-                        {{>
-                        "systems/mwd/templates/actor/character-enhanced/social-credibility.hbs"}}
+                        {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='legend'}}
+                    </div>
+                </div>
+                <div class="credibility wrapper-hexabox">
+                    {{>
+                    "systems/mwd/templates/actor/character-enhanced/hexabox.hbs"}}
+                    <div class="content">
+                        {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='credibility'}}
                     </div>
                 </div>
                 <div class="rumors wrapper-hexabox">
                     {{>
                     "systems/mwd/templates/actor/character-enhanced/hexabox.hbs"}}
                     <div class="content">
-                        {{>
-                        "systems/mwd/templates/actor/character-enhanced/social-rumor.hbs"}}
+                        {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='rumor'}}
+                    </div>
+                </div>
+                <div class="rumors wrapper-hexabox">
+                    {{>
+                    "systems/mwd/templates/actor/character-enhanced/hexabox.hbs"}}
+                    <div class="content">
+                        {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='chaos'}}
                     </div>
                 </div>
             </div>

--- a/templates/actor/character-enhanced/social-credibility.hbs
+++ b/templates/actor/character-enhanced/social-credibility.hbs
@@ -1,10 +1,10 @@
   <label class="title">
-    {{localize ANARCHY.actor.counters.social.credibility}}
+    {{localize ANARCHY.actor.counters.edgePools.credibility}}
   </label>
   {{> "systems/mwd/templates/actor/character-enhanced/checkbar.hbs"
     code='credibility'
-    labelkey=ANARCHY.actor.counters.social.credibility
-    value=system.counters.social.credibility.value
-    max=system.counters.social.credibility.max
+    labelkey=ANARCHY.actor.counters.edgePools.credibility
+    value=system.counters.edgePools.credibility.value
+    max=(actorAttribute 'edge' @root.actor)
     rowlength=5
   }}

--- a/templates/actor/character-enhanced/social-rumor.hbs
+++ b/templates/actor/character-enhanced/social-rumor.hbs
@@ -1,10 +1,10 @@
   <label class="title">
-    {{localize ANARCHY.actor.counters.social.rumor}}
+    {{localize ANARCHY.actor.counters.edgePools.rumor}}
   </label>
   {{> "systems/mwd/templates/common/checkbar.hbs"
     code='rumor'
-    labelkey=ANARCHY.actor.counters.social.rumor
-    value=system.counters.social.rumor.value
-    max=system.counters.social.rumor.max
+    labelkey=ANARCHY.actor.counters.edgePools.rumor
+    value=system.counters.edgePools.rumor.value
+    max=(actorAttribute 'edge' @root.actor)
     rowlength=5
   }}

--- a/templates/actor/character-enhanced/story.hbs
+++ b/templates/actor/character-enhanced/story.hbs
@@ -12,51 +12,6 @@
       class="section-story {{actorTabClosed actor._id 'story'}}">
       {{#unless options.limited}}
       <div class="social-info">
-        <div class="credibility wrapper-hexabox">
-          {{> "systems/mwd/templates/actor/character-enhanced/hexabox.hbs"}}
-          <div class="content">
-            <div class="title">
-              {{localize 'ANARCHY.actor.famous'}}
-            </div>
-            <div class="celeb-table">
-              <div>
-                <label>
-                  {{localize ANARCHY.actor.celebrity}}
-                </label>
-                <div class="input">
-                  <input {{#if @root.options.viewMode}}disabled{{/if}} class="info-value" type="number" data-dtype="Number"
-                    name="system.counters.social.celebrity.value"
-                    data-counter-social="celebrity"
-                    value="{{system.counters.social.celebrity.value}}" />
-                </div>
-              </div>
-              <div>
-                <label>
-                  {{localize ANARCHY.actor.counters.social.credibility}}
-                </label>
-                <div class="input">
-                  <input {{#if @root.options.viewMode}}disabled{{/if}} class="info-value"
-                    type="number" data-dtype="Number" min="0" max="10"
-                    name="system.counters.social.credibility.max"
-                    data-counter-social="credibility"
-                    value="{{system.counters.social.credibility.max}}" />
-                </div>
-              </div>
-              <div>
-                <label>
-                  {{localize ANARCHY.actor.counters.social.rumor}}
-                </label>
-                <div class="input">
-                  <input {{#if @root.options.viewMode}}disabled{{/if}} class="info-value"
-                    type="number" data-dtype="Number" min="0" max="10"
-                    name="system.counters.social.rumor.max"
-                    data-counter-social="rumor"
-                    value="{{system.counters.social.rumor.max}}" />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
         <div class="karma wrapper-hexabox">
           {{> "systems/mwd/templates/actor/character-enhanced/hexabox.hbs"}}
           <div class="content">

--- a/templates/actor/character-tabbed.hbs
+++ b/templates/actor/character-tabbed.hbs
@@ -66,8 +66,17 @@
   <section class="sheet-body">
     <div class="tab" data-group="primary" data-tab="main">
       <div class="section-group monitors-row">
-        <div class="anarchy-block">
-          {{> "systems/mwd/templates/monitors/edge.hbs"}}
+        <div class="anarchy-block flexcol edge-pools">
+          {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='grit'}}
+          {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='insight'}}
+        </div>
+        <div class="anarchy-block flexcol edge-pools">
+          {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='rumor'}}
+          {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='legend'}}
+        </div>
+        <div class="anarchy-block flexcol edge-pools">
+          {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='credibility'}}
+          {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='chaos'}}
         </div>
         <div class="anarchy-block anarchy-bar">
           {{> "systems/mwd/templates/monitors/anarchy-actor.hbs"}}
@@ -113,12 +122,6 @@
       </div>
     </div>
     <div class="tab" data-group="primary" data-tab="biography">
-      <div class="section-group monitors-row">
-        {{> "systems/mwd/templates/actor/character/social-celebrity.hbs"}}
-        {{> "systems/mwd/templates/monitors/social-credibility.hbs"}}
-        {{> "systems/mwd/templates/monitors/social-rumor.hbs"}}
-      </div>
-
       <div class="section-group items-group">
       {{> "systems/mwd/templates/actor/parts/contacts.hbs"}}
       </div>

--- a/templates/actor/character.hbs
+++ b/templates/actor/character.hbs
@@ -73,8 +73,19 @@
       <div class="anarchy-block">
         {{> "systems/mwd/templates/monitors/fatigue.hbs"}}
       </div>
+      <div class="anarchy-block flexcol edge-pools">
+        {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='grit'}}
+        {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='insight'}}
+      </div>
+      <div class="anarchy-block flexcol edge-pools">
+        {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='rumor'}}
+        {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='legend'}}
+      </div>
+      <div class="anarchy-block flexcol edge-pools">
+        {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='credibility'}}
+        {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='chaos'}}
+      </div>
       <div class="anarchy-block flexcol">
-        {{> "systems/mwd/templates/monitors/edge.hbs"}}
         {{> "systems/mwd/templates/monitors/anarchy-actor.hbs"}}
       </div>
     </div>
@@ -90,9 +101,6 @@
       {{> "systems/mwd/templates/actor/parts/contacts.hbs"}}
       </div>
       <div class="items-group third-width">
-      {{> "systems/mwd/templates/actor/character/social-celebrity.hbs"}}
-      {{> "systems/mwd/templates/monitors/social-credibility.hbs"}}
-      {{> "systems/mwd/templates/monitors/social-rumor.hbs"}}
       </div>
     </div>
 

--- a/templates/actor/character/social-celebrity.hbs
+++ b/templates/actor/character/social-celebrity.hbs
@@ -2,13 +2,13 @@
   <label>
     <a class="click-celebrity-roll">
       <label class="info-label">
-          {{localize ANARCHY.actor.celebrity}}
+          {{localize ANARCHY.actor.counters.edgePools.legend}}
       </label>
     </a>
-    <input class="info-value" type="number" data-dtype="Number" 
-      name="system.counters.social.celebrity.value"
+    <input class="info-value" type="number" data-dtype="Number"
+      name="system.counters.edgePools.legend.value"
       data-counter-social="celebrity"
-      value="{{system.counters.social.celebrity.value}}"
+      value="{{system.counters.edgePools.legend.value}}"
       {{#if @root.options.viewMode}}disabled{{/if}}
       />
   </label>

--- a/templates/actor/npc-sheet.hbs
+++ b/templates/actor/npc-sheet.hbs
@@ -38,16 +38,27 @@
     <div class="section-group monitors-row">
       <div class="anarchy-block flexcol">
         {{> "systems/mwd/templates/monitors/armor.hbs"}}
-        <div class="anarchy-block flexrow">
-          {{> "systems/mwd/templates/monitors/edge.hbs"}}
-          {{> "systems/mwd/templates/monitors/anarchy-actor.hbs"}}
-        </div>
       </div>
       <div class="anarchy-block flexrow">
         {{> "systems/mwd/templates/monitors/physical.hbs"}}
       </div>
       <div class="anarchy-block flexrow">
         {{> "systems/mwd/templates/monitors/fatigue.hbs"}}
+      </div>
+      <div class="anarchy-block flexcol edge-pools">
+        {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='grit'}}
+        {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='insight'}}
+      </div>
+      <div class="anarchy-block flexcol edge-pools">
+        {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='rumor'}}
+        {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='legend'}}
+      </div>
+      <div class="anarchy-block flexcol edge-pools">
+        {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='credibility'}}
+        {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='chaos'}}
+      </div>
+      <div class="anarchy-block flexcol">
+        {{> "systems/mwd/templates/monitors/anarchy-actor.hbs"}}
       </div>
     </div>
 

--- a/templates/chat/celebrity-roll.hbs
+++ b/templates/chat/celebrity-roll.hbs
@@ -4,7 +4,7 @@
   </div>
   <div>
     <h3 class="chat-roll-title tooltip tooltip-dotted">
-      {{actor.name}} - {{localize ANARCHY.actor.celebrity}}: {{pool}}
+      {{actor.name}} - {{localize ANARCHY.actor.counters.edgePools.legend}}: {{pool}}
       <div class="tooltiptext tooltip-roll-parameters">
         {{#each parameters as |parameter|}}
           <div class="parameter">

--- a/templates/dialog/roll-celebrite-title.hbs
+++ b/templates/dialog/roll-celebrite-title.hbs
@@ -1,1 +1,1 @@
-{{actor.name}}: {{localize ANARCHY.actor.celebrity}}
+{{actor.name}}: {{localize ANARCHY.actor.counters.edgePools.legend}}

--- a/templates/monitors/anarchy-actor.hbs
+++ b/templates/monitors/anarchy-actor.hbs
@@ -21,7 +21,7 @@
       labelkey='ANARCHY.actor.counters.sceneAnarchy'
       rowlength=6
       value=anarchy.scene
-      max=anarchy.scene
+      max=(actorAttribute 'edge' @root.actor)
   }}
 </div>
 {{/if}}

--- a/templates/monitors/edge-pool.hbs
+++ b/templates/monitors/edge-pool.hbs
@@ -1,0 +1,14 @@
+<div class="flexcol edge-pool anarchy-monitor">
+  <label class="info-label">
+    {{localize (concat 'ANARCHY.actor.counters.edgePools.' code)}}
+  </label>
+  {{#with (lookup system.counters.edgePools code) as |pool|}}
+    {{> "systems/mwd/templates/common/checkbar.hbs"
+      code=code
+      labelkey=(concat 'ANARCHY.actor.counters.edgePools.' code)
+      value=pool.value
+      max=(actorAttribute 'edge' @root.actor)
+      rowlength=6
+    }}
+  {{/with}}
+</div>

--- a/templates/monitors/edge.hbs
+++ b/templates/monitors/edge.hbs
@@ -1,11 +1,11 @@
 <div class="flexcol anarchy-monitor">
   <label class="info-label">
-    {{localize (concat 'ANARCHY.actor.counters.edge')}}
+    {{localize (concat 'ANARCHY.actor.counters.edgePools.grit')}}
   </label>
   {{> "systems/mwd/templates/common/checkbar.hbs"
-    code='edge'
-    labelkey='ANARCHY.actor.counters.edge'
-    value=system.counters.edge.value
+    code='grit'
+    labelkey='ANARCHY.actor.counters.edgePools.grit'
+    value=system.counters.edgePools.grit.value
     max=(actorAttribute 'edge' @root.actor)
     rowlength=6
   }}

--- a/templates/monitors/social-credibility.hbs
+++ b/templates/monitors/social-credibility.hbs
@@ -1,19 +1,12 @@
 <div class="flexcol anarchy-monitor">
   <label class="monitor-label">
-    {{localize ANARCHY.actor.counters.social.credibility}}
-    <input class="info-value"
-      type="number" data-dtype="Number" min="0" max="10"
-      name="system.counters.social.credibility.max"
-      data-counter-social="credibility"
-      value="{{system.counters.social.credibility.max}}"
-      {{#if @root.options.viewMode}}disabled{{/if}}
-      />
+    {{localize ANARCHY.actor.counters.edgePools.credibility}}
   </label>
   {{> "systems/mwd/templates/common/checkbar.hbs"
     code='credibility'
-    labelkey=ANARCHY.actor.counters.social.credibility
-    value=system.counters.social.credibility.value
-    max=system.counters.social.credibility.max
+    labelkey=ANARCHY.actor.counters.edgePools.credibility
+    value=system.counters.edgePools.credibility.value
+    max=(actorAttribute 'edge' @root.actor)
     rowlength=5
   }}
 </div>

--- a/templates/monitors/social-rumor.hbs
+++ b/templates/monitors/social-rumor.hbs
@@ -1,19 +1,12 @@
 <div class="flexcol anarchy-monitor">
   <label class="monitor-label">
-    {{localize ANARCHY.actor.counters.social.rumor}}
-    <input class="info-value"
-      type="number" data-dtype="Number" min="0" max="10"
-      name="system.counters.social.rumor.max"
-      data-counter-social="rumor"
-      value="{{system.counters.social.rumor.max}}"
-      {{#if @root.options.viewMode}}disabled{{/if}}
-      />
+    {{localize ANARCHY.actor.counters.edgePools.rumor}}
   </label>
   {{> "systems/mwd/templates/common/checkbar.hbs"
     code='rumor'
-    labelkey=ANARCHY.actor.counters.social.rumor
-    value=system.counters.social.rumor.value
-    max=system.counters.social.rumor.max
+    labelkey=ANARCHY.actor.counters.edgePools.rumor
+    value=system.counters.edgePools.rumor.value
+    max=(actorAttribute 'edge' @root.actor)
     rowlength=5
   }}
 </div>

--- a/templates/roll/parts/check-option.hbs
+++ b/templates/roll/parts/check-option.hbs
@@ -18,3 +18,15 @@
 {{else}}
   <label class="parameter-value info-value"></label>
 {{/if}}
+{{#if edgePools}}
+<span class="flexrow edge-pool-select-row">
+  <label class="parameter-label info-label">{{localize 'ANARCHY.common.roll.modifiers.edgePool'}}</label>
+  <select class="edge-pool-select info-value" {{#unless used}}disabled{{/unless}}>
+    {{#each edgePools}}
+      <option value="{{code}}" {{#if (eq ../pool code)}}selected{{/if}} {{#unless value}}disabled{{/unless}}>
+        {{localize label}} ({{value}})
+      </option>
+    {{/each}}
+  </select>
+</span>
+{{/if}}


### PR DESCRIPTION
## Summary
- add dedicated edge-based pools (Grit, Insight, Rumor, Legend, Credibility, Chaos) to character monitors with themed icons and shared Edge limits
- update roll handling to select a specific pool when spending edge and migrate existing resources into the new structure
- refresh translations, styling, and templates across sheet variants to surface the new pools and retire the old fame/scene anarchy trackers

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d2e4b9d74832db725d9430e21b1da)