### PR TITLE
Avoid mutating ApplicationV2 default options

### DIFF
--- a/src/modules/app/gm-manager.js
+++ b/src/modules/app/gm-manager.js
@@ -27,7 +27,7 @@ export class GMManager extends HandlebarsApplicationMixin(ApplicationV2) {
         height: "auto",
         width: "auto"
       }
-    });
+    }, { inplace: false });
   }
 
   static PARTS = {

--- a/src/modules/dialog/resistance-by-type.js
+++ b/src/modules/dialog/resistance-by-type.js
@@ -21,7 +21,7 @@ export class ResistanceByTypeDialog extends HandlebarsApplicationMixin(Applicati
       window: {
         resizable: true,
       }
-    });
+    }, { inplace: false });
   }
 
   static PARTS = {

--- a/src/modules/dialog/roll-celebrity.js
+++ b/src/modules/dialog/roll-celebrity.js
@@ -18,7 +18,7 @@ export class RollCelebrity extends HandlebarsApplicationMixin(ApplicationV2) {
       window: {
         resizable: true
       }
-    });
+    }, { inplace: false });
   }
 
   static PARTS = {

--- a/src/modules/dialog/select-actor.js
+++ b/src/modules/dialog/select-actor.js
@@ -12,7 +12,7 @@ export class SelectActor extends HandlebarsApplicationMixin(ApplicationV2) {
       window: {
         resizable: true
       }
-    });
+    }, { inplace: false });
   }
 
   static PARTS = {

--- a/src/modules/roll/roll-dialog.js
+++ b/src/modules/roll/roll-dialog.js
@@ -22,7 +22,7 @@ export class RollDialog extends HandlebarsApplicationMixin(ApplicationV2) {
         resizable: true,
         minimizable: true
       }
-    });
+    }, { inplace: false });
   }
 
   static PARTS = {


### PR DESCRIPTION
## Summary
- prevent ApplicationV2 default option mutations by cloning when merging overrides
- apply safe option merges across GM manager and dialog applications

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ea293d948832da8ca89c262fe9d3a)