### PR TITLE
Add damage-type aware resistances

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -247,7 +247,26 @@
         "legend": "Legend",
         "credibility": "Credibility",
         "chaos": "Chaos",
-        "resistance": "Resistance"
+        "resistance": "Resistance",
+        "resistanceBase": "Base resistance",
+        "resistanceByType": "By damage type",
+        "resistanceByTypeButton": "Resist by type",
+        "resistanceByTypeTitle": "Type-specific resistance",
+        "resistanceBonusLabel": "Bonuses",
+        "resistanceTotal": "Total",
+        "resistanceFallback": "Falls back to base",
+        "damageType": "Damage type",
+        "resistancePresets": {
+          "label": "Presets",
+          "biological": "Biological",
+          "armoredVehicle": "Armored vehicle",
+          "energyShielded": "Energy shielded"
+        },
+        "resistanceApplied": "{actor} resisted {value} vs {damageType} on {monitor} ({source})",
+        "resistanceSources": {
+          "default": "base",
+          "type": "type-specific"
+        }
       },
       "vehicle": {
         "moves": "Moves",
@@ -670,7 +689,8 @@
         },
         "category": {
           "max": "Increased max",
-          "resistance": "Resistance"
+          "resistance": "Resistance",
+          "resistanceByType": "Damage-type resistance"
         }
       },
       "other": {

--- a/src/modules/actor/anarchy-actor-sheet.js
+++ b/src/modules/actor/anarchy-actor-sheet.js
@@ -4,6 +4,7 @@ import { ConfirmationDialog } from "../confirmation.js";
 import { Misc } from "../misc.js";
 import { Enums } from "../enums.js";
 import { SelectActor } from "../dialog/select-actor.js";
+import { ResistanceByTypeDialog } from "../dialog/resistance-by-type.js";
 
 export class AnarchyActorSheet extends foundry.applications.sheets.ActorSheet {
 
@@ -158,6 +159,12 @@ export class AnarchyActorSheet extends foundry.applications.sheets.ActorSheet {
       }
       this.actor.rollWeapon(weapon);
     });
