### PR TITLE
Fix actor sheet data preparation

### DIFF
--- a/src/modules/actor/anarchy-actor-sheet.js
+++ b/src/modules/actor/anarchy-actor-sheet.js
@@ -30,9 +30,10 @@ export class AnarchyActorSheet extends HandlebarsApplicationMixin(foundry.applic
     return this.DEFAULT_OPTIONS;
   }
 
-  getData(options) {
+  async getData(options) {
+    const baseContext = await super._prepareContext(options);
     let hbsData = foundry.utils.mergeObject(
-      super.getData(options),
+      baseContext,
       {
         items: {},
         anarchy: this.actor.getAnarchy(),

--- a/src/modules/actor/character-base-sheet.js
+++ b/src/modules/actor/character-base-sheet.js
@@ -17,12 +17,12 @@ export class CharacterBaseSheet extends AnarchyActorSheet {
     });
   }
 
-  getData(options) {
+  async getData(options) {
     if (this.viewMode == undefined) {
       this.viewMode = true
     }
     const hbsData = foundry.utils.mergeObject(
-      super.getData(options),
+      await super.getData(options),
       {
         options: {
           viewMode: this.viewMode

--- a/src/modules/actor/character-npc-sheet.js
+++ b/src/modules/actor/character-npc-sheet.js
@@ -14,8 +14,8 @@ export class CharacterNPCSheet extends CharacterBaseSheet {
     });
   }
 
-  getData(options) {
-    let hbsData = super.getData(options);
+  async getData(options) {
+    let hbsData = await super.getData(options);
     hbsData.options.classes.push('npc-sheet');
     return hbsData;
   }

--- a/src/modules/actor/character-tabbed-sheet.js
+++ b/src/modules/actor/character-tabbed-sheet.js
@@ -16,8 +16,8 @@ export class CharacterTabbedSheet extends CharacterBaseSheet {
     });
   }
 
-  getData(options) {
-    let hbsData = super.getData(options);
+  async getData(options) {
+    let hbsData = await super.getData(options);
     hbsData.options.classes.push('tabbed-sheet');
     return hbsData;
   }

--- a/src/modules/actor/vehicle-sheet.js
+++ b/src/modules/actor/vehicle-sheet.js
@@ -11,9 +11,9 @@ export class VehicleSheet extends AnarchyActorSheet {
     });
   }
 
-  getData(options) {
+  async getData(options) {
     let hbsData = foundry.utils.mergeObject(
-      super.getData(options), {
+      await super.getData(options), {
         pilot: this.actor.getPilotReference()
     });
     return hbsData;


### PR DESCRIPTION
## Summary
- update Anarchy actor sheets to build data from the base context provided by Foundry
- adjust derived character and vehicle sheets to await async data preparation

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dc8f1e900832da738a3f960daf3d4)