### PR TITLE
Fix actor update responsibility detection

### DIFF
--- a/src/modules/actor/anarchy-actor-sheet.js
+++ b/src/modules/actor/anarchy-actor-sheet.js
@@ -10,6 +10,12 @@ const { HandlebarsApplicationMixin } = foundry.applications.api;
 
 export class AnarchyActorSheet extends HandlebarsApplicationMixin(foundry.applications.sheets.ActorSheet) {
 
+  static PARTS = {
+    sheet: {
+      template: (sheet) => sheet.template
+    }
+  };
+
   get template() {
     return `${TEMPLATES_PATH}/actor/${this.actor.type}.hbs`;
   }

--- a/src/modules/users.js
+++ b/src/modules/users.js
@@ -45,10 +45,14 @@ export class AnarchyUsers {
   }
 
   static firstResponsible(document) {
-    if (!document.testUserPermission) {
-      return undefined
+    if (!document?.testUserPermission) {
+      return undefined;
     }
-    return AnarchyUsers.getUsers(u => u.active && document.testUserPermission(u, CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER)) == game.user
+    const firstOwner = AnarchyUsers.getUsers(
+      user => user.active && document.testUserPermission(user, CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER)
+    ).sort(Misc.ascending(user => user.id)).at(0);
+
+    return firstOwner?.id === game.user.id ? document : undefined;
   }
 
   static getTargetTokens(user) {


### PR DESCRIPTION
## Summary
- ensure firstResponsible returns the actor document when the current user is the first owner
- prevent update hooks from invoking onUpdateActor on non-actor values

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dd707e7f0832da2a2cabbe5f0f2da)