+
+    html.find('.click-resistance-by-type').click(async event => {
+      event.stopPropagation();
+      const monitor = this.getEventMonitorCode(event);
+      await ResistanceByTypeDialog.show(this.actor, monitor);
+    });
   }
 
   getEventItemType(event) {
@@ -183,7 +190,7 @@ export class AnarchyActorSheet extends foundry.applications.sheets.ActorSheet {
   }
 
   getEventMonitorCode(event) {
-    return $(event.currentTarget).closest('.click-checkbar-element').attr('data-monitor-code');
+    return $(event.currentTarget).closest('[data-monitor-code]').attr('data-monitor-code');
   }
 
   getEventIndex(event) {

--- a/src/modules/combat/combat-manager.js
+++ b/src/modules/combat/combat-manager.js
@@ -124,7 +124,7 @@ export class CombatManager {
     const defender = this.getTokenActor(attack.defenderTokenId);
     const attackRoll = RollManager.inflateAnarchyRoll(attack.attackRoll);
     await ActorDamageManager.sufferDamage(defender,
-      attack.attack.damage.monitor,
+      attack.attack.damage,
       attack.attack.damage.value,
       attack.attack.success,
       attack.attack.damage.noArmor,

--- a/src/modules/config.js
+++ b/src/modules/config.js
@@ -563,6 +563,7 @@ export const ANARCHY = {
                 category: {
                     max: 'ANARCHY.modifier.monitor.category.max',
                     resistance: 'ANARCHY.modifier.monitor.category.resistance',
+                    resistanceByType: 'ANARCHY.modifier.monitor.category.resistanceByType',
                 }
         },
         other: {

--- a/src/modules/dialog/resistance-by-type.js
+++ b/src/modules/dialog/resistance-by-type.js
@@ -1,0 +1,135 @@
+import { TEMPLATES_PATH } from "../constants.js";
+import { ANARCHY } from "../config.js";
+import { Enums } from "../enums.js";
+import { AnarchyBaseActor } from "../actor/base-actor.js";
+
+const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
+
+const RESISTANCE_PRESETS = [
+  { key: 'biological', label: 'ANARCHY.actor.monitors.resistancePresets.biological', values: { poison: 2, corrosive: 1 } },
+  { key: 'armoredVehicle', label: 'ANARCHY.actor.monitors.resistancePresets.armoredVehicle', values: { kinetic: 1, explosive: 2 } },
+  { key: 'energyShielded', label: 'ANARCHY.actor.monitors.resistancePresets.energyShielded', values: { energy: 2, plasma: 1 } },
+];
+
+export class ResistanceByTypeDialog extends HandlebarsApplicationMixin(ApplicationV2) {
+
+  static get DEFAULT_OPTIONS() {
+    return foundry.utils.mergeObject(super.DEFAULT_OPTIONS, {
+      id: "resistance-by-type",
+      classes: ["anarchy-dialog", "resistance-by-type"],
+      position: { width: 480, height: "auto" },
+      window: {
+        resizable: true,
+      }
+    });
+  }
+
+  static PARTS = {
+    body: {
+      template: `${TEMPLATES_PATH}/dialog/resistance-by-type.hbs`
+    }
+  };
+
+  static async show(actor, monitor) {
+    const options = foundry.utils.mergeObject(ResistanceByTypeDialog.DEFAULT_OPTIONS, {
+      id: `${ResistanceByTypeDialog.DEFAULT_OPTIONS.id}-${foundry.utils.randomID()}`,
+      classes: [game.system.anarchy.styles.selectCssClass(), ...ResistanceByTypeDialog.DEFAULT_OPTIONS.classes],
+    }, { inplace: false });
+    const app = new ResistanceByTypeDialog(actor, monitor, options);
+    return app.render({ force: true });
+  }
+
+  constructor(actor, monitor, options) {
+    super(options);
+    this.actor = actor;
+    this.monitor = monitor;
+    this.damageTypes = Enums.getDamageTypes();
+  }
+
+  async _prepareContext() {
+    const monitorData = this.actor.system.monitors?.[this.monitor] ?? {};
+    const resistance = AnarchyBaseActor.normalizeResistance(monitorData.resistance);
+    const resistanceBonus = monitorData.resistanceBonus ?? 0;
+    const resistanceBonusByType = monitorData.resistanceBonusByType ?? {};
+    const rows = this.damageTypes.map(dt => {
+      const typedValue = resistance.byType?.[dt.value];
+      const source = typedValue !== undefined ? 'type' : 'default';
+      const value = typedValue ?? resistance.default ?? 0;
+      const typeBonus = resistanceBonusByType[dt.value] ?? 0;
+      return {
+        code: dt.value,
+        labelkey: dt.labelkey,
+        value: typedValue,
+        source,
+        sourceLabel: game.i18n.localize(ANARCHY.actor.monitors.resistanceSources?.[source] ?? source),
+        bonusTotal: resistanceBonus + typeBonus,
+        total: value + resistanceBonus + typeBonus,
+      };
+    });
+
+    return {
+      actor: this.actor,
+      monitor: this.monitor,
+      monitorLabel: game.i18n.localize(ANARCHY.actor.monitors[this.monitor] ?? this.monitor),
+      resistance,
+      resistanceBonus,
+      resistanceBonusByType,
+      damageTypes: this.damageTypes,
+      rows,
+      presets: RESISTANCE_PRESETS,
+    };
+  }
+
+  async activateListeners(html) {
+    const element = html instanceof HTMLElement ? html : html[0];
+    await super.activateListeners(element);
+    const jqHtml = $(element);
+
+    jqHtml.find('form').on('submit', async event => await this._onSubmit(event));
+    jqHtml.find('[data-action="cancel"]').on('click', async () => await this.close());
+    jqHtml.find('.click-apply-preset').click(event => this._applyPreset(event));
+  }
+
+  _applyPreset(event) {
+    const presetKey = $(event.currentTarget).attr('data-preset');
+    const preset = RESISTANCE_PRESETS.find(it => it.key === presetKey);
+    if (!preset) {
+      return;
+    }
+    const form = event.delegateTarget ?? event.currentTarget.closest('form');
+    if (!form) {
+      return;
+    }
+    this.damageTypes.forEach(dt => {
+      const value = preset.values[dt.value];
+      const input = form.querySelector(`input[name="byType.${dt.value}"]`);
+      if (input) {
+        input.value = value ?? '';
+      }
+    });
+  }
+
+  async _onSubmit(event) {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+
+    const resistanceDefault = Number(formData.get('resistance.default') ?? 0) || 0;
+    const byType = {};
+    this.damageTypes.forEach(dt => {
+      const raw = formData.get(`byType.${dt.value}`);
+      if (raw !== null && raw !== '') {
+        const numeric = Number(raw);
+        if (!Number.isNaN(numeric)) {
+          byType[dt.value] = numeric;
+        }
+      }
+    });
+
+    await this.actor.update({
+      [`system.monitors.${this.monitor}.resistance.default`]: resistanceDefault,
+      [`system.monitors.${this.monitor}.resistance.byType`]: byType,
+    });
+    await this.close();
+  }
+}

--- a/src/modules/enums.js
+++ b/src/modules/enums.js
@@ -26,6 +26,7 @@ export class Enums {
   static hbsMwdWeaponDamageTypes;
   static hbsPersonalWeaponDamageTypes;
   static hbsPersonalWeaponDamageCategories;
+  static hbsDamageTypes;
   static hbsMwdMeleeLocations;
 
   static sortedAttributeKeys;
@@ -51,6 +52,10 @@ export class Enums {
     Enums.hbsMwdWeaponDamageTypes = Enums.mapObjetToKeyValue(ANARCHY.mwd.weaponDamageType);
     Enums.hbsPersonalWeaponDamageTypes = Enums.mapObjetToKeyValue(ANARCHY.mwd.personalDamageType);
     Enums.hbsPersonalWeaponDamageCategories = Enums.mapObjetToKeyValue(ANARCHY.mwd.personalDamageCategory);
+    Enums.hbsDamageTypes = Misc.distinct(
+      Enums.hbsMwdWeaponDamageTypes.concat(Enums.hbsPersonalWeaponDamageTypes),
+      dt => dt.value
+    );
     Enums.hbsMwdMeleeLocations = Enums.mapObjetToKeyValue(ANARCHY.mwd.meleeLocation);
 
     Enums.sortedAttributeKeys = Object.keys(ANARCHY.attributes);
@@ -83,8 +88,13 @@ export class Enums {
       mwdWeaponDamageTypes: Enums.hbsMwdWeaponDamageTypes,
       personalWeaponDamageTypes: Enums.hbsPersonalWeaponDamageTypes,
       personalWeaponDamageCategories: Enums.hbsPersonalWeaponDamageCategories,
+      damageTypes: Enums.hbsDamageTypes,
       mwdMeleeLocations: Enums.hbsMwdMeleeLocations,
     };
+  }
+
+  static getDamageTypes() {
+    return Enums.hbsDamageTypes ?? [];
   }
 
   static getAttributes(filterAttributes = it => true) {

--- a/src/modules/error-manager.js
+++ b/src/modules/error-manager.js
@@ -49,7 +49,11 @@ export class ErrorManager {
     if (!monitor) {
       const error = game.i18n.format(ANARCHY.common.errors.actorCannotReceiveDamage, {
         actor: actor.name,
-        damageType: game.i18n.format('ANARCHY.actor.monitors.' + damageType)
+        damageType: game.i18n.localize(
+          ANARCHY.actor.monitors[damageType]
+          ?? ANARCHY.mwd.weaponDamageType[damageType]
+          ?? ANARCHY.mwd.personalDamageType[damageType]
+          ?? damageType)
       });
       ui.notifications.error(error);
       throw error;

--- a/src/modules/item/weapon-item.js
+++ b/src/modules/item/weapon-item.js
@@ -131,6 +131,8 @@ export class WeaponItem extends AnarchyBaseItem {
         damageAttributeValue
       ),
       monitor: monitor,
+      damageType: this.system.damageType,
+      damageTypeLabel: this.getDamageTypeLabel(),
       noArmor: this.system.noArmor ?? this.system.armorAvoidance,
       armorMode: WeaponItem.armorMode(monitor, this.system.noArmor ?? this.system.armorAvoidance)
     }
@@ -172,6 +174,12 @@ export class WeaponItem extends AnarchyBaseItem {
       return noArmor ? 'noArmor' : 'withArmor'
     }
     return '';
+  }
+
+  getDamageTypeLabel() {
+    const labelKey = ANARCHY.mwd.weaponDamageType[this.system.damageType]
+      ?? ANARCHY.mwd.personalDamageType[this.system.damageType];
+    return labelKey ? game.i18n.localize(labelKey) : this.system.damageType;
   }
 
   getRanges() {

--- a/src/modules/modifiers/modifiers.js
+++ b/src/modules/modifiers/modifiers.js
@@ -49,6 +49,8 @@ export class Modifiers {
     switch (group) {
       case 'roll':
         return true;
+      case 'monitor':
+        return category === 'resistanceByType';
     }
     return false;
   }
@@ -62,6 +64,13 @@ export class Modifiers {
         switch (options.hash.group) {
           case 'roll': {
             return this.getSelectRollSubCategories(options.hash.category);
+          }
+          case 'monitor': {
+            switch (options.hash.category) {
+              case 'resistanceByType':
+                return Enums.getDamageTypes().map(it => ({ key: it.value, label: it.labelkey }));
+            }
+            return [];
           }
         }
         return [];
@@ -135,22 +144,23 @@ export class Modifiers {
     }
   }
 
-  static sumMonitorModifiers(items, monitor, category) {
-    return Modifiers.sumModifiers(Modifiers._activeItems(items), 'monitor', monitor, category);
+  static sumMonitorModifiers(items, monitor, category, subCategory = undefined) {
+    return Modifiers.sumModifiers(Modifiers._activeItems(items), 'monitor', monitor, category, subCategory);
   }
 
-  static sumModifiers(items, group, effect, category) {
-    const filter = Modifiers._createFilter(group, effect, category);
+  static sumModifiers(items, group, effect, category, subCategory = undefined) {
+    const filter = Modifiers._createFilter(group, effect, category, subCategory);
     const itemModifiers = Modifiers._activeItems(items).map(item => Modifiers.itemModifiers(item, filter))
       .reduce((a, b) => a.concat(b), []);
 
     return Misc.sumValues(itemModifiers, m => m.modifier.value);
   }
 
-  static _createFilter(group, effect, category) {
+  static _createFilter(group, effect, category, subCategory = undefined) {
     return m => m.group == group
       && m.effect == (effect == undefined ? m.effect : effect)
-      && m.category == (category == undefined ? m.category : category);
+      && m.category == (category == undefined ? m.category : category)
+      && (subCategory == undefined ? true : m.subCategory == subCategory);
   }
 
   static countModifiers(items, group, effect = undefined, category = undefined) {

--- a/style/anarchy.css
+++ b/style/anarchy.css
@@ -1241,3 +1241,62 @@ div.column-details {
   width: 32px;
   height: 32px;
 }
+
+.resistance-by-type-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.resistance-header .title {
+  font-weight: 600;
+}
+
+.resistance-base-row,
+.resistance-presets {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.resistance-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.resistance-presets .buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.resistance-base-row input[type="number"] {
+  width: 4rem;
+}
+
+.resistance-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.resistance-table th,
+.resistance-table td {
+  padding: 0.25rem;
+  text-align: left;
+}
+
+.resistance-table td.total {
+  font-weight: 700;
+}
+
+.resistance-table td .source {
+  font-size: 0.75rem;
+  color: var(--color-text-light-primary);
+}
+
+.damage-type {
+  margin-left: 0.25rem;
+  font-style: italic;
+  color: var(--color-text-light-primary);
+}

--- a/system.json
+++ b/system.json
@@ -1,6 +1,6 @@
 {
   "id": "mwd",
-  "version": "13.5.2",
+  "version": "13.6.0",
   "manifest": "https://raw.githubusercontent.com/acemb-rso/MWD/main/system.json",
   "download": "https://github.com/acemb-rso/MWD/archive/refs/heads/main.zip",
   "url": "https://github.com/acemb-rso/MWD",

--- a/template.json
+++ b/template.json
@@ -25,7 +25,10 @@
             "marks": [],
             "value": 0,
             "max": 6,
-            "resistance": 0
+            "resistance": {
+              "default": 0,
+              "byType": {}
+            }
           }
         }
       },
@@ -205,12 +208,18 @@
         "physical": {
           "value": 0,
           "max": 10,
-          "resistance": 0
+          "resistance": {
+            "default": 0,
+            "byType": {}
+          }
         },
         "fatigue": {
           "value": 0,
           "max": 10,
-          "resistance": 0
+          "resistance": {
+            "default": 0,
+            "byType": {}
+          }
         },
         "armor": {
           "label": "Armor",
@@ -256,12 +265,18 @@
         "structure": {
           "value": 0,
           "max": 15,
-          "resistance": 2
+          "resistance": {
+            "default": 2,
+            "byType": {}
+          }
         },
         "armor": {
           "value": 0,
           "max": 12,
-          "resistance": 1
+          "resistance": {
+            "default": 1,
+            "byType": {}
+          }
         }
       },
       "weaponGroups": [],
@@ -284,17 +299,26 @@
         "structure": {
           "value": 0,
           "max": 18,
-          "resistance": 1
+          "resistance": {
+            "default": 1,
+            "byType": {}
+          }
         },
         "armor": {
           "value": 0,
           "max": 15,
-          "resistance": 1
+          "resistance": {
+            "default": 1,
+            "byType": {}
+          }
         },
         "heat": {
           "value": 0,
           "max": 4,
-          "resistance": 0
+          "resistance": {
+            "default": 0,
+            "byType": {}
+          }
         }
       },
       "hybrid": {

--- a/templates/actor/character-enhanced/fatigue.hbs
+++ b/templates/actor/character-enhanced/fatigue.hbs
@@ -1,7 +1,7 @@
  <div class="title">
     {{localize 'ANARCHY.actor.monitors.fatigue'}}
 </div>
-<div class="anarchy-monitor">
+  <div class="anarchy-monitor">
     {{> "systems/mwd/templates/actor/character-enhanced/checkbar.hbs"
     code='fatigue'
     value=system.monitors.fatigue.value
@@ -10,9 +10,14 @@
     adjust=true
     }}
   </div>
-  <label class="resistance-label">
-    {{localize ANARCHY.actor.monitors.resistance}}:
-    <div class="value">
-      {{system.monitors.fatigue.resistanceBonus}}
-    </div>
-  </label>
+  <div class="resistance-row" data-monitor-code="fatigue">
+    <label class="resistance-label">
+      {{localize ANARCHY.actor.monitors.resistance}}:
+      <div class="value">
+        {{numberFormat (sum system.monitors.fatigue.resistance.default system.monitors.fatigue.resistanceBonus) sign=true}}
+      </div>
+    </label>
+    <button type="button" class="anarchy-button click-resistance-by-type" data-monitor-code="fatigue">
+      {{localize ANARCHY.actor.monitors.resistanceByTypeButton}}
+    </button>
+  </div>

--- a/templates/actor/character-enhanced/physical.hbs
+++ b/templates/actor/character-enhanced/physical.hbs
@@ -1,7 +1,7 @@
  <div class="title">
     {{localize 'ANARCHY.actor.monitors.physical'}}
 </div>
-<div class="anarchy-monitor">
+  <div class="anarchy-monitor">
     {{> "systems/mwd/templates/actor/character-enhanced/checkbar.hbs"
     code='physical'
     value=system.monitors.physical.value
@@ -9,10 +9,15 @@
     rowlength=3
     adjust=true
     }}
-</div>
-  <label class="resistance-label">
-    {{localize ANARCHY.actor.monitors.resistance}}:
-    <div class="value">
-      {{system.monitors.physical.resistanceBonus}}
-    </div>
-  </label>
+  </div>
+  <div class="resistance-row" data-monitor-code="physical">
+    <label class="resistance-label">
+      {{localize ANARCHY.actor.monitors.resistance}}:
+      <div class="value">
+        {{numberFormat (sum system.monitors.physical.resistance.default system.monitors.physical.resistanceBonus) sign=true}}
+      </div>
+    </label>
+    <button type="button" class="anarchy-button click-resistance-by-type" data-monitor-code="physical">
+      {{localize ANARCHY.actor.monitors.resistanceByTypeButton}}
+    </button>
+  </div>

--- a/templates/combat/inform-defender.hbs
+++ b/templates/combat/inform-defender.hbs
@@ -56,13 +56,16 @@
               )
           }}}
           {{else}}
-          {{{localize ANARCHY.chat.applyDamage 
-            damage=(concat 
+          {{{localize ANARCHY.chat.applyDamage
+            damage=(concat
               (sum attack.damage.value attack.success)
               (weaponDamageLetter attack.damage.monitor)
               (iconCheckbarHit attack.damage.monitor)
               )
           }}}
+          {{/if}}
+          {{#if attack.damage.damageTypeLabel}}
+          <span class="damage-type">{{attack.damage.damageTypeLabel}}</span>
           {{/if}}
           {{> 'systems/mwd/templates/common/damage-armor.hbs' armor=attack.damage.armorMode}}
         </label>

--- a/templates/dialog/resistance-by-type.hbs
+++ b/templates/dialog/resistance-by-type.hbs
@@ -1,0 +1,52 @@
+<form class="resistance-by-type-body">
+  <header class="resistance-header">
+    <div class="title">{{monitorLabel}}</div>
+    <div class="subtitle">{{localize ANARCHY.actor.monitors.resistanceByTypeTitle}}</div>
+  </header>
+
+  <div class="resistance-base-row">
+    <label>{{localize ANARCHY.actor.monitors.resistanceBase}}</label>
+    <input type="number" data-dtype="Number" name="resistance.default" value="{{resistance.default}}" />
+    {{#if resistanceBonus}}
+      <span class="bonus">{{numberFormat resistanceBonus sign=true}}</span>
+    {{/if}}
+  </div>
+
+  <div class="resistance-presets">
+    <span class="label">{{localize ANARCHY.actor.monitors.resistancePresets.label}}</span>
+    <div class="buttons">
+      {{#each presets as |preset|}}
+        <button type="button" class="click-apply-preset" data-preset="{{preset.key}}">{{localize preset.label}}</button>
+      {{/each}}
+    </div>
+  </div>
+
+  <table class="resistance-table">
+    <thead>
+      <tr>
+        <th>{{localize ANARCHY.actor.monitors.damageType}}</th>
+        <th>{{localize ANARCHY.actor.monitors.resistanceByType}}</th>
+        <th>{{localize ANARCHY.actor.monitors.resistanceBonusLabel}}</th>
+        <th>{{localize ANARCHY.actor.monitors.resistanceTotal}}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each rows as |row|}}
+        <tr>
+          <td class="type">{{localize row.labelkey}}</td>
+          <td class="base">
+            <input type="number" data-dtype="Number" name="byType.{{row.code}}" value="{{row.value}}" placeholder="{{localize ANARCHY.actor.monitors.resistanceFallback}}" />
+            <div class="source">{{row.sourceLabel}}</div>
+          </td>
+          <td class="bonus">{{numberFormat row.bonusTotal sign=true}}</td>
+          <td class="total">{{numberFormat row.total sign=true}}</td>
+        </tr>
+      {{/each}}
+    </tbody>
+  </table>
+
+  <footer class="dialog-actions">
+    <button type="submit">{{localize ANARCHY.common.save}}</button>
+    <button type="button" data-action="cancel">{{localize ANARCHY.common.cancel}}</button>
+  </footer>
+</form>

--- a/templates/monitors/fatigue.hbs
+++ b/templates/monitors/fatigue.hbs
@@ -9,8 +9,13 @@
     rowlength=3
     adjust=true
   }}
-  <label class="resitance-label">
-    {{localize ANARCHY.actor.monitors.resistance}}:
-    {{system.monitors.fatigue.resistanceBonus}}
-  </label>
+  <div class="resistance-row" data-monitor-code="fatigue">
+    <label class="resitance-label">
+      {{localize ANARCHY.actor.monitors.resistance}}:
+      {{numberFormat (sum system.monitors.fatigue.resistance.default system.monitors.fatigue.resistanceBonus) sign=true}}
+    </label>
+    <button type="button" class="anarchy-button click-resistance-by-type" data-monitor-code="fatigue">
+      {{localize ANARCHY.actor.monitors.resistanceByTypeButton}}
+    </button>
+  </div>
 </div>

--- a/templates/monitors/heat.hbs
+++ b/templates/monitors/heat.hbs
@@ -12,14 +12,19 @@
     max=system.monitors.heat.max
     rowlength=6
   }}
-  <label class="resitance-label">
-    {{localize ANARCHY.actor.monitors.resistance}}
-    <input class="info-value" type="number" data-dtype="Number" maxlength="2"
-      name="system.monitors.heat.resistance"
-      value="{{system.monitors.heat.resistance}}"
-    />
-    {{#if system.monitors.heat.resistanceBonus}}
-    {{numberFormat system.monitors.heat.resistanceBonus sign=true}}
-    {{/if}}
-  </label>
+  <div class="resistance-row">
+    <label class="resitance-label">
+      {{localize ANARCHY.actor.monitors.resistanceBase}}
+      <input class="info-value" type="number" data-dtype="Number" maxlength="2"
+        name="system.monitors.heat.resistance.default"
+        value="{{system.monitors.heat.resistance.default}}"
+      />
+      {{#if system.monitors.heat.resistanceBonus}}
+      {{numberFormat system.monitors.heat.resistanceBonus sign=true}}
+      {{/if}}
+    </label>
+    <button type="button" class="anarchy-button click-resistance-by-type" data-monitor-code="heat">
+      {{localize ANARCHY.actor.monitors.resistanceByTypeButton}}
+    </button>
+  </div>
 </div>

--- a/templates/monitors/physical.hbs
+++ b/templates/monitors/physical.hbs
@@ -9,8 +9,13 @@
     rowlength=3
     adjust=true
   }}
-  <label class="resitance-label">
-    {{localize ANARCHY.actor.monitors.resistance}}:
-    {{system.monitors.physical.resistanceBonus}}
-  </label>
+  <div class="resistance-row" data-monitor-code="physical">
+    <label class="resitance-label">
+      {{localize ANARCHY.actor.monitors.resistance}}:
+      {{numberFormat (sum system.monitors.physical.resistance.default system.monitors.physical.resistanceBonus) sign=true}}
+    </label>
+    <button type="button" class="anarchy-button click-resistance-by-type" data-monitor-code="physical">
+      {{localize ANARCHY.actor.monitors.resistanceByTypeButton}}
+    </button>
+  </div>
 </div>

--- a/templates/monitors/structure.hbs
+++ b/templates/monitors/structure.hbs
@@ -12,14 +12,19 @@
     max=system.monitors.structure.max
     rowlength=6
   }}
-  <label class="resitance-label">
-    {{localize ANARCHY.actor.monitors.resistance}}
-    <input class="info-value" type="number" data-dtype="Number" maxlength="2"
-      name="system.monitors.structure.resistance"
-      value="{{system.monitors.structure.resistance}}" 
-    />
-    {{#if system.monitors.structure.resistanceBonus}}
-    {{numberFormat system.monitors.structure.resistanceBonus sign=true}}
-    {{/if}}
-  </label>
+  <div class="resistance-row">
+    <label class="resitance-label">
+      {{localize ANARCHY.actor.monitors.resistanceBase}}
+      <input class="info-value" type="number" data-dtype="Number" maxlength="2"
+        name="system.monitors.structure.resistance.default"
+        value="{{system.monitors.structure.resistance.default}}"
+      />
+      {{#if system.monitors.structure.resistanceBonus}}
+      {{numberFormat system.monitors.structure.resistanceBonus sign=true}}
+      {{/if}}
+    </label>
+    <button type="button" class="anarchy-button click-resistance-by-type" data-monitor-code="structure">
+      {{localize ANARCHY.actor.monitors.resistanceByTypeButton}}
+    </button>
+  </div>
 </div>


### PR DESCRIPTION
## Summary
- add per-damage-type resistance storage and typed modifier support for actors and items
- apply typed resistance values during damage resolution with notifications, migration, and version bump
- expose UI to edit type-specific resistances with presets and styling updates

## Testing
- node -e "JSON.parse(require('fs').readFileSync('lang/en.json','utf8'))"
- node -e "JSON.parse(require('fs').readFileSync('template.json','utf8'))"

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d3c4b2c74832db515dc305c536ef8)