### PR TITLE
Remove cyberdeck section from gear list

### DIFF
--- a/templates/actor/character-enhanced/equipments.hbs
+++ b/templates/actor/character-enhanced/equipments.hbs
@@ -18,7 +18,6 @@
             </div> --}}
 
             {{> "systems/mwd/templates/actor/character-enhanced/gears.hbs"}}
-            {{> "systems/mwd/templates/actor/character-enhanced/cyberdecks.hbs"}}
 
           </div>
         </div>


### PR DESCRIPTION
## Summary
- remove the cyberdeck partial from the enhanced gear section so cyberdecks are no longer shown there

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d45a36744832d9a40f361e3c2d53b)