### PR TITLE
Fix battlemech template inheritance and clean actor templates

### DIFF
--- a/template.json
+++ b/template.json
@@ -142,9 +142,6 @@
         }
       },
       "mwd-battlemech": {
-        "templates": [
-          "mwd-base"
-        ],
         "attributes": {
           "handling": { "value": 4 },
           "system": { "value": 3 },
@@ -195,8 +192,6 @@
     "character": {
       "templates": [
         "description",
-        "counters",
-        "ownership",
         "attribute-agility",
         "attribute-strength",
         "attribute-willpower",
@@ -291,6 +286,7 @@
     "battlemech": {
       "templates": [
         "description",
+        "mwd-base",
         "mwd-battlemech"
       ],
       "attributes": {},


### PR DESCRIPTION
## Summary
- remove invalid template inheritance from the mwd-battlemech template
- add the base template directly to battlemech actors and drop undefined templates from characters

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e3b1aaedc832dbfc8b35d5c7c5f20)