### PR TITLE
Add life modules to character biography

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -369,6 +369,15 @@
         "level": "Level",
         "levelShort": "Lvl"
       },
+      "lifeModule": {
+        "moduleType": "Module Type",
+        "type": {
+          "faction": "Faction",
+          "childhood": "Childhood",
+          "higherEducation": "Higher Education",
+          "realLife": "Real Life"
+        }
+      },
       "mechWeapon": {
         "category": "Weapon Category",
         "hardpoint": "Hardpoint",
@@ -407,6 +416,7 @@
         "shadowamp": "Shadow Amp",
         "gear": "Gear",
         "contact": "Contact",
+        "lifeModule": "Life Module",
         "mechWeapon": "Mech-Scale Weapon",
         "personalWeapon": "Personal Weapon"
       },
@@ -416,6 +426,7 @@
         "shadowamp": "Shadow Amps",
         "gear": "Gears",
         "contact": "Contacts",
+        "lifeModule": "Life Modules",
         "action": "Actions",
         "monitor": "Monitors",
         "mechWeapon": "Mech-Scale Weapons",

--- a/src/modules/anarchy-system.js
+++ b/src/modules/anarchy-system.js
@@ -34,6 +34,8 @@ import { ContactItem } from './item/contact-item.js';
 import { GearItem } from './item/gear-item.js';
 import { QualityItem } from './item/quality-item.js';
 import { ShadowampItem } from './item/shadowamp-item.js';
+import { LifeModuleItem } from './item/lifemodule-item.js';
+import { LifeModuleItemSheet } from './item/lifemodule-item-sheet.js';
 import { Checkbars } from './common/checkbars.js';
 import { RollParameters } from './roll/roll-parameters.js';
 import { RollDialog } from './roll/roll-dialog.js';
@@ -77,6 +79,7 @@ export class AnarchySystem {
       quality: QualityItem,
       shadowamp: ShadowampItem,
       skill: SkillItem,
+      lifeModule: LifeModuleItem,
       mechWeapon: WeaponItem,
       personalWeapon: WeaponItem
     }
