### PR TITLE
Enable actor sheet resizing and scrolling

### DIFF
--- a/src/modules/actor/anarchy-actor-sheet.js
+++ b/src/modules/actor/anarchy-actor-sheet.js
@@ -24,9 +24,10 @@ export class AnarchyActorSheet extends HandlebarsApplicationMixin(foundry.applic
       dragDrop: [{ dragSelector: ".item ", dropSelector: null }],
       classes: [game.system.anarchy.styles.selectCssClass(), "sheet", "actor"],
       actions: {},
+      resizable: true,
       position: {
-        width: 700,
-        height: 800
+        width: 760,
+        height: 760
       }
     });
   }

--- a/style/anarchy.css
+++ b/style/anarchy.css
@@ -462,6 +462,21 @@ a.click-checkbar-element[data-checked="true"] img.checkbar-img {
   margin-top: 0px;
 }
 
+.window-app.sheet.actor .window-content {
+  overflow: hidden;
+}
+
+.window-app.sheet.actor form {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.window-app.sheet.actor .sheet-body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+}
+
 :is(.section-group, .section-attributes) {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
## Summary
- set actor sheet defaults to be resizable with updated starting dimensions
- make actor sheet content scroll within the window to keep all sections reachable

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f7f657274832da443526cb058b8d7)