### PR TITLE
Add actor sheet render diagnostics and checklist

### DIFF
--- a/docs/actor-sheet-notes.md
+++ b/docs/actor-sheet-notes.md
@@ -1,0 +1,20 @@
+# Actor sheet orchestration notes
+
+These notes capture where the actor sheet lifecycle can stumble and what to check when sheets refuse to open or render cleanly.
+
+## Lifecycle refresher
+- `AnarchySystem.start` wires up actor document classes (`CONFIG.Actor.documentClass`) and registers sheet classes during the `init` hook. The default actor sheet options now come from `AnarchyActorSheet` via `DEFAULT_OPTIONS`/`defaultOptions`.  
+- When an Actor document is constructed, `AnarchyBaseActor` reroutes instantiation to the type-specific actor class in `game.system.anarchy.actorClasses`. Missing entries fall back to the base class, so unmatched `type` values can bypass custom logic.  
+- Sheet selection comes from `loadActorSheets` in `anarchy-system.js`; the active sheet for a given actor type is whichever class was registered as default or manually chosen per actor.
+
+## Fragile spots to watch
+- **Actor type drift**: `AnarchyActorSheet.template` now logs when an actor type is missing and falls back to the character template instead of crashing. Verify actor JSON includes a supported `type`, and confirm `actorClasses` plus registered sheets cover that type.
+- **System readiness**: Render logging records when `game.system.anarchy` is unavailable. If sheets break on world start, confirm `AnarchySystem.start()` ran (look for the init logs) before actors are touched.
+- **Template expectations**: The sheet diagnostics include the resolved template path and whether system data (`actor.system`) is present. Mismatched template paths or stripped `system` data will show up there.
+
+## Quick checklist before chasing render bugs
+1. **Actor type & template** – Confirm the actor `type` matches a template file under `templates/actor/` and that a sheet was registered for that type. Fallback logging now highlights when the type is missing.
+2. **Document class wiring** – Ensure `CONFIG.Actor.documentClass` points at `AnarchyBaseActor` and that `game.system.anarchy.actorClasses` has the expected constructor for the actor type.
+3. **Sheet registration** – Check `AnarchySystem.loadActorSheets()` to verify the desired sheet class is registered (and defaulted) for the actor type.
+4. **System readiness** – Look for the `${LOG_HEAD}AnarchySystem.onInit`/`onReady` console logs. If sheets render before those fire, gating logic may need to delay rendering.
+5. **Console diagnostics** – Use the new `ActorSheet` debug logs to capture `actorId`, `actorType`, template path, ownership IDs, and render timing. Rendering failures will now surface a notification and a structured error payload in the console.

--- a/src/modules/actor/anarchy-actor-sheet.js
+++ b/src/modules/actor/anarchy-actor-sheet.js
@@ -1,5 +1,5 @@
 import { ANARCHY } from "../config.js";
-import { TEMPLATE, TEMPLATES_PATH } from "../constants.js";
+import { LOG_HEAD, TEMPLATE, TEMPLATES_PATH } from "../constants.js";
 import { ConfirmationDialog } from "../confirmation.js";
 import { Misc } from "../misc.js";
 import { Enums } from "../enums.js";
@@ -17,7 +17,17 @@ export class AnarchyActorSheet extends HandlebarsApplicationMixin(foundry.applic
   };
 
   get template() {
-    return `${TEMPLATES_PATH}/actor/${this.actor.type}.hbs`;
+    const actorType = this.actor?.type;
+    if (!actorType) {
+      const fallback = `${TEMPLATES_PATH}/actor/character.hbs`;
+      console.warn(`${LOG_HEAD}Actor sheet missing type, using fallback template`, {
+        actorId: this.actor?.id,
+        actorName: this.actor?.name,
+        fallback
+      });
+      return fallback;
+    }
+    return `${TEMPLATES_PATH}/actor/${actorType}.hbs`;
   }
 
   /** @override */
@@ -37,6 +47,7 @@ export class AnarchyActorSheet extends HandlebarsApplicationMixin(foundry.applic
   }
 
   async getData(options) {
+    this._logSheetDiagnostics('getData-start', { options });
     const baseContext = await super._prepareContext(options);
     let hbsData = foundry.utils.mergeObject(
       baseContext,
@@ -69,6 +80,7 @@ export class AnarchyActorSheet extends HandlebarsApplicationMixin(foundry.applic
       ...(hbsData.items.mechWeapon ?? []),
       ...(hbsData.items.personalWeapon ?? []),
     ];
+    this._logSheetDiagnostics('getData-complete', { classes });
     return hbsData;
   }
 
@@ -189,6 +201,44 @@ export class AnarchyActorSheet extends HandlebarsApplicationMixin(foundry.applic
       const monitor = this.getEventMonitorCode(event);
       await ResistanceByTypeDialog.show(this.actor, monitor);
     });
+  }
+
+  async _render(force = false, options = {}) {
+    this._logSheetDiagnostics('render-start', { force, options });
+    try {
+      const result = await super._render(force, options);
+      this._logSheetDiagnostics('render-complete');
+      return result;
+    }
+    catch (error) {
+      console.error(`${LOG_HEAD}Actor sheet render failed`, {
+        actorId: this.actor?.id,
+        actorName: this.actor?.name,
+        actorType: this.actor?.type,
+        template: this.template,
+        options,
+        error
+      });
+      ui.notifications?.error?.('Actor sheet render failed. Check console for details.');
+      throw error;
+    }
+  }
+
+  _logSheetDiagnostics(stage, extra = {}) {
+    const diagnostics = {
+      stage,
+      actorId: this.actor?.id,
+      actorName: this.actor?.name,
+      actorType: this.actor?.type,
+      template: this.template,
+      hasSystemData: !!this.actor?.system,
+      ownerId: this.actor?.system?.ownerId ?? null,
+      systemReady: !!game.system?.anarchy,
+      sheetId: this.id,
+      rendered: this.rendered,
+      ...extra
+    };
+    console.debug(`${LOG_HEAD}ActorSheet`, diagnostics);
   }
 
   getEventItemType(event) {

--- a/src/modules/roll/roll-parameters.js
+++ b/src/modules/roll/roll-parameters.js
@@ -432,7 +432,7 @@ export class RollParameters {
     const templates = Misc.distinct([]
       .concat(Object.values(this.registeredParameters).map(p => p.options.hbsTemplateRoll))
       .concat(Object.values(this.registeredParameters).map(p => p.options.hbsTemplateChat))
-      .filter(it => it != undefined));
+      .filter(it => typeof it === "string" && it.length > 0));
     await loadTemplates(Misc.distinct(templates));
     await loadTemplates([`${TEMPLATES_PATH}/roll/parts/parameter-label.hbs`]);
   }


### PR DESCRIPTION
## Summary
- add diagnostics around actor sheet template resolution and rendering
- show a user-facing notification when render fails
- document actor sheet orchestration checkpoints for future debugging

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e01bb7b3c832db7f40c0c3d957d0c)