### PR TITLE
Update selectOptions value attribute usage

### DIFF
--- a/templates/item/parts/modifier.hbs
+++ b/templates/item/parts/modifier.hbs
@@ -2,8 +2,8 @@
   <td class="modifier-column">
     <select class="select-modifier-change" data-modifier-select='group'>
     {{selectOptions (modifierSelectOption 'group')
-      selected=group 
-      nameAttr="key" labelAttr="label"
+      selected=group
+      valueAttr="key" labelAttr="label"
       localize=true blank=''}}
     </select>
   </td>
@@ -11,7 +11,7 @@
     <select class="select-modifier-change" data-modifier-select='effect'>
     {{selectOptions (modifierSelectOption 'effect' group=group)
       selected=effect
-      nameAttr="key" labelAttr="label"
+      valueAttr="key" labelAttr="label"
       localize=true blank=''}}
     </select>
   </td>
@@ -20,7 +20,7 @@
       <select class="select-modifier-change" data-modifier-select='category'>
         {{selectOptions (modifierSelectOption 'category' group=group effect=effect)
           selected=category
-          nameAttr="key" labelAttr="label"
+          valueAttr="key" labelAttr="label"
           localize=true blank=''}}
       </select>
     {{/if}}
@@ -30,7 +30,7 @@
       <select class="select-modifier-change" data-modifier-select='subCategory'>
         {{selectOptions (modifierSelectOption 'subCategory' group=group effect=effect category=category)
           selected=subCategory
-          nameAttr="key" labelAttr="label"
+          valueAttr="key" labelAttr="label"
           localize=true blank=''}}
       </select>
     {{/if}}

--- a/templates/item/weapon.hbs
+++ b/templates/item/weapon.hbs
@@ -93,7 +93,7 @@
             <label for="system.defense" >{{localize 'ANARCHY.item.personalWeapon.defense'}} </label>
             <select name="system.defense">
               {{selectOptions ENUMS.defenses selected=(fixedDefenseCode system.defense)
-              nameAttr="code" labelAttr="labelkey" localize=true blank=''}}
+              valueAttr="code" labelAttr="labelkey" localize=true blank=''}}
             </select>
         </div>
         <div class="form-group">


### PR DESCRIPTION
## Summary
- replace deprecated `nameAttr` usage with `valueAttr` for selectOptions helpers
- align modifier and weapon templates with current Foundry helper API

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dc07ae8f0832d8e065a395c689200)