### PR TITLE
Fix actor template context and disable template guards

### DIFF
--- a/src/modules/actor/anarchy-actor-sheet.js
+++ b/src/modules/actor/anarchy-actor-sheet.js
@@ -53,7 +53,14 @@ export class AnarchyActorSheet extends HandlebarsApplicationMixin(foundry.applic
     this._logSheetDiagnostics('prepareContext-start', { options });
     
     const context = await super._prepareContext(options);
-    
+
+    console.log(`${LOG_HEAD}Actor data for template:`, {
+      actor: this.actor,
+      system: this.actor?.system,
+      type: this.actor?.type,
+      hasGetAnarchy: typeof this.actor?.getAnarchy === 'function'
+    });
+
     // Merge in your custom data
     const hbsData = foundry.utils.mergeObject(context, {
       items: {},
@@ -63,8 +70,10 @@ export class AnarchyActorSheet extends HandlebarsApplicationMixin(foundry.applic
       editable: this.isEditable,
       owner: this.document.isOwner,
       limited: !this.document.isOwner,
+      actor: this.actor,
+      data: context.data ?? this.actor,
       ENUMS: foundry.utils.mergeObject(
-        { attributeAction: this.actor.getAttributeActions?.() ?? {} }, 
+        { attributeAction: this.actor.getAttributeActions?.() ?? {} },
         Enums.getEnums()
       ),
       ANARCHY: ANARCHY,

--- a/src/modules/anarchy-system.js
+++ b/src/modules/anarchy-system.js
@@ -69,7 +69,7 @@ export class AnarchySystem {
     game.system.anarchy = this;
     this.remoteCall = new RemoteCall(); // initialize remote calls registry first: used by other singleton managers
 
-    TemplateGuards.install();
+    // TemplateGuards.install();  // Disabled - loadTemplates is frozen in Foundry V12
 
     this.actorClasses = {
       character: CharacterActor,

--- a/src/modules/handlebars-manager.js
+++ b/src/modules/handlebars-manager.js
@@ -193,7 +193,13 @@ export class HandlebarsManager {
     Handlebars.registerHelper('either', (a, b) => a ? a : b);
     Handlebars.registerHelper('includes', (list, value) => list?.includes(value));
     Handlebars.registerHelper('isInteger', a => a !== undefined && Number.isInteger(a));
-    Handlebars.registerHelper('actorAttribute', (attribute, actor, item = undefined) => actor.getAttributeValue(attribute, item));
+    Handlebars.registerHelper('actorAttribute', (attribute, actor, item = undefined) => {
+      if (!actor || typeof actor.getAttributeValue !== 'function') {
+        console.warn('ANARCHY | actorAttribute helper: invalid actor', { attribute, actor });
+        return 0;
+      }
+      return actor.getAttributeValue(attribute, item);
+    });
     Handlebars.registerHelper('localizeAttribute', Enums.localizeAttribute);
     Handlebars.registerHelper('iconFA', Icons.fontAwesome);
     Handlebars.registerHelper('iconSrc', Icons.iconSystemPath);


### PR DESCRIPTION
## Summary
- disable TemplateGuards installation to avoid issues with frozen loadTemplates
- expose actor data on the sheet context and add logging for template debugging
- harden the actorAttribute Handlebars helper against missing actors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e631bc1cc832daa0c55a88dd546cc)