### PR TITLE
Fix asset module template definition

### DIFF
--- a/template.json
+++ b/template.json
@@ -395,6 +395,15 @@
       "positive": true
     },
     "assetModule": {
+      "templates": [
+        "modifiers",
+        "inactive",
+        "references"
+      ],
+      "category": "special",
+      "capacity": "mundane",
+      "level": 1
+    },
     "lifeModule": {
       "templates": [
         "inactive",


### PR DESCRIPTION
## Summary
- add default templates and fields for the assetModule item definition
- ensure the lifeModule entry is properly structured so template.json parses

## Testing
- jq . template.json

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692da63c572c832da8bc17b6af88dc1b)