### PR TITLE
Align actor sheets by type

### DIFF
--- a/templates/actor/battlemech.hbs
+++ b/templates/actor/battlemech.hbs
@@ -36,7 +36,6 @@
       {{> "systems/mwd/templates/actor/parts/mech-quick-actions.hbs"}}
     </div>
     <div class="section-attributes anarchy-attributes">
-      {{> "systems/mwd/templates/actor/parts/attributes.hbs"}}
       {{> "systems/mwd/templates/actor/vehicle/vehicle-attributes.hbs"}}
     </div>
     <div class="section-group monitors-row">
@@ -111,9 +110,6 @@
     </div>
     <div class="section-group items-group">
       {{> "systems/mwd/templates/actor/parts/battlemech-loadout.hbs"}}
-    </div>
-    <div class="section-group items-group">
-      {{> "systems/mwd/templates/actor/npc-parts/asset-modules.hbs"}}
     </div>
     <div class="section-group items-group">
       {{> "systems/mwd/templates/actor/parts/battlemech-weapons.hbs"}}

--- a/templates/actor/npc-sheet.hbs
+++ b/templates/actor/npc-sheet.hbs
@@ -52,17 +52,6 @@
       {{> "systems/mwd/templates/actor/npc-parts/weapons.hbs"}}
       </div>
     </div>
-    <div class="section-group items-group">
-    {{> "systems/mwd/templates/actor/npc-parts/asset-modules.hbs"}}
-    </div>
-    <div class="section-group items-group">
-      {{> "systems/mwd/templates/actor/npc-parts/qualities.hbs"}}
-    </div>
-    {{#if ownedActors}}
-      <div class="section-group items-group">
-        {{> "systems/mwd/templates/actor/parts/owned-actors.hbs"}}
-      </div>
-    {{/if}}
     <div class="anarchy-block">
     {{> 'systems/mwd/templates/actor/parts/description.hbs'}}
     {{> 'systems/mwd/templates/actor/parts/gmnotes.hbs'}}

--- a/templates/actor/parts/battlemech-loadout.hbs
+++ b/templates/actor/parts/battlemech-loadout.hbs
@@ -24,7 +24,7 @@
       </div>
       <label class="small-label">{{localize 'ANARCHY.mwd.loadout.primarySlot.allowedWeapons'}}</label>
       <select name="system.mwd.primarySlot.allowedWeaponIds" multiple>
-        {{#each items.weapon as |weapon|}}
+        {{#each items.mechWeapon as |weapon|}}
           {{#if (ne weapon.system.weaponCategory 'melee')}}
           <option value="{{weapon._id}}" {{#if (includes ../system.mwd.primarySlot.allowedWeaponIds weapon._id)}}selected{{/if}}>{{weapon.name}}</option>
           {{/if}}
@@ -75,16 +75,16 @@
         {{#each system.mwd.weaponGroups as |group idx|}}
           <div class="loadout-row">
             <input type="text" name="system.mwd.weaponGroups.{{idx}}.name" value="{{group.name}}" />
-            <label>
-              <input class="input-primary-group" data-index="{{idx}}" type="checkbox" name="system.mwd.weaponGroups.{{idx}}.isPrimary" {{checked group.isPrimary}} />
-              {{localize 'ANARCHY.mwd.loadout.primaryTag'}}
-            </label>
-            <select name="system.mwd.weaponGroups.{{idx}}.weaponIds" multiple>
-              {{#each ../../items.weapon as |weapon|}}
-                {{#if (ne weapon.system.weaponCategory 'melee')}}
-                <option value="{{weapon._id}}" {{#if (includes ../group.weaponIds weapon._id)}}selected{{/if}}>{{weapon.name}}</option>
-                {{/if}}
-              {{/each}}
+          <label>
+            <input class="input-primary-group" data-index="{{idx}}" type="checkbox" name="system.mwd.weaponGroups.{{idx}}.isPrimary" {{checked group.isPrimary}} />
+            {{localize 'ANARCHY.mwd.loadout.primaryTag'}}
+          </label>
+          <select name="system.mwd.weaponGroups.{{idx}}.weaponIds" multiple>
+            {{#each ../../items.mechWeapon as |weapon|}}
+              {{#if (ne weapon.system.weaponCategory 'melee')}}
+              <option value="{{weapon._id}}" {{#if (includes ../group.weaponIds weapon._id)}}selected{{/if}}>{{weapon.name}}</option>
+              {{/if}}
+            {{/each}}
             </select>
             <a class="click-delete-weapon-group" data-index="{{idx}}"><i class="fa-solid fa-trash"></i></a>
           </div>

--- a/templates/actor/vehicle.hbs
+++ b/templates/actor/vehicle.hbs
@@ -20,17 +20,11 @@
           </div>
           {{> "systems/mwd/templates/actor/vehicle/vehicle-pilot.hbs"}}
         </div>
-        <div class="passport-action-row">
-          <div class="passport-action">
-            {{> "systems/mwd/templates/actor/parts/attributebuttons.hbs"}}
-          </div>
-        </div>
       </div>
     </div>
   </header>
   <section class="sheet-body">
     <div class="section-attributes anarchy-attributes">
-      {{> "systems/mwd/templates/actor/parts/attributes.hbs"}}
       {{> "systems/mwd/templates/actor/vehicle/vehicle-attributes.hbs"}}
     </div>
     <div class="section-group monitors-row">
@@ -40,9 +34,6 @@
       <div class="anarchy-block">
       {{> "systems/mwd/templates/monitors/armor.hbs"}}
       </div>
-    </div>
-    <div class="section-group items-group">
-    {{> "systems/mwd/templates/actor/npc-parts/skills.hbs"}}
     </div>
     <div class="section-group items-group">
     {{> "systems/mwd/templates/actor/npc-parts/asset-modules.hbs"}}


### PR DESCRIPTION
## Summary
- streamline the NPC sheet to focus on core attributes, monitors, skills, and weapons
- restrict vehicle sheets to vehicle stats, structure/armor, asset modules, and vehicle weapons
- limit battlemech loadouts and sheets to mech-specific stats and weapons

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fd7d6fdc8832dbf8d800bd2f75b50)