@@ -171,6 +174,7 @@ export class AnarchySystem {
     Items.registerSheet(SYSTEM_NAME, ContactItemSheet, { types: ["contact"], makeDefault: true });
     Items.registerSheet(SYSTEM_NAME, GearItemSheet, { types: ["gear"], makeDefault: true });
     Items.registerSheet(SYSTEM_NAME, QualityItemSheet, { types: ["quality"], makeDefault: true });
+    Items.registerSheet(SYSTEM_NAME, LifeModuleItemSheet, { types: ["lifeModule"], makeDefault: true });
     Items.registerSheet(SYSTEM_NAME, ShadowampItemSheet, { types: ["shadowamp"], makeDefault: true });
     Items.registerSheet(SYSTEM_NAME, SkillItemSheet, { types: ["skill"], makeDefault: true });
     Items.registerSheet(SYSTEM_NAME, WeaponItemSheet, { types: ["mechWeapon", "personalWeapon"], makeDefault: true });

--- a/src/modules/config.js
+++ b/src/modules/config.js
@@ -12,6 +12,7 @@ export const ANARCHY = {
             quality: "TYPES.Item.quality",
             shadowamp: "TYPES.Item.shadowamp",
             skill: "TYPES.Item.skill",
+            lifeModule: "TYPES.Item.lifeModule",
             mechWeapon: "TYPES.Item.mechWeapon",
             personalWeapon: "TYPES.Item.personalWeapon"
         }
@@ -334,7 +335,8 @@ export const ANARCHY = {
             mechWeapon: 'ANARCHY.itemType.singular.mechWeapon',
             personalWeapon: 'ANARCHY.itemType.singular.personalWeapon',
             gear: 'ANARCHY.itemType.singular.gear',
-            contact: 'ANARCHY.itemType.singular.contact'
+            contact: 'ANARCHY.itemType.singular.contact',
+            lifeModule: 'ANARCHY.itemType.singular.lifeModule'
         },
         plural: {
             skill: 'ANARCHY.itemType.plural.skill',
@@ -343,7 +345,16 @@ export const ANARCHY = {
             mechWeapon: 'ANARCHY.itemType.plural.mechWeapon',
             personalWeapon: 'ANARCHY.itemType.plural.personalWeapon',
             gear: 'ANARCHY.itemType.plural.gear',
-            contact: 'ANARCHY.itemType.plural.contact'
+            contact: 'ANARCHY.itemType.plural.contact',
+            lifeModule: 'ANARCHY.itemType.plural.lifeModule'
+        }
+    },
+    lifeModule: {
+        type: {
+            faction: 'ANARCHY.item.lifeModule.type.faction',
+            childhood: 'ANARCHY.item.lifeModule.type.childhood',
+            higherEducation: 'ANARCHY.item.lifeModule.type.higherEducation',
+            realLife: 'ANARCHY.item.lifeModule.type.realLife',
         }
     },
     capacity: {

--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -37,6 +37,7 @@ export const TEMPLATE = {
     personalWeapon: 'personalWeapon',
     gear: 'gear',
     contact: 'contact',
+    lifeModule: 'lifeModule',
   },
   attributes: {
     agility: 'agility',

--- a/src/modules/enums.js
+++ b/src/modules/enums.js
@@ -15,6 +15,7 @@ export class Enums {
   static hbsMonitors;
   static hbsMonitorLetters;
   static hbsShadowampCategories;
+  static hbsLifeModuleTypes;
   static hbsAreas;
   static hbsRanges;
   static hbsMwdWeightClasses;
@@ -40,6 +41,7 @@ export class Enums {
     Enums.hbsMonitors = Enums.mapObjetToKeyValue(ANARCHY.monitor);
     Enums.hbsMonitorLetters = Enums.mapObjetToKeyValue(ANARCHY.monitorLetter);
     Enums.hbsShadowampCategories = Enums.mapObjetToKeyValue(ANARCHY.shadowampCategory);
+    Enums.hbsLifeModuleTypes = Enums.mapObjetToKeyValue(ANARCHY.lifeModule.type);
     Enums.hbsAreas = Enums.mapObjetToKeyValue(ANARCHY.area);
     Enums.hbsRanges = Enums.mapObjetToKeyValue(ANARCHY.range);
     Enums.hbsVehicleCategories = Enums.mapObjetToKeyValue(ANARCHY.vehicleCategory);
@@ -78,6 +80,7 @@ export class Enums {
         .map(it => { return { value: it.code, label: game.i18n.localize(it.labelkey), labelkey: it.labelkey }; }),
       areas: Enums.hbsAreas,
       ranges: Enums.hbsRanges,
+      lifeModuleTypes: Enums.hbsLifeModuleTypes,
       vehicleCategories: Enums.hbsVehicleCategories,
       mwdWeightClasses: Enums.hbsMwdWeightClasses,
       mwdHardpointTypes: Enums.hbsMwdHardpointTypes,

--- a/src/modules/item/lifemodule-item-sheet.js
+++ b/src/modules/item/lifemodule-item-sheet.js
@@ -1,0 +1,13 @@
+import { BaseItemSheet } from "./base-item-sheet.js";
+
+export class LifeModuleItemSheet extends BaseItemSheet {
+
+  getData(options) {
+    const hbsData = super.getData(options);
+    return hbsData;
+  }
+
+  activateListeners(html) {
+    super.activateListeners(html);
+  }
+}

--- a/src/modules/item/lifemodule-item.js
+++ b/src/modules/item/lifemodule-item.js
@@ -1,0 +1,9 @@
+import { ICONS_PATH } from "../constants.js";
+import { AnarchyBaseItem } from "./anarchy-base-item.js";
+
+export class LifeModuleItem extends AnarchyBaseItem {
+
+  static get defaultIcon() {
+    return `${ICONS_PATH}/quality-positive.svg`;
+  }
+}

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -182,4 +182,42 @@
         line-height: 1.2;
     }
 }
+
+.life-modules .life-modules-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.life-modules .life-module-line {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.life-modules .life-module-label {
+    min-width: 9rem;
+    font-weight: bold;
+    text-transform: uppercase;
+}
+
+.life-modules .life-module-items {
+    flex: 1;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+}
+
+.life-modules .life-module {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.1rem 0.35rem;
+    border: 1px solid var(--color-border-light-highlight);
+    border-radius: 0.2rem;
+}
+
+.life-modules .life-module .life-module-name {
+    font-weight: bold;
+}
     }

--- a/template.json
+++ b/template.json
@@ -355,6 +355,7 @@
       "quality",
       "shadowamp",
       "skill",
+      "lifeModule",
       "mechWeapon",
       "personalWeapon"
     ],
@@ -392,6 +393,13 @@
         "references"
       ],
       "positive": true
+    },
+    "lifeModule": {
+      "templates": [
+        "inactive",
+        "references"
+      ],
+      "moduleType": "faction"
     },
     "shadowamp": {
       "templates": [

--- a/templates/actor/character-enhanced/story.hbs
+++ b/templates/actor/character-enhanced/story.hbs
@@ -27,6 +27,9 @@
         {{> "systems/mwd/templates/actor/character-enhanced/contacts.hbs"}}
       </div>
       {{/unless}}
+      <div class="life-modules">
+        {{> 'systems/mwd/templates/actor/parts/life-modules.hbs'}}
+      </div>
       <div class="description">
         {{> 'systems/mwd/templates/actor/character-enhanced/description.hbs'}}
       </div>

--- a/templates/actor/character-tabbed.hbs
+++ b/templates/actor/character-tabbed.hbs
@@ -122,6 +122,9 @@
       </div>
     </div>
     <div class="tab" data-group="primary" data-tab="biography">
+      <div class="anarchy-block">
+        {{> 'systems/mwd/templates/actor/parts/life-modules.hbs'}}
+      </div>
       <div class="section-group items-group">
       {{> "systems/mwd/templates/actor/parts/contacts.hbs"}}
       </div>

--- a/templates/actor/character.hbs
+++ b/templates/actor/character.hbs
@@ -105,6 +105,10 @@
     </div>
 
     <div class="anarchy-block">
+      {{> 'systems/mwd/templates/actor/parts/life-modules.hbs'}}
+    </div>
+
+    <div class="anarchy-block">
       {{> 'systems/mwd/templates/actor/parts/description.hbs'}}
       {{> 'systems/mwd/templates/actor/parts/gmnotes.hbs'}}
     </div>

--- a/templates/actor/parts/life-module.hbs
+++ b/templates/actor/parts/life-module.hbs
@@ -1,0 +1,7 @@
+<div class="item life-module {{#if system.inactive}}inactive{{/if}}" data-item-id="{{_id}}" data-item-type="lifeModule" draggable="true">
+  <img class="anarchy-img item-img" src="{{img}}" alt="{{name}}" data-tooltip="{{name}}"/>
+  <span class="life-module-name">{{name}}</span>
+  <div class="item-controls">
+    {{> 'systems/mwd/templates/common/item-controls.hbs'}}
+  </div>
+</div>

--- a/templates/actor/parts/life-modules.hbs
+++ b/templates/actor/parts/life-modules.hbs
@@ -1,0 +1,48 @@
+<div class="define-item-type life-modules" data-item-type="lifeModule">
+  <h2 class="section-group-header">
+    {{localize 'ANARCHY.itemType.plural.lifeModule'}}
+    {{> 'systems/mwd/templates/common/item-control-add.hbs' itemType='lifeModule'}}
+  </h2>
+  <div class="life-modules-list">
+    <div class="life-module-line">
+      <div class="life-module-label">{{localize 'ANARCHY.item.lifeModule.type.faction'}}</div>
+      <div class="life-module-items">
+        {{#each items.lifeModule}}
+          {{#if (eq system.moduleType 'faction')}}
+            {{> 'systems/mwd/templates/actor/parts/life-module.hbs'}}
+          {{/if}}
+        {{/each}}
+      </div>
+    </div>
+    <div class="life-module-line">
+      <div class="life-module-label">{{localize 'ANARCHY.item.lifeModule.type.childhood'}}</div>
+      <div class="life-module-items">
+        {{#each items.lifeModule}}
+          {{#if (eq system.moduleType 'childhood')}}
+            {{> 'systems/mwd/templates/actor/parts/life-module.hbs'}}
+          {{/if}}
+        {{/each}}
+      </div>
+    </div>
+    <div class="life-module-line">
+      <div class="life-module-label">{{localize 'ANARCHY.item.lifeModule.type.higherEducation'}}</div>
+      <div class="life-module-items">
+        {{#each items.lifeModule}}
+          {{#if (eq system.moduleType 'higherEducation')}}
+            {{> 'systems/mwd/templates/actor/parts/life-module.hbs'}}
+          {{/if}}
+        {{/each}}
+      </div>
+    </div>
+    <div class="life-module-line">
+      <div class="life-module-label">{{localize 'ANARCHY.item.lifeModule.type.realLife'}}</div>
+      <div class="life-module-items">
+        {{#each items.lifeModule}}
+          {{#if (eq system.moduleType 'realLife')}}
+            {{> 'systems/mwd/templates/actor/parts/life-module.hbs'}}
+          {{/if}}
+        {{/each}}
+      </div>
+    </div>
+  </div>
+</div>

--- a/templates/item/lifemodule.hbs
+++ b/templates/item/lifemodule.hbs
@@ -1,0 +1,30 @@
+<form class="{{options.cssClass}}" autocomplete="off">
+  <header class="sheet-header">
+    <img class="anarchy-img profile-img" src="{{data.img}}" data-edit="img" data-tooltip="{{data.name}}"/>
+    {{> 'systems/mwd/templates/item/parts/itemname.hbs'
+      labelkey='ANARCHY.itemType.singular.lifeModule'
+      type="lifeModule"
+    }}
+  </header>
+  <nav class="sheet-tabs tabs" data-group="primary">
+    <div class="sheet-tab" data-tab="main">
+      <a>{{localize ANARCHY.item.tabs.main}}</a>
+    </div>
+    <div class="sheet-tab-fill"></div>
+  </nav>
+
+  <section class="sheet-body">
+    <div class="tab section-group" data-group="primary" data-tab="main">
+      <div class="form-group">
+        <label for="system.moduleType">{{localize 'ANARCHY.item.lifeModule.moduleType'}}</label>
+        <select name="system.moduleType">
+          {{#each ENUMS.lifeModuleTypes}}
+          <option value="{{value}}" {{#if (eq ../system.moduleType value)}}selected{{/if}}>{{localize labelkey}}</option>
+          {{/each}}
+        </select>
+      </div>
+      {{> 'systems/mwd/templates/item/parts/inactive.hbs'}}
+      {{> 'systems/mwd/templates/item/parts/references.hbs'}}
+    </div>
+  </section>
+</form>


### PR DESCRIPTION
## Summary
- add a dedicated Life Module item type with sheet support and default data
- surface life modules in character biography sections with localized fields for key life stages
- style the life module entries to align with other item lists

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d46f74fb4832dba11d82b543cc52f)