### PR TITLE
Create dedicated Battlemech sheet layout

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -328,6 +328,50 @@
           }
         }
       },
+      "battlemech": {
+        "chassis": "Chassis",
+        "tonnage": "Tonnage",
+        "heat": {
+          "thresholds": "Heat thresholds",
+          "runningHot": "Running hot",
+          "overheated": "Overheated",
+          "shutdown": "Shutdown",
+          "statusLabel": "Current heat state",
+          "status": {
+            "safe": "Safe",
+            "runningHot": "Running hot",
+            "overheated": "Overheated",
+            "shutdown": "Shutdown"
+          }
+        },
+        "hardpoints": {
+          "title": "Hardpoint summary",
+          "type": "Type",
+          "size": "Size",
+          "location": "Location",
+          "assigned": "Assigned to",
+          "none": "No hardpoints configured."
+        },
+        "weaponGroups": {
+          "title": "Weapon groups",
+          "mountPoints": "Mount points used: {used} / {total}",
+          "group": "Group",
+          "weapons": "Weapons",
+          "empty": "No weapons assigned to this group.",
+          "none": "No weapon groups configured.",
+          "missingWeapon": "Weapon {missingId} is missing from the actor."
+        },
+        "weapons": {
+          "title": "Battlemech weapons",
+          "weapon": "Weapon",
+          "category": "Category",
+          "mount": "Mount",
+          "hardpoint": "Hardpoint",
+          "heat": "Heat",
+          "none": "No mech weapons equipped.",
+          "mountUnknown": "Unspecified"
+        }
+      },
       "ownership": {
         "owner": "Owner",
         "unknown": "Unknown",

--- a/src/modules/mwd/battlemech-loadout.js
+++ b/src/modules/mwd/battlemech-loadout.js
@@ -1,4 +1,5 @@
 import { ANARCHY } from "../config.js";
+import { TEMPLATE } from "../constants.js";
 
 const MOUNT_POINTS = {
   light: 4,
@@ -193,7 +194,8 @@ export class BattlemechLoadout {
 
   _getWeapons(filter) {
     return this.actor.items
-      .filter(it => it.type === "weapon")
+      .filter(it => it.type === TEMPLATE.itemType.mechWeapon)
+      .filter(it => it.isActive?.())
       .filter(filter);
   }
 

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -220,4 +220,60 @@
 .life-modules .life-module .life-module-name {
     font-weight: bold;
 }
+
+.battlemech-sheet .mech-passport-row {
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.mech-heat-block .heat-thresholds {
+    margin-top: 0.5rem;
+    border-top: 1px solid var(--color-border-light-highlight);
+    padding-top: 0.35rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.mech-heat-block .heat-threshold-row {
+    display: flex;
+    justify-content: space-between;
+}
+
+.mech-heat-block .heat-status {
+    font-weight: 600;
+}
+
+.battlemech-hardpoints .anarchy-table,
+.battlemech-weapon-groups .anarchy-table,
+.battlemech-weapons-table.anarchy-table {
+    width: 100%;
+}
+
+.battlemech-hardpoints .empty-state,
+.battlemech-weapon-groups .empty-state,
+.battlemech-weapons-table .empty-state {
+    margin: 0.25rem 0;
+}
+
+.battlemech-weapon-groups .group-mountpoints {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    margin-bottom: 0.35rem;
+}
+
+.battlemech-weapon-groups .weapon-list {
+    margin: 0;
+    padding-left: 1rem;
+}
+
+.battlemech-weapon-groups .missing-weapon {
+    color: var(--anarchy-color-warning, #b8860b);
+}
+
+.battlemech-weapons-table .item-controls {
+    white-space: nowrap;
+}
     }

--- a/style.css
+++ b/style.css
@@ -1673,4 +1673,60 @@
   padding-left: 1rem;
 }
 
+.battlemech-sheet .mech-passport-row {
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.mech-heat-block .heat-thresholds {
+  margin-top: 0.5rem;
+  border-top: 1px solid var(--color-border-light-highlight);
+  padding-top: 0.35rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.mech-heat-block .heat-threshold-row {
+  display: flex;
+  justify-content: space-between;
+}
+
+.mech-heat-block .heat-status {
+  font-weight: 600;
+}
+
+.battlemech-hardpoints .anarchy-table,
+.battlemech-weapon-groups .anarchy-table,
+.battlemech-weapons-table.anarchy-table {
+  width: 100%;
+}
+
+.battlemech-hardpoints .empty-state,
+.battlemech-weapon-groups .empty-state,
+.battlemech-weapons-table .empty-state {
+  margin: 0.25rem 0;
+}
+
+.battlemech-weapon-groups .group-mountpoints {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-bottom: 0.35rem;
+}
+
+.battlemech-weapon-groups .weapon-list {
+  margin: 0;
+  padding-left: 1rem;
+}
+
+.battlemech-weapon-groups .missing-weapon {
+  color: var(--anarchy-color-warning, #b8860b);
+}
+
+.battlemech-weapons-table .item-controls {
+  white-space: nowrap;
+}
+
 /*# sourceMappingURL=style.css.map */

--- a/template.json
+++ b/template.json
@@ -172,6 +172,17 @@
             "injuryLevel": 0,
             "bailedOut": false
           },
+          "heat": {
+            "current": 0,
+            "max": 4,
+            "thresholds": {
+              "runningHot": 2,
+              "overheated": 3,
+              "shutdown": 4
+            }
+          },
+          "chassis": "",
+          "tonnage": 0,
           "weightClass": "medium",
           "hardpoints": [],
           "weaponGroups": [],

--- a/templates/actor/battlemech.hbs
+++ b/templates/actor/battlemech.hbs
@@ -14,7 +14,18 @@
           </div>
           {{> "systems/mwd/templates/actor/vehicle/vehicle-pilot.hbs"}}
         </div>
-        <div class="passport-action-row">
+        <div class="passport-action-row mech-passport-row">
+          <div class="passport-action">
+            <label>{{localize 'ANARCHY.actor.battlemech.chassis'}}</label>
+            <input class="info-value" type="text" name="system.mwd.chassis" value="{{system.mwd.chassis}}" />
+          </div>
+          <div class="passport-action">
+            <label>{{localize 'ANARCHY.actor.battlemech.tonnage'}}</label>
+            <input class="info-value" type="number" data-dtype="Number" name="system.mwd.tonnage" value="{{system.mwd.tonnage}}" />
+          </div>
+          <div class="passport-action">
+            {{> "systems/mwd/templates/actor/vehicle/vehicle-category.hbs"}}
+          </div>
         </div>
       </div>
     </div>
@@ -30,20 +41,29 @@
     </div>
     <div class="section-group monitors-row">
       <div class="anarchy-block">
-      {{> "systems/mwd/templates/monitors/structure.hbs"}}
+        {{> "systems/mwd/templates/monitors/structure.hbs"}}
       </div>
       <div class="anarchy-block">
-      {{> "systems/mwd/templates/monitors/armor.hbs"}}
+        {{> "systems/mwd/templates/monitors/armor.hbs"}}
       </div>
-      <div class="anarchy-block">
-      {{> "systems/mwd/templates/monitors/heat.hbs"}}
-      <label class="resitance-label">
-        {{localize ANARCHY.actor.vehicle.heatDissipation}}
-        <input class="info-value" type="number" data-dtype="Number" maxlength="2"
-          name="system.hybrid.heat.dissipation"
-          value="{{system.hybrid.heat.dissipation}}"
-        />
-      </label>
+      <div class="anarchy-block mech-heat-block">
+        {{> "systems/mwd/templates/monitors/heat.hbs"}}
+        <div class="heat-thresholds">
+          <label class="monitor-label">{{localize 'ANARCHY.actor.battlemech.heat.thresholds'}}</label>
+          <div class="heat-threshold-row">
+            <span>{{localize 'ANARCHY.actor.battlemech.heat.runningHot'}}</span>
+            <input class="info-value" type="number" data-dtype="Number" name="system.mwd.heat.thresholds.runningHot" value="{{system.mwd.heat.thresholds.runningHot}}" />
+          </div>
+          <div class="heat-threshold-row">
+            <span>{{localize 'ANARCHY.actor.battlemech.heat.overheated'}}</span>
+            <input class="info-value" type="number" data-dtype="Number" name="system.mwd.heat.thresholds.overheated" value="{{system.mwd.heat.thresholds.overheated}}" />
+          </div>
+          <div class="heat-threshold-row">
+            <span>{{localize 'ANARCHY.actor.battlemech.heat.shutdown'}}</span>
+            <input class="info-value" type="number" data-dtype="Number" name="system.mwd.heat.thresholds.shutdown" value="{{system.mwd.heat.thresholds.shutdown}}" />
+          </div>
+          <div class="heat-status">{{localize 'ANARCHY.actor.battlemech.heat.statusLabel'}}: {{system.mwd.heatStatus.label}}</div>
+        </div>
       </div>
     </div>
     <div class="section-group monitors-row">
@@ -80,16 +100,23 @@
       </div>
     </div>
     <div class="section-group items-group">
-    {{> "systems/mwd/templates/actor/npc-parts/skills.hbs"}}
+      <div class="anarchy-block">
+        {{> "systems/mwd/templates/actor/parts/battlemech-hardpoints.hbs"}}
+      </div>
+    </div>
+    <div class="section-group items-group">
+      <div class="anarchy-block">
+        {{> "systems/mwd/templates/actor/parts/battlemech-weapon-groups.hbs"}}
+      </div>
     </div>
     <div class="section-group items-group">
       {{> "systems/mwd/templates/actor/parts/battlemech-loadout.hbs"}}
     </div>
     <div class="section-group items-group">
-    {{> "systems/mwd/templates/actor/npc-parts/asset-modules.hbs"}}
+      {{> "systems/mwd/templates/actor/npc-parts/asset-modules.hbs"}}
     </div>
     <div class="section-group items-group">
-    {{> "systems/mwd/templates/actor/npc-parts/weapons.hbs"}}
+      {{> "systems/mwd/templates/actor/parts/battlemech-weapons.hbs"}}
     </div>
     <div class="anarchy-block">
       {{> 'systems/mwd/templates/actor/parts/description.hbs'}}

--- a/templates/actor/parts/battlemech-hardpoints.hbs
+++ b/templates/actor/parts/battlemech-hardpoints.hbs
@@ -1,0 +1,33 @@
+<div class="battlemech-hardpoints">
+  <h3 class="section-group-header">{{localize 'ANARCHY.actor.battlemech.hardpoints.title'}}</h3>
+  {{#if system.mwd.loadout.hardpoints.length}}
+  <table class="anarchy-table">
+    <thead>
+      <tr>
+        <th>{{localize 'ANARCHY.actor.battlemech.hardpoints.type'}}</th>
+        <th>{{localize 'ANARCHY.actor.battlemech.hardpoints.size'}}</th>
+        <th>{{localize 'ANARCHY.actor.battlemech.hardpoints.location'}}</th>
+        <th>{{localize 'ANARCHY.actor.battlemech.hardpoints.assigned'}}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each system.mwd.loadout.hardpoints as |hardpoint|}}
+      <tr>
+        <td>{{localize (lookup ../ANARCHY.mwd.hardpointType hardpoint.type)}}</td>
+        <td>{{localize (lookup ../ANARCHY.mwd.hardpointSize hardpoint.size)}}</td>
+        <td>{{localize (lookup ../ANARCHY.mwd.hardpointLocation hardpoint.location)}}</td>
+        <td>
+          {{#if hardpoint.occupiedByName}}
+            {{hardpoint.occupiedByName}}
+          {{else}}
+            {{localize 'ANARCHY.mwd.loadout.emptyHardpoint'}}
+          {{/if}}
+        </td>
+      </tr>
+      {{/each}}
+    </tbody>
+  </table>
+  {{else}}
+    <p class="empty-state">{{localize 'ANARCHY.actor.battlemech.hardpoints.none'}}</p>
+  {{/if}}
+</div>

--- a/templates/actor/parts/battlemech-weapon-groups.hbs
+++ b/templates/actor/parts/battlemech-weapon-groups.hbs
@@ -1,0 +1,57 @@
+<div class="battlemech-weapon-groups">
+  <h3 class="section-group-header">{{localize 'ANARCHY.actor.battlemech.weaponGroups.title'}}</h3>
+  <div class="group-mountpoints">
+    <span>{{localize 'ANARCHY.actor.battlemech.weaponGroups.mountPoints' used=system.mwd.loadout.mountPoints.used total=system.mwd.loadout.mountPoints.total}}</span>
+    {{#if system.mwd.loadout.primaryGroupId}}
+      <span class="primary-label">{{localize 'ANARCHY.mwd.loadout.primaryTag'}}{{#if system.mwd.primaryGroupName}}: {{system.mwd.primaryGroupName}}{{/if}}</span>
+    {{/if}}
+  </div>
+  {{#if system.mwd.weaponGroupDetails.length}}
+  <table class="anarchy-table">
+    <thead>
+      <tr>
+        <th>{{localize 'ANARCHY.actor.battlemech.weaponGroups.group'}}</th>
+        <th>{{localize 'ANARCHY.actor.battlemech.weaponGroups.weapons'}}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each system.mwd.weaponGroupDetails as |group|}}
+      <tr>
+        <td>
+          <div class="group-name">{{group.name}}</div>
+          {{#if group.isPrimary}}
+            <span class="primary-label">{{localize 'ANARCHY.mwd.loadout.primaryTag'}}</span>
+          {{/if}}
+        </td>
+        <td>
+          {{#if group.weapons.length}}
+          <ul class="weapon-list">
+            {{#each group.weapons as |weapon|}}
+              <li class="item" data-item-id="{{weapon._id}}" data-item-type="{{weapon.type}}">
+                <a class="click-weapon-roll">{{weapon.name}}</a>
+                {{#if weapon.system.mountLocation}}
+                  <span class="weapon-location">({{localize (lookup ../../ANARCHY.mwd.meleeLocation weapon.system.mountLocation)}})</span>
+                {{/if}}
+              </li>
+            {{/each}}
+          </ul>
+          {{/if}}
+          {{#if group.missingWeaponIds.length}}
+          <ul class="weapon-list missing-weapons">
+            {{#each group.missingWeaponIds as |missing|}}
+              <li class="missing-weapon">{{localize 'ANARCHY.actor.battlemech.weaponGroups.missingWeapon' missingId=missing}}</li>
+            {{/each}}
+          </ul>
+          {{/if}}
+          {{#unless group.weapons.length}}
+            <p class="empty-state">{{localize 'ANARCHY.actor.battlemech.weaponGroups.empty'}}</p>
+          {{/unless}}
+        </td>
+      </tr>
+      {{/each}}
+    </tbody>
+  </table>
+  {{else}}
+    <p class="empty-state">{{localize 'ANARCHY.actor.battlemech.weaponGroups.none'}}</p>
+  {{/if}}
+</div>

--- a/templates/actor/parts/battlemech-weapons.hbs
+++ b/templates/actor/parts/battlemech-weapons.hbs
@@ -1,0 +1,47 @@
+<div class="define-item-type" data-item-type="mechWeapon">
+  <h2 class="section-group-header">
+    {{localize 'ANARCHY.actor.battlemech.weapons.title'}}
+    {{> 'systems/mwd/templates/common/item-control-add.hbs' itemType='mechWeapon'}}
+  </h2>
+  {{#if items.mechWeapon.length}}
+  <table class="anarchy-table battlemech-weapons-table">
+    <thead>
+      <tr>
+        <th>{{localize 'ANARCHY.actor.battlemech.weapons.weapon'}}</th>
+        <th>{{localize 'ANARCHY.actor.battlemech.weapons.category'}}</th>
+        <th>{{localize 'ANARCHY.actor.battlemech.weapons.mount'}}</th>
+        <th>{{localize 'ANARCHY.actor.battlemech.weapons.hardpoint'}}</th>
+        <th>{{localize 'ANARCHY.actor.battlemech.weapons.heat'}}</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each items.mechWeapon as |weapon|}}
+      <tr class="item {{#if weapon.system.inactive}}inactive{{/if}}" data-item-id="{{weapon._id}}" data-item-type="{{weapon.type}}">
+        <td><a class="click-weapon-roll">{{weapon.name}}</a></td>
+        <td>{{localize (lookup ../ANARCHY.mwd.weaponCategory weapon.system.weaponCategory)}}</td>
+        <td>
+          {{#if weapon.system.mountLocation}}
+            {{localize (lookup ../ANARCHY.mwd.meleeLocation weapon.system.mountLocation)}}
+          {{else}}
+            {{localize 'ANARCHY.actor.battlemech.weapons.mountUnknown'}}
+          {{/if}}
+        </td>
+        <td>{{localize (lookup ../ANARCHY.mwd.hardpointType weapon.system.hardpointType)}}, {{localize (lookup ../ANARCHY.mwd.hardpointSize weapon.system.hardpointSize)}}</td>
+        <td>{{weapon.system.heat}}</td>
+        <td class="item-controls">
+          {{> 'systems/mwd/templates/common/favorite.hbs'
+            isFavorite=(actorHasFavorite @root.actor.id id=weapon._id type=weapon.type)
+            weapon=weapon
+          }}
+          {{> 'systems/mwd/templates/common/item-control-activate.hbs'}}
+          {{> 'systems/mwd/templates/common/item-controls.hbs'}}
+        </td>
+      </tr>
+      {{/each}}
+    </tbody>
+  </table>
+  {{else}}
+    <p class="empty-state">{{localize 'ANARCHY.actor.battlemech.weapons.none'}}</p>
+  {{/if}}
+</div>


### PR DESCRIPTION
## Summary
- compute mech-specific heat, loadout, and weapon group data in the battlemech actor
- redesign the battlemech sheet to show heat, hardpoints, weapon groups, and mech weapons
- add defaults, translations, and styling for the mech-only UI elements

## Testing
- npm run validate:json


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f8005ff80832da2644ec0ad516d1f)