### PR TITLE
Add pilot/crew references to vehicle and battlemech sheets

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -284,6 +284,7 @@
         "pilot": {
           "label": "Pilot",
           "none": "No pilot selected",
+          "placeholder": "Select an actor or paste its UUID",
           "selectActor": "Select Pilot",
           "selectToken": "Use Selected Token",
           "tokenTag": "Token ({{scene}})",
@@ -291,6 +292,10 @@
             "noActors": "No valid actors available to pilot this vehicle.",
             "noTokens": "Select a token with permission to pilot as the vehicle's pilot."
           }
+        },
+        "crew": {
+          "label": "Crew",
+          "placeholder": "Crew names or notes"
         },
         "quickActions": {
           "title": "Quick Actions",

--- a/src/modules/actor/vehicle-sheet.js
+++ b/src/modules/actor/vehicle-sheet.js
@@ -37,6 +37,13 @@ export class VehicleSheet extends AnarchyActorSheet {
       await this.actor.update({ 'system.pilot.uuid': '' });
       this.render();
     });
+
+    html.find('.pilot-reference .actor-reference').click(async event => {
+      event.preventDefault();
+      const uuid = event.currentTarget.dataset.actorUuid ?? this.actor.getPilotUuid();
+      const pilot = uuid ? await fromUuid(uuid) : this.actor.getPilotActor();
+      pilot?.sheet?.render(true);
+    });
   }
 
   async selectPilotFromActor() {

--- a/src/modules/handlebars-manager.js
+++ b/src/modules/handlebars-manager.js
@@ -116,6 +116,7 @@ const HBS_PARTIAL_TEMPLATES = [
   // Vehicles
   'systems/mwd/templates/actor/vehicle/vehicle-attributes.hbs',
   'systems/mwd/templates/actor/vehicle/vehicle-category.hbs',
+  'systems/mwd/templates/actor/vehicle/vehicle-crew.hbs',
   'systems/mwd/templates/actor/vehicle/vehicle-pilot.hbs',
   'systems/mwd/templates/actor/vehicle/vehicle-skill.hbs',
   'systems/mwd/templates/actor/vehicle/vehicle-weapons.hbs',

--- a/template.json
+++ b/template.json
@@ -151,9 +151,6 @@
           "chassis": { "value": 4 },
           "condition": { "value": 3 }
         },
-        "pilot": {
-          "uuid": ""
-        },
         "mwd": {
           "unitType": "mech",
           "locations": {
@@ -351,7 +348,11 @@
       "stealth": 0,
       "category": "",
       "skill": "piloting",
-      "passengers": 4
+      "passengers": 4,
+      "pilot": {
+        "uuid": ""
+      },
+      "crew": ""
     },
     "battlemech": {
       "templates": [
@@ -409,7 +410,11 @@
       "stealth": 0,
       "category": "mech",
       "skill": "gunnery",
-      "passengers": 1
+      "passengers": 1,
+      "pilot": {
+        "uuid": ""
+      },
+      "crew": ""
     }
   },
   "Item": {

--- a/templates/actor/battlemech.hbs
+++ b/templates/actor/battlemech.hbs
@@ -13,6 +13,7 @@
             {{> 'systems/mwd/templates/actor/parts/ownership.hbs'}}
           </div>
           {{> "systems/mwd/templates/actor/vehicle/vehicle-pilot.hbs"}}
+          {{> "systems/mwd/templates/actor/vehicle/vehicle-crew.hbs"}}
         </div>
         <div class="passport-action-row mech-passport-row">
           <div class="passport-action">

--- a/templates/actor/vehicle.hbs
+++ b/templates/actor/vehicle.hbs
@@ -19,6 +19,7 @@
             {{> 'systems/mwd/templates/actor/parts/ownership.hbs'}}
           </div>
           {{> "systems/mwd/templates/actor/vehicle/vehicle-pilot.hbs"}}
+          {{> "systems/mwd/templates/actor/vehicle/vehicle-crew.hbs"}}
         </div>
         <div class="passport-action-row">
           <div class="passport-action">

--- a/templates/actor/vehicle/vehicle-crew.hbs
+++ b/templates/actor/vehicle/vehicle-crew.hbs
@@ -1,0 +1,4 @@
+<div class="passport-detail vehicle-crew">
+  <label class="info-label">{{localize ANARCHY.actor.vehicle.crew.label}}</label>
+  <textarea class="info-value" name="system.crew" rows="1" placeholder="{{localize ANARCHY.actor.vehicle.crew.placeholder}}">{{system.crew}}</textarea>
+</div>

--- a/templates/actor/vehicle/vehicle-pilot.hbs
+++ b/templates/actor/vehicle/vehicle-pilot.hbs
@@ -15,6 +15,9 @@
       <span class="pilot-placeholder">{{localize ANARCHY.actor.vehicle.pilot.none}}</span>
     {{/if}}
   </div>
+  <div class="pilot-picker">
+    <input class="info-value" type="text" name="system.pilot.uuid" value="{{system.pilot.uuid}}" data-dtype="String" data-document-picker="Actor" placeholder="{{localize ANARCHY.actor.vehicle.pilot.placeholder}}" />
+  </div>
   <div class="pilot-actions">
     <a class="anarchy-button click-select-pilot" data-tooltip="{{localize ANARCHY.actor.vehicle.pilot.selectActor}}">{{localize ANARCHY.actor.vehicle.pilot.selectActor}}</a>
     <a class="anarchy-button click-select-pilot-token" data-tooltip="{{localize ANARCHY.actor.vehicle.pilot.selectToken}}">{{localize ANARCHY.actor.vehicle.pilot.selectToken}}</a>

--- a/templates/common/actor-reference.hbs
+++ b/templates/common/actor-reference.hbs
@@ -1,4 +1,4 @@
-<span class="actor-reference" data-actor-id="{{id}}">
+<a class="actor-reference" data-actor-id="{{id}}" data-actor-uuid="{{uuid}}">
   <img class="anarchy-img actor-reference-img" src="{{img}}"/>
   {{name}}
-</span>
+</a>


### PR DESCRIPTION
## Summary
- add pilot and crew fields to vehicle and battlemech actor data
- provide pilot picker using the actor directory and make pilot references clickable
- expose a crew notes field on vehicle and battlemech sheets with localization

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fdf66c278832d963a7c748e7bd5c6)