### PR TITLE
Handle view mode defaults and heat data safety

### DIFF
--- a/src/modules/actor/battlemech-actor.js
+++ b/src/modules/actor/battlemech-actor.js
@@ -124,9 +124,13 @@ export class BattlemechActor extends VehicleActor {
   }
 
   _prepareHeatTrack() {
+    const systemData = this.system ?? {};
+    const heatMonitor = systemData.monitors?.heat ?? { value: 0, max: 0 };
+    const mwdHeat = systemData.mwd?.heat ?? {};
+
     const defaults = {
-      current: this.system.monitors?.heat?.value ?? 0,
-      max: this.system.monitors?.heat?.max ?? 0,
+      current: heatMonitor.value ?? 0,
+      max: heatMonitor.max ?? 0,
       thresholds: {
         runningHot: 2,
         overheated: 3,
@@ -134,10 +138,10 @@ export class BattlemechActor extends VehicleActor {
       }
     };
 
-    const heat = foundry.utils.mergeObject(defaults, this.system.mwd?.heat ?? {}, { inplace: false });
-    heat.thresholds = foundry.utils.mergeObject(defaults.thresholds, this.system.mwd?.heat?.thresholds ?? {}, { inplace: false });
-    heat.current = this.system.monitors?.heat?.value ?? heat.current;
-    heat.max = this.system.monitors?.heat?.max ?? heat.max;
+    const heat = foundry.utils.mergeObject(defaults, mwdHeat, { inplace: false });
+    heat.thresholds = foundry.utils.mergeObject(defaults.thresholds, mwdHeat.thresholds ?? {}, { inplace: false });
+    heat.current = heatMonitor.value ?? heat.current;
+    heat.max = heatMonitor.max ?? heat.max;
 
     const status = this._resolveHeatStatus(heat.current, heat.thresholds, heat.max);
     this.system.mwd.heatStatus = {

--- a/src/modules/actor/character-base-sheet.js
+++ b/src/modules/actor/character-base-sheet.js
@@ -13,6 +13,7 @@ export class CharacterBaseSheet extends AnarchyActorSheet {
     return foundry.utils.mergeObject(super.DEFAULT_OPTIONS, {
       width: 720,
       height: 700,
+      viewMode: false,
       tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "main" }],
     });
   }
@@ -20,7 +21,6 @@ export class CharacterBaseSheet extends AnarchyActorSheet {
   async _prepareContext(options) {
     const context = await super._prepareContext(options);
     const viewMode = this.options.viewMode ?? false;
-    this.options.viewMode = viewMode;
 
     return foundry.utils.mergeObject(context, {
       options: {


### PR DESCRIPTION
## Summary
- add a default view mode flag for character sheets to avoid mutating frozen options objects
- make battlemech heat track preparation resilient to missing system data

## Testing
- npm run validate:json

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ff661ec98832d8cf4535f9f7daf40)