### PR TITLE
Add JSON validation utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "run": "npx vite serve",
     "packCompendiumsToDist": "node ./tools/packCompendiumsToDist.mjs",
     "packCompendiumsToPublic": "node ./tools/packCompendiumsToPublic.mjs",
-    "unpackCompendiumsFromPublic": "node ./tools/unpackCompendiumsFromPublic.mjs"
+    "unpackCompendiumsFromPublic": "node ./tools/unpackCompendiumsFromPublic.mjs",
+    "validate:json": "node ./tools/validate-json.js"
   },
   "devDependencies": {
     "@foundryvtt/foundryvtt-cli": "^1.0.3",

--- a/tools/validate-json.js
+++ b/tools/validate-json.js
@@ -1,0 +1,55 @@
+const fs = require("fs");
+const path = require("path");
+
+const ignoredDirectories = new Set([
+  "node_modules",
+  ".git",
+  ".vscode",
+  "dist"
+]);
+
+function collectJsonFiles(directory, results = []) {
+  const entries = fs.readdirSync(directory, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (ignoredDirectories.has(entry.name)) continue;
+
+    const fullPath = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      collectJsonFiles(fullPath, results);
+    } else if (entry.isFile() && entry.name.endsWith(".json")) {
+      results.push(fullPath);
+    }
+  }
+
+  return results;
+}
+
+function validateJsonFiles(filePaths) {
+  const errors = [];
+
+  for (const filePath of filePaths) {
+    try {
+      const contents = fs.readFileSync(filePath, "utf8");
+      JSON.parse(contents);
+    } catch (error) {
+      errors.push({ filePath, message: error.message });
+    }
+  }
+
+  return errors;
+}
+
+const files = collectJsonFiles(process.cwd());
+const errors = validateJsonFiles(files);
+
+if (errors.length > 0) {
+  console.error("Invalid JSON files detected:");
+  for (const error of errors) {
+    console.error(`- ${error.filePath}: ${error.message}`);
+  }
+  process.exit(1);
+}
+
+console.log(`Validated ${files.length} JSON files successfully.`);


### PR DESCRIPTION
## Summary
- add a utility script to recursively validate JSON files while ignoring build artifacts
- expose a package script for running JSON validation from npm

## Testing
- npm run validate:json


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692db13b3f6c832d90707bc189b74b2e)