### PR TITLE
Deduplicate sheet header buttons

### DIFF
--- a/src/modules/actor/anarchy-actor-sheet.js
+++ b/src/modules/actor/anarchy-actor-sheet.js
@@ -40,6 +40,18 @@ export class AnarchyActorSheet extends HandlebarsApplicationMixin(foundry.applic
   }
 
   /** @override */
+  _getHeaderButtons() {
+    const buttons = super._getHeaderButtons?.() ?? [];
+    const seen = new Set();
+    return buttons.filter(button => {
+      const key = `${button.class ?? ''}|${button.icon ?? ''}|${button.label ?? button.title ?? ''}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  }
+
+  /** @override */
   _configureRenderOptions(options) {
     super._configureRenderOptions(options);
     

--- a/src/modules/item/base-item-sheet.js
+++ b/src/modules/item/base-item-sheet.js
@@ -62,6 +62,18 @@ export class BaseItemSheet extends foundry.appv1.sheets.ItemSheet {
     return hbsData;
   }
 
+  /** @override */
+  _getHeaderButtons() {
+    const buttons = super._getHeaderButtons?.() ?? [];
+    const seen = new Set();
+    return buttons.filter(button => {
+      const key = `${button.class ?? ''}|${button.icon ?? ''}|${button.label ?? button.title ?? ''}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  }
+
 
   activateListeners(html) {
     super.activateListeners(html);


### PR DESCRIPTION
## Summary
- add header button deduplication to actor sheets
- ensure item sheets only keep a single copy of each header button

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fc4a55a44832d83429a0df4e0c797)