### PR TITLE
Allow reroll cap to be boosted by modifiers

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -669,6 +669,7 @@
         "effect": {
           "pool": "Pool bonus",
           "reroll": "Rerolls",
+          "rerollMax": "Reroll allowance cap",
           "glitch": "Glitch dice",
           "successReroll": "Reroll own successes",
           "opponentPool": "Opponent pool malus",

--- a/src/modules/config.js
+++ b/src/modules/config.js
@@ -542,6 +542,7 @@ export const ANARCHY = {
             effect: {
                 pool: 'ANARCHY.modifier.roll.effect.pool',
                 reroll: 'ANARCHY.modifier.roll.effect.reroll',
+                rerollMax: 'ANARCHY.modifier.roll.effect.rerollMax',
                 glitch: 'ANARCHY.modifier.roll.effect.glitch',
                 successReroll: 'ANARCHY.modifier.roll.effect.successReroll',
                 opponentPool: 'ANARCHY.modifier.roll.effect.opponentPool',

--- a/src/modules/roll/roll-parameters.js
+++ b/src/modules/roll/roll-parameters.js
@@ -12,6 +12,7 @@ export const ROLL_PARAMETER_CATEGORY = {
   title: 'title',
   pool: 'pool',
   reroll: 'reroll',
+  rerollMax: 'rerollMax',
   rerollForced: 'rerollForced',
   successReroll: 'successReroll',
   glitch: 'glitch',
@@ -21,6 +22,8 @@ export const ROLL_PARAMETER_CATEGORY = {
   opponentPool: 'opponentPool',
   opponentReroll: 'opponentReroll'
 }
+
+const DEFAULT_REROLL_MAX = 4;
 
 const DEFAULT_ROLL_PARAMETERS = [
   // attribute1
@@ -256,9 +259,15 @@ const DEFAULT_ROLL_PARAMETERS = [
       order: 30, category: ROLL_PARAMETER_CATEGORY.reroll,
       labelkey: ANARCHY.common.roll.modifiers.reroll,
       hbsTemplateRoll: `${TEMPLATES_PATH}/roll/parts/input-numeric.hbs`,
-      min: 0, max: 4
+      min: 0, max: DEFAULT_REROLL_MAX
     },
-    factory: context => RollParameters.computeRollModifiers(ROLL_PARAMETER_CATEGORY.reroll, context)
+    factory: context => {
+      const reroll = RollParameters.computeRollModifiers(ROLL_PARAMETER_CATEGORY.reroll, context);
+      const rerollMax = RollParameters.computeRollModifiers(ROLL_PARAMETER_CATEGORY.rerollMax, context);
+      return foundry.utils.mergeObject(reroll, {
+        max: DEFAULT_REROLL_MAX + Math.max(0, rerollMax.value ?? 0)
+      });
+    }
   },
   // reduction from opponent
   {


### PR DESCRIPTION
## Summary
- allow roll modifiers to raise the reroll allowance cap
- add a rerollMax roll modifier option and expose its translation label
- base reroll max remains 4 but gains bonus capacity from qualifying items

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d42029c5c832da3a53c4e3c8d3f9a)