### PR TITLE
Fix personal weapon labels using correct localization keys

### DIFF
--- a/src/modules/config.js
+++ b/src/modules/config.js
@@ -504,16 +504,16 @@ export const ANARCHY = {
             none: 'ANARCHY.mwd.weapon.damageType.none'
         },
         personalDamageType: {
-            energy: 'ANARCHY.personal.weapon.damageType.energy',
-            kinetic: 'ANARCHY.personal.weapon.damageType.kinetic',
-            explosive: 'ANARCHY.personal.weapon.damageType.explosive',
-            plasma: 'ANARCHY.personal.weapon.damageType.plasma',
-            corrosive: 'ANARCHY.personal.weapon.damageType.corrosive',
-            poison: 'ANARCHY.personal.weapon.damageType.poison'
+            energy: 'ANARCHY.mwd.personalWeapon.damageType.energy',
+            kinetic: 'ANARCHY.mwd.personalWeapon.damageType.kinetic',
+            explosive: 'ANARCHY.mwd.personalWeapon.damageType.explosive',
+            plasma: 'ANARCHY.mwd.personalWeapon.damageType.plasma',
+            corrosive: 'ANARCHY.mwd.personalWeapon.damageType.corrosive',
+            poison: 'ANARCHY.mwd.personalWeapon.damageType.poison'
         },
         personalDamageCategory: {
-            physical: 'ANARCHY.personal.weapon.damageCategory.physical',
-            fatigue: 'ANARCHY.personal.weapon.damageCategory.fatigue'
+            physical: 'ANARCHY.mwd.personalWeapon.damageCategory.physical',
+            fatigue: 'ANARCHY.mwd.personalWeapon.damageCategory.fatigue'
         },
         meleeLocation: {
             head: 'ANARCHY.mwd.melee.location.head',


### PR DESCRIPTION
## Summary
- update personal weapon damage type and category localization keys so personal weapon sheets show translated friendly labels

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d33e0ec6c832da89b779cd480de04)