### PR TITLE
Improve NPC and vehicle sheet layout sizing

### DIFF
--- a/src/modules/actor/character-npc-sheet.js
+++ b/src/modules/actor/character-npc-sheet.js
@@ -9,8 +9,8 @@ export class CharacterNPCSheet extends CharacterBaseSheet {
 
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
-      width: 450,
-      height: 550
+      width: 760,
+      height: 650
     });
   }
 

--- a/src/modules/actor/vehicle-sheet.js
+++ b/src/modules/actor/vehicle-sheet.js
@@ -6,8 +6,8 @@ export class VehicleSheet extends AnarchyActorSheet {
 
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
-      width: 450,
-      height: 550
+      width: 760,
+      height: 650
     });
   }
 

--- a/style/anarchy.css
+++ b/style/anarchy.css
@@ -204,6 +204,8 @@ img.anarchy-img.item-img {
   display: flex;
   flex-direction: row;
   margin: 2px;
+  flex-wrap: wrap;
+  gap: 6px;
 }
 
 .passport-img img {
@@ -230,6 +232,7 @@ img.anarchy-img.item-img {
 .vehicle-sheet .passport-img {
   min-height: 92px;
   min-width: 92px;
+  flex: 0 0 92px;
 }
 
 .npc-sheet .passport-img img,
@@ -271,8 +274,9 @@ img.anarchy-img.item-img {
 
 .npc-sheet .passport-column,
 .vehicle-sheet .passport-column {
-  width: calc(100% - 92px);
+  width: auto;
   min-height: 92px;
+  flex: 1 1 340px;
 }
 
 .device-sheet .passport-column {
@@ -303,11 +307,14 @@ img.anarchy-img.item-img {
   justify-content: flex-start;
   vertical-align: text-bottom;
   text-align: left;
-  height: 32px;
+  min-height: 32px;
+  height: auto;
+  gap: 4px;
 }
 
 :is(.passport-detail, .passport-owner) {
-  width: calc(49% - 2px);
+  width: auto;
+  flex: 1 1 240px;
 }
 
 img.owned-actor-img {
@@ -475,6 +482,25 @@ a.click-checkbar-element[data-checked="true"] img.checkbar-img {
 .window-app.sheet.actor .sheet-body {
   flex: 1 1 auto;
   overflow-y: auto;
+}
+
+.window-app.sheet.npc-sheet,
+.window-app.sheet.vehicle-sheet {
+  min-width: 720px;
+  min-height: 620px;
+}
+
+.npc-sheet .sheet-body,
+.vehicle-sheet .sheet-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.npc-sheet .section-group,
+.vehicle-sheet .section-group {
+  gap: 0.5rem;
+  align-items: stretch;
 }
 
 :is(.section-group, .section-attributes) {


### PR DESCRIPTION
## Summary
- expand NPC and vehicle sheet window defaults and minimums to match Anarchy-style layouts
- add flex and spacing tweaks to passport headers and body sections for cleaner alignment

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ffcb5c7e4832da1debea5e77a191a)