### PR TITLE
Create separate personal and mech weapon sheets

### DIFF
--- a/src/modules/item/anarchy-base-item.js
+++ b/src/modules/item/anarchy-base-item.js
@@ -20,8 +20,10 @@ export class AnarchyBaseItem extends Item {
       foundry.utils.mergeObject(context, { anarchy: { ready: true } });
       const ItemConstructor = game.system.anarchy.itemClasses[docData.type];
       if (ItemConstructor) {
+        const defaultIcon = ItemConstructor.defaultIconForType?.(docData.type)
+          ?? ItemConstructor.defaultIcon;
         if (!docData.img) {
-          docData.img = ItemConstructor.defaultIcon;
+          docData.img = defaultIcon;
         }
         return new ItemConstructor(docData, context);
       }

--- a/src/modules/item/base-item-sheet.js
+++ b/src/modules/item/base-item-sheet.js
@@ -20,10 +20,13 @@ export class BaseItemSheet extends foundry.appv1.sheets.ItemSheet {
   }
 
   get template() {
-    if ([TEMPLATE.itemType.mechWeapon, TEMPLATE.itemType.personalWeapon].includes(this.object.type)) {
-      return `${TEMPLATES_PATH}/item/weapon.hbs`;
-    }
-    return `${TEMPLATES_PATH}/item/${this.object.type}.hbs`;
+    const weaponTemplates = {
+      [TEMPLATE.itemType.mechWeapon]: `${TEMPLATES_PATH}/item/mech-weapon.hbs`,
+      [TEMPLATE.itemType.personalWeapon]: `${TEMPLATES_PATH}/item/personal-weapon.hbs`,
+    };
+
+    return weaponTemplates[this.object.type]
+      ?? `${TEMPLATES_PATH}/item/${this.object.type}.hbs`;
   }
 
   getData(options) {

--- a/src/modules/item/weapon-item.js
+++ b/src/modules/item/weapon-item.js
@@ -82,6 +82,13 @@ export class WeaponItem extends AnarchyBaseItem {
     return `${ICONS_PATH}/weapons/mac-10.svg`;
   }
 
+  static defaultIconForType(type) {
+    if (type === TEMPLATE.itemType.mechWeapon) {
+      return `${ICONS_PATH}/weapons/cannon.svg`;
+    }
+    return this.defaultIcon;
+  }
+
   isWeaponSkill(item) {
     return item.type == 'skill' && item.system.code === this.system.skill;
   }

--- a/templates/item/mech-weapon.hbs
+++ b/templates/item/mech-weapon.hbs
@@ -1,0 +1,84 @@
+<form class="{{options.cssClass}}" autocomplete="off">
+  <header class="sheet-header">
+    <img class="anarchy-img profile-img" src="{{data.img}}" data-edit="img" data-tooltip="{{data.name}}"/>
+    {{> 'systems/mwd/templates/item/parts/itemname.hbs'
+      labelkey=(concat 'ANARCHY.itemType.singular.' type)
+      type=type
+    }}
+  </header>
+
+  <nav class="sheet-tabs tabs" data-group="primary">
+    <div class="sheet-tab" data-tab="main">
+      <a>{{localize ANARCHY.item.tabs.main}}</a>
+    </div>
+    <div class="sheet-tab" data-tab="modifiers">
+      <a>{{localize ANARCHY.item.tabs.modifiers}}</a>
+    </div>
+    <div class="sheet-tab-fill"></div>
+  </nav>
+
+  <section class="sheet-body">
+    <div class="tab section-group" data-group="primary" data-tab="main">
+      <div class="form-group">
+        <label for="system.weaponCategory">{{localize 'ANARCHY.item.mechWeapon.category'}}</label>
+        <select name="system.weaponCategory">
+          {{selectOptions ENUMS.mwdWeaponCategories selected=system.weaponCategory labelAttr="labelkey" localize=true blank=''}}
+        </select>
+      </div>
+      <div class="form-group">
+        <label>{{localize 'ANARCHY.item.mechWeapon.hardpoint'}}</label>
+        <div class="flexrow">
+          <select name="system.hardpointType">
+            {{selectOptions ENUMS.mwdHardpointTypes selected=system.hardpointType labelAttr="labelkey" localize=true blank=''}}
+          </select>
+          <select name="system.hardpointSize">
+            {{selectOptions ENUMS.mwdHardpointSizes selected=system.hardpointSize labelAttr="labelkey" localize=true blank=''}}
+          </select>
+        </div>
+      </div>
+      <div class="form-group">
+        <label for="system.damage">{{localize 'ANARCHY.item.mechWeapon.damage'}}</label>
+        <input class="type-numeric" type="number" data-dtype="Number" name="system.damage" value="{{system.damage}}" />
+      </div>
+      <div class="form-group">
+        <label for="system.damageType">{{localize 'ANARCHY.item.mechWeapon.damageType'}}</label>
+        <select name="system.damageType">
+          {{selectOptions ENUMS.mwdWeaponDamageTypes selected=system.damageType labelAttr="labelkey" localize=true blank=''}}
+        </select>
+      </div>
+      <div class="form-group">
+        <label for="system.heat">{{localize 'ANARCHY.item.mechWeapon.heat'}}</label>
+        <input class="type-numeric" type="number" data-dtype="Number" name="system.heat" value="{{system.heat}}" />
+      </div>
+      <div class="form-group">
+        <label for="system.area" >{{localize 'ANARCHY.item.mechWeapon.area'}} </label>
+        <select name="system.area" data-dtype="String">
+          {{selectOptions ENUMS.areas selected=system.area labelAttr="labelkey" localize=true blank=''}}
+        </select>
+      </div>
+      <div class="form-group">
+          <label for="system.range.max" >{{localize 'ANARCHY.item.mechWeapon.range.max'}} </label>
+          <select name="system.range.max">
+            {{selectOptions ENUMS.ranges selected=system.range.max labelAttr="labelkey" localize=true blank=''}}
+          </select>
+      </div>
+      {{#each (weaponRangeList system.range)}}
+        {{#if allowed}}
+        <div class="form-group">
+            <label for="system.range.{{key}}" >{{localize (concat 'ANARCHY.range.' key)}} </label>
+            <input class="type-numeric" type="number" data-dtype="Number"
+              name="system.range.{{key}}" value="{{numberFormat value decimals=0 sign=false}}"
+            />
+        </div>
+        {{/if}}
+      {{/each}}
+      {{> 'systems/mwd/templates/item/parts/inactive.hbs'}}
+      {{> 'systems/mwd/templates/item/parts/references.hbs'}}
+    </div>
+    <div class="tab section-group" data-group="primary" data-tab="modifiers">
+      <div class="form-group">
+        {{> 'systems/mwd/templates/item/parts/modifiers.hbs'}}
+      </div>
+    </div>
+  </section>
+</form>

--- a/templates/item/personal-weapon.hbs
+++ b/templates/item/personal-weapon.hbs
@@ -1,0 +1,104 @@
+<form class="{{options.cssClass}}" autocomplete="off">
+  <header class="sheet-header">
+    <img class="anarchy-img profile-img" src="{{data.img}}" data-edit="img" data-tooltip="{{data.name}}"/>
+    {{> 'systems/mwd/templates/item/parts/itemname.hbs'
+      labelkey=(concat 'ANARCHY.itemType.singular.' type)
+      type=type
+    }}
+  </header>
+
+  <nav class="sheet-tabs tabs" data-group="primary">
+    <div class="sheet-tab" data-tab="main">
+      <a>{{localize ANARCHY.item.tabs.main}}</a>
+    </div>
+    <div class="sheet-tab" data-tab="modifiers">
+      <a>{{localize ANARCHY.item.tabs.modifiers}}</a>
+    </div>
+    <div class="sheet-tab-fill"></div>
+  </nav>
+
+  <section class="sheet-body">
+    <div class="tab section-group" data-group="primary" data-tab="main">
+      <div class="form-group">
+        <label for="system.skill">{{localize 'ANARCHY.item.personalWeapon.skill'}} </label>
+        <select class="select-weapon-skill" name="system.skill" data-dtype="String">
+          {{selectOptions ENUMS.skills selected=system.skill labelAttr="label" localize=false}}
+        </select>
+      </div>
+      <div class="form-group">
+        <label for="system.weaponCategory">{{localize 'ANARCHY.item.personalWeapon.category'}}</label>
+        <select name="system.weaponCategory">
+          {{selectOptions ENUMS.mwdWeaponCategories selected=system.weaponCategory labelAttr="labelkey" localize=true blank=''}}
+        </select>
+      </div>
+      <div class="form-group">
+        <label for="system.damageCategory">{{localize 'ANARCHY.item.personalWeapon.damageCategory'}}</label>
+        <select name="system.damageCategory">
+          {{selectOptions ENUMS.personalWeaponDamageCategories selected=system.damageCategory labelAttr="labelkey" localize=true blank=''}}
+        </select>
+      </div>
+      <div class="form-group">
+        <label for="system.damage">{{localize 'ANARCHY.item.personalWeapon.damage'}}</label>
+        <div class="flexrow flex-wrap">
+          <input class="type-numeric" type="number" data-dtype="Number" name="system.damage" value="{{system.damage}}" />
+          {{#if (eq system.weaponCategory 'melee')}}
+            <span>+
+            <select name="system.damageAttribute" data-dtype="String">
+                {{selectOptions ENUMS.attributes selected=system.damageAttribute labelAttr="labelkey" localize=true blank=''}}
+            </select>
+            /2</span>
+          {{/if}}
+        </div>
+      </div>
+      <div class="form-group">
+        <label for="system.damageType">{{localize 'ANARCHY.item.personalWeapon.damageType'}}</label>
+        <select name="system.damageType">
+          {{selectOptions ENUMS.personalWeaponDamageTypes selected=system.damageType labelAttr="labelkey" localize=true blank=''}}
+        </select>
+      </div>
+      <div class="form-group">
+          <label for="system.defense" >{{localize 'ANARCHY.item.personalWeapon.defense'}} </label>
+          <select name="system.defense">
+            {{selectOptions ENUMS.defenses selected=(fixedDefenseCode system.defense)
+            nameAttr="code" labelAttr="labelkey" localize=true blank=''}}
+          </select>
+      </div>
+      <div class="form-group">
+        <label>{{localize 'ANARCHY.item.personalWeapon.armorAvoidance'}}</label>
+        <input class="item-field-value" name="system.armorAvoidance" type="checkbox" {{checked system.armorAvoidance}}>
+          <label>{{localize 'ANARCHY.item.personalWeapon.armorAvoidanceHelp'}}
+        </label>
+        </input>
+      </div>
+      <div class="form-group">
+        <label for="system.area" >{{localize 'ANARCHY.item.personalWeapon.area'}} </label>
+        <select name="system.area" data-dtype="String">
+          {{selectOptions ENUMS.areas selected=system.area labelAttr="labelkey" localize=true blank=''}}
+        </select>
+      </div>
+      <div class="form-group">
+          <label for="system.range.max" >{{localize 'ANARCHY.item.personalWeapon.range.max'}} </label>
+          <select name="system.range.max">
+            {{selectOptions ENUMS.ranges selected=system.range.max labelAttr="labelkey" localize=true blank=''}}
+          </select>
+      </div>
+      {{#each (weaponRangeList system.range)}}
+        {{#if allowed}}
+        <div class="form-group">
+            <label for="system.range.{{key}}" >{{localize (concat 'ANARCHY.range.' key)}} </label>
+            <input class="type-numeric" type="number" data-dtype="Number"
+              name="system.range.{{key}}" value="{{numberFormat value decimals=0 sign=false}}"
+            />
+        </div>
+        {{/if}}
+      {{/each}}
+      {{> 'systems/mwd/templates/item/parts/inactive.hbs'}}
+      {{> 'systems/mwd/templates/item/parts/references.hbs'}}
+    </div>
+    <div class="tab section-group" data-group="primary" data-tab="modifiers">
+      <div class="form-group">
+        {{> 'systems/mwd/templates/item/parts/modifiers.hbs'}}
+      </div>
+    </div>
+  </section>
+</form>


### PR DESCRIPTION
## Summary
- add dedicated templates for personal and mech-scale weapons to avoid showing incorrect fields
- set mech-scale weapons to use a cannon icon by default and keep their unique mount and heat fields
- use explicit localization keys for weapon area and range labels

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dc29c1d6c832dbb9d9afa8fdb0c4a)