### PR TITLE
Address Foundry V13 deprecations

### DIFF
--- a/src/modules/actor/anarchy-actor-sheet.js
+++ b/src/modules/actor/anarchy-actor-sheet.js
@@ -5,7 +5,7 @@ import { Misc } from "../misc.js";
 import { Enums } from "../enums.js";
 import { SelectActor } from "../dialog/select-actor.js";
 
-export class AnarchyActorSheet extends foundry.appv1.sheets.ActorSheet {
+export class AnarchyActorSheet extends foundry.applications.sheets.ActorSheet {
 
   get template() {
     return `${TEMPLATES_PATH}/actor/${this.actor.type}.hbs`;

--- a/src/modules/chat/chat-manager.js
+++ b/src/modules/chat/chat-manager.js
@@ -21,7 +21,7 @@ const CHAT_MESSAGE_BUTTON_HANDLERS = [
 export class ChatManager {
 
   static async init() {
-    Hooks.on('renderChatMessage', async (app, html, msg) => await ChatManager.onRenderChatMessage(app, html, msg));
+    Hooks.on('renderChatMessageHTML', async (chatMessage, html) => await ChatManager.onRenderChatMessage(chatMessage, html));
 
     RemoteCall.register(CHAT_MANAGER_REMOVE_FAMILY, {
       callback: data => this.removeFamily(data),
@@ -34,8 +34,8 @@ export class ChatManager {
     });
   }
 
-  static async onRenderChatMessage(app, html, msg) {
-    const chatMessage = ChatManager.getChatMessageFromHtml(html);
+  static async onRenderChatMessage(chatMessage, htmlElement) {
+    const html = $(htmlElement);
     const showButtons = ChatManager.hasRight(chatMessage);
     CHAT_MESSAGE_BUTTON_HANDLERS.forEach(it => {
       const jQueryButtonSelector = html.find(it.selector);


### PR DESCRIPTION
## Summary
- update chat message render hook to use the supported `renderChatMessageHTML` callback
- move actor sheets to the Application V2 namespace to avoid deprecation warnings

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d3adad360832dba8aaa6d3215746e)