### PR TITLE
Restore missing character tab layout sections

### DIFF
--- a/style/anarchy.css
+++ b/style/anarchy.css
@@ -545,6 +545,73 @@ a.click-checkbar-element[data-checked="true"] img.checkbar-img {
   width: 100%;
 }
 
+.actions-section .section-group-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.actions-block {
+  width: 100%;
+}
+
+.actions-content {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.actions-buttons {
+  flex: 1 1 260px;
+}
+
+.actions-weapons {
+  flex: 2 1 360px;
+}
+
+.gear-owned-section {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.gear-owned-section .items-group {
+  flex: 1 1 320px;
+}
+
+.biography-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.biography-content {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.biography-content .items-group,
+.biography-content .anarchy-block {
+  margin: 0;
+}
+
+@media (min-width: 900px) {
+  .biography-content {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .biography-content .items-group,
+  .biography-content .anarchy-block {
+    flex: 1 1 45%;
+  }
+
+  .biography-notes {
+    flex-basis: 100%;
+  }
+}
+
 .items-group.half-width {
   width: calc(50% - 2px);
 }

--- a/templates/actor/character-tabbed.hbs
+++ b/templates/actor/character-tabbed.hbs
@@ -79,6 +79,19 @@
           {{> "systems/mwd/templates/monitors/anarchy-actor.hbs"}}
         </div>
       </div>
+      <div class="section-group actions-section">
+        <div class="actions-block">
+          <h2 class="section-group-header">{{localize ANARCHY.itemType.plural.action}}</h2>
+          <div class="actions-content">
+            <div class="actions-buttons">
+              {{> "systems/mwd/templates/actor/parts/attributebuttons.hbs"}}
+            </div>
+            <div class="actions-weapons">
+              {{> "systems/mwd/templates/actor/parts/weapons.hbs"}}
+            </div>
+          </div>
+        </div>
+      </div>
       <div class="section-group anarchy-words-section">
         <div class="anarchy-words anarchy-keywords">
         {{> "systems/mwd/templates/actor/parts/words.hbs" wordType='keywords' values=system.keywords}}
@@ -99,9 +112,6 @@
       <div class="section-group items-group">
       {{> "systems/mwd/templates/actor/parts/qualities.hbs"}}
       </div>
-      <div class="section-group items-group">
-      {{> "systems/mwd/templates/actor/parts/weapons.hbs"}}
-      </div>
     </div>
     <div class="tab" data-group="primary" data-tab="equipment">
       <div class="section-group items-group">
@@ -110,25 +120,30 @@
       <div class="section-group items-group">
         {{> "systems/mwd/templates/actor/parts/cyberdecks.hbs"}}
       </div>
-
-      <div class="section-group items-group">
-        {{> "systems/mwd/templates/actor/parts/owned-actors.hbs"}}
-      </div>
-      <div class="section-group items-group">
-        {{> "systems/mwd/templates/actor/parts/gears.hbs"}}
+      <div class="section-group items-group gear-owned-section">
+        <div class="items-group half-width">
+          {{> "systems/mwd/templates/actor/parts/owned-actors.hbs"}}
+        </div>
+        <div class="items-group half-width">
+          {{> "systems/mwd/templates/actor/parts/gears.hbs"}}
+        </div>
       </div>
     </div>
     <div class="tab" data-group="primary" data-tab="biography">
-      <div class="anarchy-block">
-        {{> 'systems/mwd/templates/actor/parts/life-modules.hbs'}}
-      </div>
-      <div class="section-group items-group">
-      {{> "systems/mwd/templates/actor/parts/contacts.hbs"}}
-      </div>
-
-      <div class="anarchy-block">
-        {{> 'systems/mwd/templates/actor/parts/description.hbs'}}
-        {{> 'systems/mwd/templates/actor/parts/gmnotes.hbs'}}
+      <div class="section-group biography-section">
+        <h2 class="section-group-header">{{localize ANARCHY.actor.tabs.biography}}</h2>
+        <div class="biography-content">
+          <div class="anarchy-block biography-life-modules">
+            {{> 'systems/mwd/templates/actor/parts/life-modules.hbs'}}
+          </div>
+          <div class="section-group items-group biography-contacts">
+            {{> "systems/mwd/templates/actor/parts/contacts.hbs"}}
+          </div>
+          <div class="anarchy-block biography-notes">
+            {{> 'systems/mwd/templates/actor/parts/description.hbs'}}
+            {{> 'systems/mwd/templates/actor/parts/gmnotes.hbs'}}
+          </div>
+        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- add actions and weapon block plus structured biography content to the character tabbed sheet
- group owned gear and general gear into a shared equipment layout
- style the restored sections for actions, equipment, and biography areas

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f4afe3cf0832d8dc48e882a25836b)