### PR TITLE
Remove genre field from actor templates

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -191,7 +191,6 @@
       "battlemechSheet": "Battlemech sheet",
       "characterNPCSheet": "NPC sheet",
       "actorName": "Name",
-      "genre": "Genre",
       "celebrity": "Legend",
       "famous": "Fame",
       "edgePools": {

--- a/src/modules/config.js
+++ b/src/modules/config.js
@@ -177,7 +177,6 @@ export const ANARCHY = {
         vehicleSheet: 'ANARCHY.actor.vehicleSheet',
         characterNPCSheet: 'ANARCHY.actor.characterNPCSheet',
         actorName: 'ANARCHY.actor.actorName',
-        genre: 'ANARCHY.actor.genre',
         celebrity: 'ANARCHY.actor.counters.edgePools.legend',
         tabs: {
             main: 'ANARCHY.actor.tabs.main',

--- a/src/modules/handlebars-manager.js
+++ b/src/modules/handlebars-manager.js
@@ -25,7 +25,6 @@ const HBS_PARTIAL_TEMPLATES = [
 
   // character
   'systems/mwd/templates/actor/character/description.hbs',
-  'systems/mwd/templates/actor/character/genre.hbs',
   'systems/mwd/templates/actor/character/karma.hbs',
   'systems/mwd/templates/actor/character/social-celebrity.hbs',
   // character parts

--- a/template.json
+++ b/template.json
@@ -257,7 +257,6 @@
         }
       },
       "style": "",
-      "genre": "",
       "connectionMode": "disconnected",
       "ownAnarchy": false,
       "keywords": [],

--- a/templates/actor/character-limited.hbs
+++ b/templates/actor/character-limited.hbs
@@ -8,9 +8,6 @@
         <div class="passport-detail">
           {{> "systems/mwd/templates/actor/character/name.hbs"}}
         </div>
-        <div class="passport-detail">
-          {{> "systems/mwd/templates/actor/character/genre.hbs"}}
-        </div>
       </div>
     </div>
   </header>

--- a/templates/actor/character-tabbed.hbs
+++ b/templates/actor/character-tabbed.hbs
@@ -13,9 +13,6 @@
             {{> "systems/mwd/templates/actor/character/name.hbs"}}
           </div>
           <div class="passport-detail">
-            {{> "systems/mwd/templates/actor/character/genre.hbs"}}
-          </div>
-          <div class="passport-detail">
             {{> "systems/mwd/templates/actor/character/karma.hbs"}}
           </div>
         </div>

--- a/templates/actor/character.hbs
+++ b/templates/actor/character.hbs
@@ -13,9 +13,6 @@
             {{> "systems/mwd/templates/actor/character/name.hbs"}}
           </div>
           <div class="passport-detail">
-            {{> "systems/mwd/templates/actor/character/genre.hbs"}}
-          </div>
-          <div class="passport-detail">
             {{> "systems/mwd/templates/actor/character/karma.hbs"}}
           </div>
         </div>

--- a/templates/actor/character/genre.hbs
+++ b/templates/actor/character/genre.hbs
@@ -1,5 +1,0 @@
-<input class="info-value anarchy-character-genre" name="system.genre"
-  type="text" data-dtype="String"
-  value="{{system.genre}}"
-  placeholder="{{localize 'ANARCHY.actor.genre'}}"
-  />

--- a/templates/actor/parts/passport-details.hbs
+++ b/templates/actor/parts/passport-details.hbs
@@ -3,15 +3,9 @@
   <div class="passport-detail">
     {{> "systems/mwd/templates/actor/character/name.hbs"}}
   </div>
-  <div class="passport-detail">
-    {{> "systems/mwd/templates/actor/character/genre.hbs"}}
-  </div>
 {{else}}
   <div class="passport-detail">
     {{> "systems/mwd/templates/actor/character/name.hbs"}}
-  </div>
-  <div class="passport-detail">
-    {{> "systems/mwd/templates/actor/character/genre.hbs"}}
   </div>
   <div class="passport-detail">
     {{> "systems/mwd/templates/actor/character/karma.hbs"}}


### PR DESCRIPTION
## Summary
- remove the genre property from the character data schema and localization
- drop genre references from partial registrations and character passport markup
## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fc4527ac8832d80192828911b8eba)