### PR TITLE
Filter invalid roll parameter templates before loading

### DIFF
--- a/src/modules/roll/roll-parameters.js
+++ b/src/modules/roll/roll-parameters.js
@@ -432,7 +432,7 @@ export class RollParameters {
     const templates = Misc.distinct([]
       .concat(Object.values(this.registeredParameters).map(p => p.options.hbsTemplateRoll))
       .concat(Object.values(this.registeredParameters).map(p => p.options.hbsTemplateChat))
-      .filter(it => it != undefined));
+      .filter(it => typeof it === "string" && it.length > 0));
     await loadTemplates(Misc.distinct(templates));
     await loadTemplates([`${TEMPLATES_PATH}/roll/parts/parameter-label.hbs`]);
   }


### PR DESCRIPTION
## Summary
- ensure roll parameter template lists only include non-empty strings before loading

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e01bb7b3c832db7f40c0c3d957d0c)