### PR TITLE
Use enhanced character sheet by default

### DIFF
--- a/src/modules/anarchy-system.js
+++ b/src/modules/anarchy-system.js
@@ -139,19 +139,11 @@ export class AnarchySystem {
   loadActorSheets() {
     const { Actors } = foundry.documents.collections;
     Actors.unregisterSheet('core', foundry.appv1.sheets.ActorSheet);
-    Actors.registerSheet(SYSTEM_NAME, CharacterActorSheet, {
-      label: game.i18n.localize(ANARCHY.actor.characterSheet),
-      makeDefault: false,
-      types: ['character']
-    });
+    Actors.unregisterSheet(SYSTEM_NAME, CharacterActorSheet);
+    Actors.unregisterSheet(SYSTEM_NAME, CharacterTabbedSheet);
     Actors.registerSheet(SYSTEM_NAME, CharacterNPCSheet, {
       label: game.i18n.localize(ANARCHY.actor.characterNPCSheet),
-      makeDefault: false,
-      types: ['character']
-    });
-    Actors.registerSheet(SYSTEM_NAME, CharacterTabbedSheet, {
-      label: game.i18n.localize(ANARCHY.actor.characterTabbedSheet),
-      makeDefault: false,
+      makeDefault: true,
       types: ['character']
     });
     Actors.registerSheet(SYSTEM_NAME, CharacterEnhancedSheet, {


### PR DESCRIPTION
## Summary
- unregister unused character sheet registrations during system init
- register only the enhanced player and NPC character sheets as defaults

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fd6b8b3ac832db2aa2e416b8d7124)