### PR TITLE
Align ApplicationV2 apps with context-based constructors

### DIFF
--- a/src/modules/anarchy-system.js
+++ b/src/modules/anarchy-system.js
@@ -124,7 +124,7 @@ export class AnarchySystem {
     AnarchyBaseActor.init()
     ActorDamageManager.init();
     ChatManager.init();
-    this.gmManager = new GMManager(this.gmAnarchy);
+    this.gmManager = new GMManager({ gmAnarchy: this.gmAnarchy });
     console.log(LOG_HEAD + 'AnarchySystem.onInit | done');
     Hooks.once('ready', () => this.onReady());
   }

--- a/src/modules/app/gm-manager.js
+++ b/src/modules/app/gm-manager.js
@@ -27,7 +27,7 @@ export class GMManager extends HandlebarsApplicationMixin(ApplicationV2) {
         height: "auto",
         width: "auto"
       }
-    });
+    }, { inplace: false });
   }
 
   static PARTS = {
@@ -36,9 +36,9 @@ export class GMManager extends HandlebarsApplicationMixin(ApplicationV2) {
     }
   };
 
-  constructor(gmAnarchy) {
-    super();
-    this.gmAnarchy = gmAnarchy;
+  constructor(context = {}, options = {}) {
+    super(context, options);
+    this.gmAnarchy = context.gmAnarchy;
     this.gmDifficulty = new GMDifficulty();
     this.size = this._registerSizeSetting();
     this.handleDrag = new HandleDragApplication(

--- a/src/modules/dialog/resistance-by-type.js
+++ b/src/modules/dialog/resistance-by-type.js
@@ -21,7 +21,7 @@ export class ResistanceByTypeDialog extends HandlebarsApplicationMixin(Applicati
       window: {
         resizable: true,
       }
-    });
+    }, { inplace: false });
   }
 
   static PARTS = {
@@ -31,18 +31,18 @@ export class ResistanceByTypeDialog extends HandlebarsApplicationMixin(Applicati
   };
 
   static async show(actor, monitor) {
-    const options = foundry.utils.mergeObject(ResistanceByTypeDialog.DEFAULT_OPTIONS, {
+    const options = {
       id: `${ResistanceByTypeDialog.DEFAULT_OPTIONS.id}-${foundry.utils.randomID()}`,
       classes: [game.system.anarchy.styles.selectCssClass(), ...ResistanceByTypeDialog.DEFAULT_OPTIONS.classes],
-    }, { inplace: false });
-    const app = new ResistanceByTypeDialog(actor, monitor, options);
+    };
+    const app = new ResistanceByTypeDialog({ actor, monitor }, options);
     return app.render({ force: true });
   }
 
-  constructor(actor, monitor, options) {
-    super(options);
-    this.actor = actor;
-    this.monitor = monitor;
+  constructor(context = {}, options = {}) {
+    super(context, options);
+    this.actor = context.actor;
+    this.monitor = context.monitor;
     this.damageTypes = Enums.getDamageTypes();
   }
 

--- a/src/modules/dialog/roll-celebrity.js
+++ b/src/modules/dialog/roll-celebrity.js
@@ -18,7 +18,7 @@ export class RollCelebrity extends HandlebarsApplicationMixin(ApplicationV2) {
       window: {
         resizable: true
       }
-    });
+    }, { inplace: false });
   }
 
   static PARTS = {
@@ -46,18 +46,18 @@ export class RollCelebrity extends HandlebarsApplicationMixin(ApplicationV2) {
     }
 
     const title = await renderTemplate(`${TEMPLATES_PATH}/dialog/roll-celebrite-title.hbs`, rollData);
-    const app = new RollCelebrity(rollData, title);
-    return app.render({ force: true });
-  }
-
-  constructor(roll, title) {
-    const options = foundry.utils.mergeObject(RollCelebrity.DEFAULT_OPTIONS, {
+    const options = {
       id: `roll-celebrity-${foundry.utils.randomID()}`,
       classes: [game.system.anarchy.styles.selectCssClass(), ...RollCelebrity.DEFAULT_OPTIONS.classes],
       window: { title }
-    }, { inplace: false });
-    super(options);
-    this.roll = roll;
+    };
+    const app = new RollCelebrity({ roll: rollData }, options);
+    return app.render({ force: true });
+  }
+
+  constructor(context = {}, options = {}) {
+    super(context, options);
+    this.roll = context.roll;
   }
 
   async _prepareContext() {

--- a/src/modules/dialog/select-actor.js
+++ b/src/modules/dialog/select-actor.js
@@ -12,7 +12,7 @@ export class SelectActor extends HandlebarsApplicationMixin(ApplicationV2) {
       window: {
         resizable: true
       }
-    });
+    }, { inplace: false });
   }
 
   static PARTS = {
@@ -26,20 +26,20 @@ export class SelectActor extends HandlebarsApplicationMixin(ApplicationV2) {
     onActorSelected = async actor => { },
     onCancel = async () => { }) {
 
-    const app = new SelectActor(actors, onActorSelected, onCancel, title);
-    return app.render({ force: true });
-  }
-
-  constructor(actors, onActorSelected, onCancel, title) {
-    const options = foundry.utils.mergeObject(SelectActor.DEFAULT_OPTIONS, {
+    const options = {
       id: `select-actor-${foundry.utils.randomID()}`,
       classes: [game.system.anarchy.styles.selectCssClass(), ...SelectActor.DEFAULT_OPTIONS.classes],
       window: { title }
-    }, { inplace: false });
-    super(options);
-    this.actors = actors;
-    this.onActorSelected = onActorSelected;
-    this.onCancel = onCancel;
+    };
+    const app = new SelectActor({ actors, onActorSelected, onCancel }, options);
+    return app.render({ force: true });
+  }
+
+  constructor(context = {}, options = {}) {
+    super(context, options);
+    this.actors = context.actors;
+    this.onActorSelected = context.onActorSelected;
+    this.onCancel = context.onCancel;
     this._actorSelected = false;
   }
 

--- a/src/modules/roll/roll-dialog.js
+++ b/src/modules/roll/roll-dialog.js
@@ -22,7 +22,7 @@ export class RollDialog extends HandlebarsApplicationMixin(ApplicationV2) {
         resizable: true,
         minimizable: true
       }
-    });
+    }, { inplace: false });
   }
 
   static PARTS = {
@@ -121,10 +121,15 @@ export class RollDialog extends HandlebarsApplicationMixin(ApplicationV2) {
     await RollDialog.create(rollData); 
   } 
 
-  static async create(roll) { 
+  static async create(roll) {
     const preparedRoll = RollDialog.#prepareRollData(roll);
     const title = await renderTemplate(`${TEMPLATES_PATH}/roll/roll-dialog-title.hbs`, preparedRoll);
-    const app = new RollDialog(preparedRoll, title);
+    const options = {
+      id: `roll-dialog-${foundry.utils.randomID()}`,
+      classes: [game.system.anarchy.styles.selectCssClass(), ...RollDialog.DEFAULT_OPTIONS.classes],
+      window: { title }
+    };
+    const app = new RollDialog({ roll: preparedRoll }, options);
     return app.render({ force: true });
   }
 
@@ -138,15 +143,9 @@ export class RollDialog extends HandlebarsApplicationMixin(ApplicationV2) {
   }
 
 
-  constructor(roll, title) {
-    const options = foundry.utils.mergeObject(RollDialog.DEFAULT_OPTIONS, {
-      id: `roll-dialog-${foundry.utils.randomID()}`,
-      classes: [game.system.anarchy.styles.selectCssClass(), ...RollDialog.DEFAULT_OPTIONS.classes],
-      window: { title: title }
-    }, { inplace: false });
-
-    super(options);
-    this.roll = roll;
+  constructor(context = {}, options = {}) {
+    super(context, options);
+    this.roll = context.roll;
   }
 
   async _prepareContext() {


### PR DESCRIPTION
## Summary
- update ApplicationV2 dialogs and the GM manager to use context-first constructors
- instantiate applications with explicit context and option overrides instead of merging defaults per instance

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ea293d948832da8ca89c262fe9d3a)