### PR TITLE
Rebuild actor sheet layout into grids

### DIFF
--- a/docs/codebase-map.md
+++ b/docs/codebase-map.md
@@ -29,7 +29,7 @@ This document summarizes each file in the MechWarrior: Destiny Foundry VTT syste
 - `src/modules/actor/actor-damage.js` – Singleton `ActorDamageManager` for applying and tracking damage/resistance across actor monitor types.【F:src/modules/actor/actor-damage.js†L1-L140】
 - `src/modules/actor/anarchy-actor-sheet.js` – Base sheet class shared by actor sheet variants, handling generic data preparation and UI listeners.【F:src/modules/actor/anarchy-actor-sheet.js†L1-L140】
 - `src/modules/actor/character-sheet.js` – Default character sheet implementation with tab management and embedded item controls for a single-page view.【F:src/modules/actor/character-sheet.js†L1-L17】
-- `src/modules/actor/character-npc-sheet.js` – NPC-oriented character sheet variant with simplified layout and listeners.【F:src/modules/actor/character-npc-sheet.js†L1-L21】
+- `src/modules/actor/character-npc-sheet.js` – NPC-oriented sheet built directly on the base actor sheet with its own layout and sizing defaults.【F:src/modules/actor/character-npc-sheet.js†L1-L17】
 - `src/modules/actor/character-tabbed-sheet.js` – Character sheet that separates main/equipment/biography tabs; registered as an optional actor sheet.【F:src/modules/actor/character-tabbed-sheet.js†L1-L23】
 - `src/modules/actor/character-enhanced-sheet.js` – Enhanced character sheet offering expanded controls and summary blocks; set as default in `AnarchySystem`.【F:src/modules/actor/character-enhanced-sheet.js†L1-L41】
 - `src/modules/actor/character-base-sheet.js` – Shared utilities for character sheets (tab activation, rendering helpers) used by enhanced/tabbed variants.【F:src/modules/actor/character-base-sheet.js†L1-L96】

--- a/docs/layout-comparison.md
+++ b/docs/layout-comparison.md
@@ -1,0 +1,13 @@
+# Destiny vs. Third-Party Sheet Layouts
+
+## Availability of third-party references
+The repository does not currently include the `/third-party` directory referenced for the original Shadowrun: Anarchy templates, so a file-by-file comparison cannot be performed in-tree. If those templates are added, we can directly diff the markup and CSS scaffolding.
+
+## Observations on the current Destiny templates
+* **Everything is stacked in one long column.** The character sheet streams attributes, words, skills, items, monitors, edge pools, cyberdecks, and descriptions sequentially inside a single `<section>` without columnar scaffolding or tabbing. This means every partial expands to full width and wraps based on its own internal flex rules instead of fitting a consistent grid.
+* **Monitor rows mix disparate widgets.** The character sheet’s `monitors-row` packs armor, physical, fatigue, six separate edge pools, and the Anarchy block into one flex row; as soon as any label grows, the row wraps unpredictably and the blocks end up jagged.
+* **Battlemech sheets follow the same pattern.** The mech layout repeats the stacked `section-group` pattern for quick actions, attributes, multiple monitor blocks, hardpoints, weapon groups, loadouts, and weapons, so nothing is grouped into stable columns.
+* **Shared flex rules amplify the sprawl.** Global sheet styles force every `.section-group` to flex and wrap, but without fixed bases or max widths for the children, wide labels or long lists push each other around, producing uneven spacing instead of the fixed grids seen in more structured templates.
+
+## Why the Destiny layouts feel less clean
+Because the Destiny templates rely on a single long flow with broadly applied flex-and-wrap rules, each partial sizes itself independently. Without the tighter column and grid scaffolding that the original Anarchy sheets used, the Destiny layouts are more prone to wrapping, uneven widths, and jagged alignment when content length varies.

--- a/lang/en.json
+++ b/lang/en.json
@@ -195,6 +195,9 @@
       "famous": "Fame",
       "edgePools": {
         "title": "Edge Pools",
+        "physical": "Physical",
+        "mental": "Mental",
+        "social": "Social",
         "grit": "Grit",
         "insight": "Insight",
         "rumor": "Rumor",
@@ -217,10 +220,13 @@
         "xpUnused": "Unspent XP",
         "xpTotal": "Lifetime XP",
         "edge": "Edge",
-        "anarchy": "Anarchy",
+        "anarchy": "Destiny",
         "sceneAnarchy": "Chaos",
         "plot": "Plot",
         "edgePools": {
+          "physical": "Physical",
+          "mental": "Mental",
+          "social": "Social",
           "grit": "Grit",
           "insight": "Insight",
           "rumor": "Rumor",
@@ -228,9 +234,13 @@
           "credibility": "Credibility",
           "chaos": "Chaos"
         },
-        "social": {
-          "credibility": "Credibility",
+        "mental": {
+          "insight": "Insight",
           "rumor": "Rumor"
+        },
+        "social": {
+          "legend": "Legend",
+          "credibility": "Credibility"
         }
       },
       "monitors": {

--- a/src/modules/actor/actor-damage.js
+++ b/src/modules/actor/actor-damage.js
@@ -221,7 +221,7 @@ export class ActorDamageManager {
   }
 
   static _computeStrengthResistance(actor, monitor) {
-    const strength = actor.getAttributeValue(TEMPLATE.attributes.strength);
+    const strength = actor.getAttributeValue(TEMPLATE.actorAttributes.strength);
     return Math.max(0, Math.floor(strength / 4));
   }
 }

--- a/src/modules/actor/anarchy-actor-sheet.js
+++ b/src/modules/actor/anarchy-actor-sheet.js
@@ -54,11 +54,14 @@ export class AnarchyActorSheet extends HandlebarsApplicationMixin(foundry.applic
   /** @override */
   _configureRenderOptions(options) {
     super._configureRenderOptions(options);
-    
+
     // Dynamically set the template based on actor type
     if (this.actor?.type) {
       const template = `${TEMPLATES_PATH}/actor/${this.actor.type}.hbs`;
       this.constructor.PARTS.sheet.template = template;
+      options.parts = foundry.utils.mergeObject(options.parts ?? {}, {
+        sheet: { template }
+      });
     }
   }
 

--- a/src/modules/actor/base-actor.js
+++ b/src/modules/actor/base-actor.js
@@ -1,7 +1,7 @@
 import { AttributeActions } from "../attribute-actions.js";
 import { Checkbars } from "../common/checkbars.js";
 import { ANARCHY } from "../config.js";
-import { BASE_MONITOR, TEMPLATE } from "../constants.js";
+import { ACTOR_ATTRIBUTE_SETS, BASE_MONITOR, TEMPLATE } from "../constants.js";
 import { Enums } from "../enums.js";
 import { ErrorManager } from "../error-manager.js";
 import { Misc } from "../misc.js";
@@ -172,7 +172,7 @@ export class AnarchyBaseActor extends Actor {
     return normalized;
   }
 
-  getAttributes() { return []; }
+  getAttributes() { return ACTOR_ATTRIBUTE_SETS[this.type] ?? []; }
   getPhysicalAgility() { return undefined }
   getCorrespondingAttribute(attribute) {
     const attributes = this.getAttributes()
@@ -209,7 +209,7 @@ export class AnarchyBaseActor extends Actor {
       return;
     }
 
-    const edgeValue = this.getAttributeValue(TEMPLATE.attributes.edge);
+    const edgeValue = this.getAttributeValue(TEMPLATE.actorAttributes.edge);
     const pools = foundry.utils.getProperty(this.system, 'counters.edgePools') ?? {};
 
     Object.values(TEMPLATE.counters.edgePools).forEach(code => {
@@ -422,7 +422,7 @@ export class AnarchyBaseActor extends Actor {
     await this.spendEdgePool(TEMPLATE.counters.social.credibility, count);
   }
   async spendRumor(count) {
-    await this.spendEdgePool(TEMPLATE.counters.social.rumor, count);
+    await this.spendEdgePool(TEMPLATE.counters.mental.rumor, count);
   }
 
   async spendAnarchy(count) {
@@ -434,7 +434,7 @@ export class AnarchyBaseActor extends Actor {
   getEdgePools() { return this.system.counters?.edgePools ?? {}; }
 
   getEdgePoolValue(pool) {
-    const edge = this.getAttributeValue(TEMPLATE.attributes.edge);
+    const edge = this.getAttributeValue(TEMPLATE.actorAttributes.edge);
     const poolValue = this.getEdgePools()?.[pool]?.value;
     const value = poolValue ?? edge ?? 0;
     return Math.min(value, edge ?? value ?? 0);
@@ -448,7 +448,7 @@ export class AnarchyBaseActor extends Actor {
   }
 
   canUseEdge() {
-    return this.getAttributes().includes(TEMPLATE.attributes.edge);
+    return this.getAttributes().includes(TEMPLATE.actorAttributes.edge);
   }
 
   async spendEdgePool(pool, count) {

--- a/src/modules/actor/character-actor.js
+++ b/src/modules/actor/character-actor.js
@@ -1,5 +1,5 @@
 import { ANARCHY } from "../config.js";
-import { TEMPLATE, TEMPLATES_PATH } from "../constants.js";
+import { ACTOR_ATTRIBUTE_SETS, TEMPLATE, TEMPLATES_PATH } from "../constants.js";
 import { AnarchyBaseActor } from "./base-actor.js";
 import { ErrorManager } from "../error-manager.js";
 import { Misc } from "../misc.js";
@@ -24,8 +24,8 @@ export class CharacterActor extends AnarchyBaseActor {
     if (!this.system.monitors.fatigue && this.system.monitors.stun) {
       this.system.monitors.fatigue = foundry.utils.duplicate(this.system.monitors.stun)
     }
-    this.system.monitors.physical.max = this._getMonitorMax(TEMPLATE.attributes.strength)
-    this.system.monitors.fatigue.max = this._getMonitorMax(TEMPLATE.attributes.willpower)
+    this.system.monitors.physical.max = this._getMonitorMax(TEMPLATE.actorAttributes.strength)
+    this.system.monitors.fatigue.max = this._getMonitorMax(TEMPLATE.actorAttributes.willpower)
     super.prepareDerivedData()
     this.system.ignoreWounds = Modifiers.sumModifiers(this.items, 'other', 'ignoreWounds')
   }
@@ -44,21 +44,14 @@ export class CharacterActor extends AnarchyBaseActor {
   }
 
   getAttributes() {
-    return [
-      TEMPLATE.attributes.strength,
-      TEMPLATE.attributes.agility,
-      TEMPLATE.attributes.willpower,
-      TEMPLATE.attributes.logic,
-      TEMPLATE.attributes.charisma,
-      TEMPLATE.attributes.edge
-    ];
+    return ACTOR_ATTRIBUTE_SETS[this.type] ?? ACTOR_ATTRIBUTE_SETS[TEMPLATE.actorTypes.character];
   }
 
-  getPhysicalAgility() { return TEMPLATE.attributes.agility }
+  getPhysicalAgility() { return TEMPLATE.actorAttributes.agility }
 
   getCorrespondingAttribute(attribute) {
-    if (TEMPLATE.attributes.firewall == attribute) {
-      return TEMPLATE.attributes.firewall
+    if (TEMPLATE.itemAttributes.firewall == attribute) {
+      return TEMPLATE.itemAttributes.firewall
     }
     return super.getCorrespondingAttribute(attribute)
   }
@@ -128,7 +121,7 @@ export class CharacterActor extends AnarchyBaseActor {
     return this.getEdgePoolValue(TEMPLATE.counters.social.credibility);
   }
   getRumorValue() {
-    return this.getEdgePoolValue(TEMPLATE.counters.social.rumor);
+    return this.getEdgePoolValue(TEMPLATE.counters.mental.rumor);
   }
 
   getAnarchy() {

--- a/src/modules/actor/character-npc-sheet.js
+++ b/src/modules/actor/character-npc-sheet.js
@@ -1,11 +1,6 @@
-import { TEMPLATES_PATH } from "../constants.js";
-import { CharacterBaseSheet } from "./character-base-sheet.js";
+import { AnarchyActorSheet } from "./anarchy-actor-sheet.js";
 
-export class CharacterNPCSheet extends CharacterBaseSheet {
-
-  get template() {
-    return `${TEMPLATES_PATH}/actor/npc-sheet.hbs`;
-  }
+export class CharacterNPCSheet extends AnarchyActorSheet {
 
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
@@ -14,9 +9,9 @@ export class CharacterNPCSheet extends CharacterBaseSheet {
     });
   }
 
-  async getData(options) {
-    let hbsData = await super.getData(options);
-    hbsData.options.classes.push('npc-sheet');
-    return hbsData;
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+    context.options.classes = Array.from(new Set([...(context.options.classes ?? []), 'npc-sheet']));
+    return context;
   }
 }

--- a/src/modules/actor/vehicle-actor.js
+++ b/src/modules/actor/vehicle-actor.js
@@ -1,15 +1,8 @@
 import { ANARCHY } from "../config.js";
-import { ICONS_PATH, TEMPLATE } from "../constants.js";
+import { ACTOR_ATTRIBUTE_SETS, ICONS_PATH, TEMPLATE } from "../constants.js";
 import { ErrorManager } from "../error-manager.js";
 import { AnarchyUsers } from "../users.js";
 import { AnarchyBaseActor } from "./base-actor.js";
-
-const VEHICLE_ATTRIBUTES = [
-  TEMPLATE.attributes.handling,
-  TEMPLATE.attributes.system,
-  TEMPLATE.attributes.chassis,
-  TEMPLATE.attributes.condition,
-]
 
 export class VehicleActor extends AnarchyBaseActor {
 
@@ -104,11 +97,9 @@ export class VehicleActor extends AnarchyBaseActor {
     return pilot ? pilot : undefined;
   }
 
-  getAttributes() {
-    return VEHICLE_ATTRIBUTES
-  }
+  getAttributes() { return ACTOR_ATTRIBUTE_SETS[this.type] ?? ACTOR_ATTRIBUTE_SETS[TEMPLATE.actorTypes.vehicle]; }
 
-  getPhysicalAgility() { return TEMPLATE.attributes.handling }
+  getPhysicalAgility() { return TEMPLATE.actorAttributes.handling }
 
   getDamageMonitor(damageType) {
     damageType = this.resolveDamageType(damageType);

--- a/src/modules/attribute-actions.js
+++ b/src/modules/attribute-actions.js
@@ -23,7 +23,7 @@ function defense(code, actionCode) {
   }
 }
 
-const ATTR = TEMPLATE.attributes;
+const ATTR = TEMPLATE.actorAttributes;
 const ACTOR = TEMPLATE.actorTypes;
 const ACTION = ANARCHY_SYSTEM.actions;
 const DEFENSE = ANARCHY_SYSTEM.defenses;

--- a/src/modules/common/checkbars.js
+++ b/src/modules/common/checkbars.js
@@ -85,7 +85,7 @@ export const DEFAULT_CHECKBARS = {
     path: 'system.counters.edgePools.chaos.value',
     monitor: it => {
       const value = it.getEdgePoolValue(TEMPLATE.counters.edgePools.chaos);
-      const max = it.getAttributeValue(TEMPLATE.attributes.edge);
+      const max = it.getAttributeValue(TEMPLATE.actorAttributes.edge);
       return { value: value, max: max };
     },
     iconChecked: Icons.iconPath('systems/mwd/icons/default/explosion.svg', 'checkbar-img'),
@@ -96,7 +96,7 @@ export const DEFAULT_CHECKBARS = {
     path: 'system.counters.edgePools.grit.value',
     monitor: it => {
       const value = it.getEdgePoolValue(TEMPLATE.counters.edgePools.grit);
-      return { value: value, max: it.getAttributeValue(TEMPLATE.attributes.edge) };
+      return { value: value, max: it.getAttributeValue(TEMPLATE.actorAttributes.edge) };
     },
     iconChecked: Icons.iconPath('systems/mwd/icons/default/shield.svg', 'checkbar-img'),
     iconUnchecked: Icons.iconPath('systems/mwd/icons/default/shield.svg', 'checkbar-img'),
@@ -106,7 +106,7 @@ export const DEFAULT_CHECKBARS = {
     path: 'system.counters.edgePools.insight.value',
     monitor: it => {
       const value = it.getEdgePoolValue(TEMPLATE.counters.edgePools.insight);
-      return { value: value, max: it.getAttributeValue(TEMPLATE.attributes.edge) };
+      return { value: value, max: it.getAttributeValue(TEMPLATE.actorAttributes.edge) };
     },
     iconChecked: Icons.iconPath('systems/mwd/icons/default/eye.svg', 'checkbar-img'),
     iconUnchecked: Icons.iconPath('systems/mwd/icons/default/eye.svg', 'checkbar-img'),
@@ -116,7 +116,7 @@ export const DEFAULT_CHECKBARS = {
     path: 'system.counters.edgePools.legend.value',
     monitor: it => {
       const value = it.getEdgePoolValue(TEMPLATE.counters.edgePools.legend);
-      return { value: value, max: it.getAttributeValue(TEMPLATE.attributes.edge) };
+      return { value: value, max: it.getAttributeValue(TEMPLATE.actorAttributes.edge) };
     },
     iconChecked: Icons.iconPath('systems/mwd/icons/default/tower-flag.svg', 'checkbar-img'),
     iconUnchecked: Icons.iconPath('systems/mwd/icons/default/tower-flag.svg', 'checkbar-img'),
@@ -126,7 +126,7 @@ export const DEFAULT_CHECKBARS = {
     path: 'system.counters.edgePools.credibility.value',
     monitor: it => {
       const value = it.getEdgePoolValue(TEMPLATE.counters.edgePools.credibility);
-      return { value: value, max: it.getAttributeValue(TEMPLATE.attributes.edge) };
+      return { value: value, max: it.getAttributeValue(TEMPLATE.actorAttributes.edge) };
     },
     iconChecked: Icons.iconPath('systems/mwd/icons/misc/hand.svg', 'checkbar-img'),
     iconUnchecked: Icons.iconPath('systems/mwd/icons/misc/hand.svg', 'checkbar-img'),
@@ -136,7 +136,7 @@ export const DEFAULT_CHECKBARS = {
     path: 'system.counters.edgePools.rumor.value',
     monitor: it => {
       const value = it.getEdgePoolValue(TEMPLATE.counters.edgePools.rumor);
-      return { value: value, max: it.getAttributeValue(TEMPLATE.attributes.edge) };
+      return { value: value, max: it.getAttributeValue(TEMPLATE.actorAttributes.edge) };
     },
     iconChecked: Icons.iconPath('systems/mwd/icons/default/mystery-man.svg', 'checkbar-img'),
     iconUnchecked: Icons.iconPath('systems/mwd/icons/default/mystery-man.svg', 'checkbar-img'),

--- a/src/modules/config.js
+++ b/src/modules/config.js
@@ -197,6 +197,9 @@ export const ANARCHY = {
             plot: 'ANARCHY.actor.counters.plot',
             edgePools: {
                 title: 'ANARCHY.actor.counters.edgePools.title',
+                physical: 'ANARCHY.actor.counters.edgePools.physical',
+                mental: 'ANARCHY.actor.counters.edgePools.mental',
+                social: 'ANARCHY.actor.counters.edgePools.social',
                 grit: 'ANARCHY.actor.counters.edgePools.grit',
                 insight: 'ANARCHY.actor.counters.edgePools.insight',
                 rumor: 'ANARCHY.actor.counters.edgePools.rumor',
@@ -204,9 +207,13 @@ export const ANARCHY = {
                 credibility: 'ANARCHY.actor.counters.edgePools.credibility',
                 chaos: 'ANARCHY.actor.counters.edgePools.chaos',
             },
+            mental: {
+                insight: 'ANARCHY.actor.counters.mental.insight',
+                rumor: 'ANARCHY.actor.counters.mental.rumor',
+            },
             social: {
+                legend: 'ANARCHY.actor.counters.social.legend',
                 credibility: 'ANARCHY.actor.counters.social.credibility',
-                rumor: 'ANARCHY.actor.counters.social.rumor',
             }
         },
         monitors: {

--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -23,6 +23,40 @@ export const TARGET_SUCCESS_EDGE = 4;
 
 export const BASE_MONITOR = 8;
 
+export const ACTOR_ATTRIBUTES = {
+  agility: 'agility',
+  strength: 'strength',
+  willpower: 'willpower',
+  logic: 'logic',
+  charisma: 'charisma',
+  edge: 'edge',
+  handling: 'handling',
+  system: 'system',
+  chassis: 'chassis',
+  condition: 'condition',
+};
+
+export const ITEM_ATTRIBUTES = {
+  autopilot: 'autopilot',
+  firewall: 'firewall',
+  knowledge: 'knowledge',
+};
+
+const EDGE_POOLS = {
+  grit: 'grit',
+  chaos: 'chaos',
+  insight: 'insight',
+  rumor: 'rumor',
+  legend: 'legend',
+  credibility: 'credibility',
+};
+
+export const EDGE_POOL_GROUPS = {
+  physical: [EDGE_POOLS.grit, EDGE_POOLS.chaos],
+  mental: [EDGE_POOLS.insight, EDGE_POOLS.rumor],
+  social: [EDGE_POOLS.legend, EDGE_POOLS.credibility],
+};
+
 export const TEMPLATE = {
   actorTypes: {
     character: 'character',
@@ -40,21 +74,9 @@ export const TEMPLATE = {
     contact: 'contact',
     lifeModule: 'lifeModule',
   },
-  attributes: {
-    agility: 'agility',
-    strength: 'strength',
-    willpower: 'willpower',
-    logic: 'logic',
-    charisma: 'charisma',
-    edge: 'edge',
-    autopilot: 'autopilot',
-    handling: 'handling',
-    firewall: 'firewall',
-    system: 'system',
-    chassis: 'chassis',
-    condition: 'condition',
-    knowledge: 'knowledge',
-  },
+  actorAttributes: ACTOR_ATTRIBUTES,
+  itemAttributes: ITEM_ATTRIBUTES,
+  attributes: { ...ACTOR_ATTRIBUTES, ...ITEM_ATTRIBUTES },
   monitors: {
     fatigue: 'fatigue',
     armor: 'armor',
@@ -66,21 +88,26 @@ export const TEMPLATE = {
     sceneAnarchy: 'sceneAnarchy',
   },
   counters: {
+    xp: 'xp',
+    xpTotal: 'xpTotal',
+    xpUnused: 'xpUnused',
+    edge: 'edge',
     anarchy: 'anarchy',
-    edgePools: {
-      grit: 'grit',
-      insight: 'insight',
-      rumor: 'rumor',
-      legend: 'legend',
-      credibility: 'credibility',
-      chaos: 'chaos',
+    edgePools: EDGE_POOLS,
+    edgePoolGroups: EDGE_POOL_GROUPS,
+    physical: {
+      grit: EDGE_POOLS.grit,
+      chaos: EDGE_POOLS.chaos,
+    },
+    mental: {
+      insight: EDGE_POOLS.insight,
+      rumor: EDGE_POOLS.rumor,
     },
     social: {
-      legend: 'legend',
-      credibility: 'credibility',
-      rumor: 'rumor'
+      legend: EDGE_POOLS.legend,
+      credibility: EDGE_POOLS.credibility,
     },
-    chaos: 'chaos'
+    chaos: EDGE_POOLS.chaos
   },
   area: {
     none: 'none',
@@ -90,6 +117,37 @@ export const TEMPLATE = {
     rect: 'rect',
     ray: 'ray'
   }
+}
+
+export const ACTOR_ATTRIBUTE_SETS = {
+  [TEMPLATE.actorTypes.character]: [
+    TEMPLATE.actorAttributes.strength,
+    TEMPLATE.actorAttributes.agility,
+    TEMPLATE.actorAttributes.willpower,
+    TEMPLATE.actorAttributes.logic,
+    TEMPLATE.actorAttributes.charisma,
+    TEMPLATE.actorAttributes.edge,
+  ],
+  [TEMPLATE.actorTypes.npc]: [
+    TEMPLATE.actorAttributes.strength,
+    TEMPLATE.actorAttributes.agility,
+    TEMPLATE.actorAttributes.willpower,
+    TEMPLATE.actorAttributes.logic,
+    TEMPLATE.actorAttributes.charisma,
+    TEMPLATE.actorAttributes.edge,
+  ],
+  [TEMPLATE.actorTypes.vehicle]: [
+    TEMPLATE.actorAttributes.handling,
+    TEMPLATE.actorAttributes.system,
+    TEMPLATE.actorAttributes.chassis,
+    TEMPLATE.actorAttributes.condition,
+  ],
+  [TEMPLATE.actorTypes.battlemech]: [
+    TEMPLATE.actorAttributes.handling,
+    TEMPLATE.actorAttributes.system,
+    TEMPLATE.actorAttributes.chassis,
+    TEMPLATE.actorAttributes.condition,
+  ],
 }
 
 export const ANARCHY_SYSTEM = {
@@ -142,6 +200,9 @@ globalThis.ANARCHY_CONSTANTS = {
   TARGET_SUCCESS,
   TARGET_SUCCESS_EDGE,
   BASE_MONITOR,
+  ACTOR_ATTRIBUTES,
+  ITEM_ATTRIBUTES,
+  EDGE_POOL_GROUPS,
   TEMPLATE,
   ANARCHY_SYSTEM
 }

--- a/src/modules/enums.js
+++ b/src/modules/enums.js
@@ -1,4 +1,5 @@
 import { ANARCHY } from "./config.js";
+import { ACTOR_ATTRIBUTE_SETS } from "./constants.js";
 import { Misc } from "./misc.js";
 
 const actorWordTypes = {
@@ -58,7 +59,8 @@ export class Enums {
     );
     Enums.hbsMwdMeleeLocations = Enums.mapObjetToKeyValue(ANARCHY.mwd.meleeLocation);
 
-    Enums.sortedAttributeKeys = Object.keys(ANARCHY.attributes);
+    const attributeOrder = Object.values(ACTOR_ATTRIBUTE_SETS).flat();
+    Enums.sortedAttributeKeys = Misc.distinct(attributeOrder.concat(Object.keys(ANARCHY.attributes)));
 
     Enums.registerHandleBarHelpers();
   }

--- a/src/modules/item/cyberdeck-item.js
+++ b/src/modules/item/cyberdeck-item.js
@@ -10,7 +10,7 @@ export class CyberdeckItem extends AnarchyBaseItem {
 
   getAttributes() {
     return [
-      TEMPLATE.attributes.firewall
+      TEMPLATE.itemAttributes.firewall
     ];
   }
 }

--- a/src/modules/migrations.js
+++ b/src/modules/migrations.js
@@ -66,7 +66,7 @@ class _0_3_8_MigrateWeaponDamage extends Migration {
     const fixItemDamage = it => {
       return {
         _id: it.id,
-        'system.damageAttribute': TEMPLATE.attributes.strength,
+        'system.damageAttribute': TEMPLATE.actorAttributes.strength,
         'system.strength': undefined,
       }
     };
@@ -269,7 +269,7 @@ class _11_1_16_MigrateSkillsAttributes extends Migration {
         return {
           _id: it.id,
           'system.attribute': '',
-          'system.code': TEMPLATE.attributes.knowledge
+          'system.code': TEMPLATE.itemAttributes.knowledge
         }
       }));
   }

--- a/src/modules/roll/roll-dialog.js
+++ b/src/modules/roll/roll-dialog.js
@@ -81,7 +81,7 @@ export class RollDialog extends HandlebarsApplicationMixin(ApplicationV2) {
     const rollData = foundry.utils.mergeObject(RollDialog.prepareActorRoll(actor), {
       mode: ANARCHY_SYSTEM.rollType.skill,
       skill: skill,
-      attribute1: skill?.system.attribute ?? TEMPLATE.attributes.agility,
+      attribute1: skill?.system.attribute ?? TEMPLATE.actorAttributes.agility,
       specialization: specialization,
     });
     await RollDialog.create(rollData);

--- a/src/modules/roll/roll-parameters.js
+++ b/src/modules/roll/roll-parameters.js
@@ -362,11 +362,11 @@ const DEFAULT_ROLL_PARAMETERS = [
     factory: context => {
       const poolOrder = [
         TEMPLATE.counters.edgePools.grit,
+        TEMPLATE.counters.edgePools.chaos,
         TEMPLATE.counters.edgePools.insight,
         TEMPLATE.counters.edgePools.rumor,
         TEMPLATE.counters.edgePools.legend,
         TEMPLATE.counters.edgePools.credibility,
-        TEMPLATE.counters.edgePools.chaos,
       ];
       const edgePools = poolOrder.map(code => {
         const value = context.actor.getEdgePoolValue(code);

--- a/src/modules/skills.js
+++ b/src/modules/skills.js
@@ -6,7 +6,7 @@ import { Misc } from "./misc.js";
 const SELECTED_SKILL_LIST = "selected-skill-list";
 const SETTING_KEY_SELECTED_SKILL_LIST = `${SYSTEM_NAME}.${SELECTED_SKILL_LIST}`;
 
-const ATTR = TEMPLATE.attributes;
+const ATTR = TEMPLATE.actorAttributes;
 const DEFENSE = ANARCHY_SYSTEM.defenses;
 
 const DEFAULT_SKILLSET_ANARCHY = 'shadowrun-anarchy-en';

--- a/style.css
+++ b/style.css
@@ -1791,4 +1791,73 @@
   width: calc(100% - 16px);
 }
 
+/* Sheet layout helpers to organize actor templates into stable grids */
+.sheet-layout {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 10px;
+  align-items: start;
+}
+
+.sheet-layout.vehicle-layout {
+  grid-template-columns: 1.35fr 1fr;
+}
+
+.sheet-layout.battlemech-layout {
+  grid-template-columns: 1.4fr 1fr;
+}
+
+.sheet-layout .sheet-column {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.sheet-layout .section-group,
+.sheet-layout .section-attributes,
+.sheet-layout .anarchy-block,
+.sheet-layout .items-group {
+  width: 100%;
+}
+
+.sheet-layout .section-group,
+.sheet-layout .section-attributes {
+  display: block;
+  margin-bottom: 0;
+}
+
+.sheet-layout .anarchy-attributes {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+  gap: 6px;
+}
+
+.word-grid {
+  display: grid;
+  grid-template-columns: 0.9fr 1.2fr 1fr;
+  gap: 8px;
+}
+
+.stacked-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 8px;
+}
+
+.stacked-grid.tertiary-grid {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.character-monitor-grid,
+.vehicle-monitor-grid,
+.mech-monitor-grid {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.mech-monitor-grid textarea.info-value {
+  min-height: 60px;
+}
+
 /*# sourceMappingURL=style.css.map */

--- a/templates/actor/battlemech.hbs
+++ b/templates/actor/battlemech.hbs
@@ -32,92 +32,101 @@
     </div>
   </header>
   <section class="sheet-body">
-    <div class="anarchy-block quick-actions-block">
-      <div class="section-group-header">{{localize 'ANARCHY.actor.vehicle.quickActions.title'}}</div>
-      {{> "systems/mwd/templates/actor/parts/mech-quick-actions.hbs"}}
-    </div>
-    <div class="section-attributes anarchy-attributes">
-      {{> "systems/mwd/templates/actor/vehicle/vehicle-attributes.hbs"}}
-    </div>
-    <div class="section-group monitors-row">
-      <div class="anarchy-block">
-        {{> "systems/mwd/templates/monitors/structure.hbs"}}
-      </div>
-      <div class="anarchy-block">
-        {{> "systems/mwd/templates/monitors/armor.hbs"}}
-      </div>
-      <div class="anarchy-block mech-heat-block">
-        {{> "systems/mwd/templates/monitors/heat.hbs"}}
-        <div class="heat-thresholds">
-          <label class="monitor-label">{{localize 'ANARCHY.actor.battlemech.heat.thresholds'}}</label>
-          <div class="heat-threshold-row">
-            <span>{{localize 'ANARCHY.actor.battlemech.heat.runningHot'}}</span>
-            <input class="info-value" type="number" data-dtype="Number" name="system.mwd.heat.thresholds.runningHot" value="{{system.mwd.heat.thresholds.runningHot}}" />
-          </div>
-          <div class="heat-threshold-row">
-            <span>{{localize 'ANARCHY.actor.battlemech.heat.overheated'}}</span>
-            <input class="info-value" type="number" data-dtype="Number" name="system.mwd.heat.thresholds.overheated" value="{{system.mwd.heat.thresholds.overheated}}" />
-          </div>
-          <div class="heat-threshold-row">
-            <span>{{localize 'ANARCHY.actor.battlemech.heat.shutdown'}}</span>
-            <input class="info-value" type="number" data-dtype="Number" name="system.mwd.heat.thresholds.shutdown" value="{{system.mwd.heat.thresholds.shutdown}}" />
-          </div>
-          <div class="heat-status">{{localize 'ANARCHY.actor.battlemech.heat.statusLabel'}}: {{system.mwd.heatStatus.label}}</div>
+    <div class="sheet-layout battlemech-layout">
+      <div class="sheet-column">
+        <div class="anarchy-block quick-actions-block">
+          <div class="section-group-header">{{localize 'ANARCHY.actor.vehicle.quickActions.title'}}</div>
+          {{> "systems/mwd/templates/actor/parts/mech-quick-actions.hbs"}}
         </div>
-      </div>
-    </div>
-    <div class="section-group monitors-row">
-      <div class="anarchy-block">
-        <label class="monitor-label">{{localize ANARCHY.actor.vehicle.criticalTrack}}</label>
-        {{> "systems/mwd/templates/common/checkbar.hbs"
-          code='criticals'
-          value=system.hybrid.criticals.value
-          max=system.hybrid.criticals.max
-          rowlength=6
-        }}
-        <textarea class="info-value" name="system.hybrid.criticals.notes" rows="3" placeholder="{{localize ANARCHY.actor.vehicle.criticalTrack}}">{{system.hybrid.criticals.notes}}</textarea>
-      </div>
-      <div class="anarchy-block hybrid-locations">
-        <label class="monitor-label">{{localize ANARCHY.actor.monitors.armor}}</label>
-        <div class="flexcol location-grid">
-          <div class="flexrow location-row">
-            <span class="location-label">{{localize ANARCHY.actor.vehicle.locationFront}}</span>
-            <input class="info-value" type="text" name="system.hybrid.locations.front" value="{{system.hybrid.locations.front}}" />
+
+        <div class="section-attributes anarchy-attributes anarchy-block">
+          {{> "systems/mwd/templates/actor/vehicle/vehicle-attributes.hbs"}}
+        </div>
+
+        <div class="mech-monitor-grid">
+          <div class="anarchy-block">
+            {{> "systems/mwd/templates/monitors/structure.hbs"}}
           </div>
-          <div class="flexrow location-row">
-            <span class="location-label">{{localize ANARCHY.actor.vehicle.locationSide}}</span>
-            <input class="info-value" type="text" name="system.hybrid.locations.sides" value="{{system.hybrid.locations.sides}}" />
+          <div class="anarchy-block">
+            {{> "systems/mwd/templates/monitors/armor.hbs"}}
           </div>
-          <div class="flexrow location-row">
-            <span class="location-label">{{localize ANARCHY.actor.vehicle.locationRear}}</span>
-            <input class="info-value" type="text" name="system.hybrid.locations.rear" value="{{system.hybrid.locations.rear}}" />
-          </div>
-          <div class="flexrow location-row">
-            <span class="location-label">{{localize ANARCHY.actor.vehicle.locationCore}}</span>
-            <input class="info-value" type="text" name="system.hybrid.locations.core" value="{{system.hybrid.locations.core}}" />
+          <div class="anarchy-block mech-heat-block">
+            {{> "systems/mwd/templates/monitors/heat.hbs"}}
+            <div class="heat-thresholds">
+              <label class="monitor-label">{{localize 'ANARCHY.actor.battlemech.heat.thresholds'}}</label>
+              <div class="heat-threshold-row">
+                <span>{{localize 'ANARCHY.actor.battlemech.heat.runningHot'}}</span>
+                <input class="info-value" type="number" data-dtype="Number" name="system.mwd.heat.thresholds.runningHot" value="{{system.mwd.heat.thresholds.runningHot}}" />
+              </div>
+              <div class="heat-threshold-row">
+                <span>{{localize 'ANARCHY.actor.battlemech.heat.overheated'}}</span>
+                <input class="info-value" type="number" data-dtype="Number" name="system.mwd.heat.thresholds.overheated" value="{{system.mwd.heat.thresholds.overheated}}" />
+              </div>
+              <div class="heat-threshold-row">
+                <span>{{localize 'ANARCHY.actor.battlemech.heat.shutdown'}}</span>
+                <input class="info-value" type="number" data-dtype="Number" name="system.mwd.heat.thresholds.shutdown" value="{{system.mwd.heat.thresholds.shutdown}}" />
+              </div>
+              <div class="heat-status">{{localize 'ANARCHY.actor.battlemech.heat.statusLabel'}}: {{system.mwd.heatStatus.label}}</div>
+            </div>
           </div>
         </div>
+
+        <div class="mech-monitor-grid">
+          <div class="anarchy-block">
+            <label class="monitor-label">{{localize ANARCHY.actor.vehicle.criticalTrack}}</label>
+            {{> "systems/mwd/templates/common/checkbar.hbs"
+              code='criticals'
+              value=system.hybrid.criticals.value
+              max=system.hybrid.criticals.max
+              rowlength=6
+            }}
+            <textarea class="info-value" name="system.hybrid.criticals.notes" rows="3" placeholder="{{localize ANARCHY.actor.vehicle.criticalTrack}}">{{system.hybrid.criticals.notes}}</textarea>
+          </div>
+          <div class="anarchy-block hybrid-locations">
+            <label class="monitor-label">{{localize ANARCHY.actor.monitors.armor}}</label>
+            <div class="flexcol location-grid">
+              <div class="flexrow location-row">
+                <span class="location-label">{{localize ANARCHY.actor.vehicle.locationFront}}</span>
+                <input class="info-value" type="text" name="system.hybrid.locations.front" value="{{system.hybrid.locations.front}}" />
+              </div>
+              <div class="flexrow location-row">
+                <span class="location-label">{{localize ANARCHY.actor.vehicle.locationSide}}</span>
+                <input class="info-value" type="text" name="system.hybrid.locations.sides" value="{{system.hybrid.locations.sides}}" />
+              </div>
+              <div class="flexrow location-row">
+                <span class="location-label">{{localize ANARCHY.actor.vehicle.locationRear}}</span>
+                <input class="info-value" type="text" name="system.hybrid.locations.rear" value="{{system.hybrid.locations.rear}}" />
+              </div>
+              <div class="flexrow location-row">
+                <span class="location-label">{{localize ANARCHY.actor.vehicle.locationCore}}</span>
+                <input class="info-value" type="text" name="system.hybrid.locations.core" value="{{system.hybrid.locations.core}}" />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="stacked-grid">
+          <div class="anarchy-block">
+            {{> "systems/mwd/templates/actor/parts/battlemech-hardpoints.hbs"}}
+          </div>
+          <div class="anarchy-block">
+            {{> "systems/mwd/templates/actor/parts/battlemech-weapon-groups.hbs"}}
+          </div>
+        </div>
       </div>
-    </div>
-    <div class="section-group items-group">
-      <div class="anarchy-block">
-        {{> "systems/mwd/templates/actor/parts/battlemech-hardpoints.hbs"}}
+
+      <div class="sheet-column sidebar">
+        <div class="anarchy-block">
+          {{> "systems/mwd/templates/actor/parts/battlemech-loadout.hbs"}}
+        </div>
+        <div class="anarchy-block">
+          {{> "systems/mwd/templates/actor/parts/battlemech-weapons.hbs"}}
+        </div>
+        <div class="anarchy-block">
+          {{> 'systems/mwd/templates/actor/parts/description.hbs'}}
+          {{> 'systems/mwd/templates/actor/parts/gmnotes.hbs'}}
+        </div>
       </div>
-    </div>
-    <div class="section-group items-group">
-      <div class="anarchy-block">
-        {{> "systems/mwd/templates/actor/parts/battlemech-weapon-groups.hbs"}}
-      </div>
-    </div>
-    <div class="section-group items-group">
-      {{> "systems/mwd/templates/actor/parts/battlemech-loadout.hbs"}}
-    </div>
-    <div class="section-group items-group">
-      {{> "systems/mwd/templates/actor/parts/battlemech-weapons.hbs"}}
-    </div>
-    <div class="anarchy-block">
-      {{> 'systems/mwd/templates/actor/parts/description.hbs'}}
-      {{> 'systems/mwd/templates/actor/parts/gmnotes.hbs'}}
     </div>
   </section>
 </form>

--- a/templates/actor/character.hbs
+++ b/templates/actor/character.hbs
@@ -31,80 +31,91 @@
     </div>
   </header>
   <section class="sheet-body">
-    <div class="section-attributes anarchy-attributes">
-      {{> "systems/mwd/templates/actor/parts/attributes.hbs"}}
-    </div>
-    <div class="section-group anarchy-words-section">
-      <div class="anarchy-words anarchy-keywords">
-      {{> "systems/mwd/templates/actor/parts/words.hbs" wordType='keywords' values=system.keywords}}
-      </div>
-      <div class="anarchy-words anarchy-cues">
-      {{> "systems/mwd/templates/actor/parts/words.hbs" wordType='cues' values=system.cues}}
-      </div>
-      <div class="anarchy-words anarchy-dispositions">
-      {{> "systems/mwd/templates/actor/parts/words.hbs" wordType='dispositions' values=system.dispositions}}
-      </div>
-    </div>
-    <div class="section-group items-group">
-    {{> "systems/mwd/templates/actor/parts/skills.hbs"}}
-    </div>
-    <div class="section-group items-group">
-    {{> "systems/mwd/templates/actor/parts/asset-modules.hbs"}}
-    </div>
-    <div class="section-group items-group">
-    {{> "systems/mwd/templates/actor/parts/qualities.hbs"}}
-    </div>
-    <div class="section-group items-group">
-    {{> "systems/mwd/templates/actor/parts/weapons.hbs"}}
-    </div>
-    <div class="section-group monitors-row">
-      <div class="anarchy-block">
-        {{> "systems/mwd/templates/monitors/armor.hbs"}}
-      </div>
-      <div class="anarchy-block">
-        {{> "systems/mwd/templates/monitors/physical.hbs"}}
-      </div>
-      <div class="anarchy-block">
-        {{> "systems/mwd/templates/monitors/fatigue.hbs"}}
-      </div>
-      <div class="anarchy-block flexcol edge-pools">
-        {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='grit'}}
-        {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='insight'}}
-      </div>
-      <div class="anarchy-block flexcol edge-pools">
-        {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='rumor'}}
-        {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='legend'}}
-      </div>
-      <div class="anarchy-block flexcol edge-pools">
-        {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='credibility'}}
-        {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='chaos'}}
-      </div>
-      <div class="anarchy-block flexcol">
-        {{> "systems/mwd/templates/monitors/anarchy-actor.hbs"}}
-      </div>
-    </div>
-    <div class="section-group items-group">
-    {{> "systems/mwd/templates/actor/parts/cyberdecks.hbs"}}
-    </div>
-    <div class="section-group">
-      <div class="items-group third-width">
-      {{> "systems/mwd/templates/actor/parts/owned-actors.hbs"}}
-      {{> "systems/mwd/templates/actor/parts/gears.hbs"}}
-      </div>
-      <div class="items-group third-width">
-      {{> "systems/mwd/templates/actor/parts/contacts.hbs"}}
-      </div>
-      <div class="items-group third-width">
-      </div>
-    </div>
+    <div class="sheet-layout character-layout">
+      <div class="sheet-column">
+        <div class="section-attributes anarchy-attributes anarchy-block">
+          {{> "systems/mwd/templates/actor/parts/attributes.hbs"}}
+        </div>
 
-    <div class="anarchy-block">
-      {{> 'systems/mwd/templates/actor/parts/life-modules.hbs'}}
-    </div>
+        <div class="anarchy-block word-grid">
+          <div class="anarchy-words anarchy-keywords">
+          {{> "systems/mwd/templates/actor/parts/words.hbs" wordType='keywords' values=system.keywords}}
+          </div>
+          <div class="anarchy-words anarchy-cues">
+          {{> "systems/mwd/templates/actor/parts/words.hbs" wordType='cues' values=system.cues}}
+          </div>
+          <div class="anarchy-words anarchy-dispositions">
+          {{> "systems/mwd/templates/actor/parts/words.hbs" wordType='dispositions' values=system.dispositions}}
+          </div>
+        </div>
 
-    <div class="anarchy-block">
-      {{> 'systems/mwd/templates/actor/parts/description.hbs'}}
-      {{> 'systems/mwd/templates/actor/parts/gmnotes.hbs'}}
+        <div class="stacked-grid">
+          <div class="anarchy-block">
+          {{> "systems/mwd/templates/actor/parts/skills.hbs"}}
+          </div>
+          <div class="anarchy-block">
+          {{> "systems/mwd/templates/actor/parts/asset-modules.hbs"}}
+          </div>
+          <div class="anarchy-block">
+          {{> "systems/mwd/templates/actor/parts/qualities.hbs"}}
+          </div>
+          <div class="anarchy-block">
+          {{> "systems/mwd/templates/actor/parts/weapons.hbs"}}
+          </div>
+        </div>
+
+        <div class="stacked-grid tertiary-grid">
+          <div class="anarchy-block">
+          {{> "systems/mwd/templates/actor/parts/cyberdecks.hbs"}}
+          </div>
+          <div class="anarchy-block">
+          {{> "systems/mwd/templates/actor/parts/owned-actors.hbs"}}
+          </div>
+          <div class="anarchy-block">
+          {{> "systems/mwd/templates/actor/parts/gears.hbs"}}
+          </div>
+          <div class="anarchy-block">
+          {{> "systems/mwd/templates/actor/parts/contacts.hbs"}}
+          </div>
+          <div class="anarchy-block">
+          {{> 'systems/mwd/templates/actor/parts/life-modules.hbs'}}
+          </div>
+        </div>
+
+        <div class="anarchy-block">
+          {{> 'systems/mwd/templates/actor/parts/description.hbs'}}
+          {{> 'systems/mwd/templates/actor/parts/gmnotes.hbs'}}
+        </div>
+      </div>
+
+      <div class="sheet-column sidebar">
+        <div class="character-monitor-grid">
+          <div class="anarchy-block">
+            {{> "systems/mwd/templates/monitors/armor.hbs"}}
+          </div>
+          <div class="anarchy-block">
+            {{> "systems/mwd/templates/monitors/physical.hbs"}}
+          </div>
+          <div class="anarchy-block">
+            {{> "systems/mwd/templates/monitors/fatigue.hbs"}}
+          </div>
+          <div class="anarchy-block flexcol edge-pools">
+            {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='grit'}}
+            {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='insight'}}
+          </div>
+          <div class="anarchy-block flexcol edge-pools">
+            {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='rumor'}}
+            {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='legend'}}
+          </div>
+          <div class="anarchy-block flexcol edge-pools">
+            {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='credibility'}}
+            {{> "systems/mwd/templates/monitors/edge-pool.hbs" code='chaos'}}
+          </div>
+          <div class="anarchy-block flexcol">
+            {{> "systems/mwd/templates/monitors/anarchy-actor.hbs"}}
+          </div>
+        </div>
+      </div>
     </div>
   </section>
 </form>

--- a/templates/actor/npc-sheet.hbs
+++ b/templates/actor/npc-sheet.hbs
@@ -24,37 +24,44 @@
           {{/if}}
         </div>
       </div>
-      {{> "systems/mwd/templates/common/view-mode.hbs"}}
     </div>
   </header>
 
   <section class="sheet-body">
-    <div class="section-attributes anarchy-attributes">
-      {{> "systems/mwd/templates/actor/parts/attributes.hbs"}}
-    </div>
-    <div class="section-group monitors-row">
-      <div class="anarchy-block flexcol">
-        {{> "systems/mwd/templates/monitors/armor.hbs"}}
-      </div>
-      <div class="anarchy-block flexrow">
-        {{> "systems/mwd/templates/monitors/physical.hbs"}}
-      </div>
-      <div class="anarchy-block flexrow">
-        {{> "systems/mwd/templates/monitors/fatigue.hbs"}}
-      </div>
-    </div>
+    <div class="sheet-layout npc-layout">
+      <div class="sheet-column">
+        <div class="section-attributes anarchy-attributes anarchy-block">
+          {{> "systems/mwd/templates/actor/parts/attributes.hbs"}}
+        </div>
 
-    <div class="section-group">
-      <div class="section-group items-group half-width">
-        {{> "systems/mwd/templates/actor/npc-parts/skills.hbs"}}
+        <div class="stacked-grid">
+          <div class="anarchy-block">
+            {{> "systems/mwd/templates/actor/npc-parts/skills.hbs"}}
+          </div>
+          <div class="anarchy-block">
+          {{> "systems/mwd/templates/actor/npc-parts/weapons.hbs"}}
+          </div>
+        </div>
+
+        <div class="anarchy-block">
+        {{> 'systems/mwd/templates/actor/parts/description.hbs'}}
+        {{> 'systems/mwd/templates/actor/parts/gmnotes.hbs'}}
+        </div>
       </div>
-      <div class="section-group items-group half-width">
-      {{> "systems/mwd/templates/actor/npc-parts/weapons.hbs"}}
+
+      <div class="sheet-column sidebar">
+        <div class="character-monitor-grid">
+          <div class="anarchy-block flexcol">
+            {{> "systems/mwd/templates/monitors/armor.hbs"}}
+          </div>
+          <div class="anarchy-block flexrow">
+            {{> "systems/mwd/templates/monitors/physical.hbs"}}
+          </div>
+          <div class="anarchy-block flexrow">
+            {{> "systems/mwd/templates/monitors/fatigue.hbs"}}
+          </div>
+        </div>
       </div>
-    </div>
-    <div class="anarchy-block">
-    {{> 'systems/mwd/templates/actor/parts/description.hbs'}}
-    {{> 'systems/mwd/templates/actor/parts/gmnotes.hbs'}}
     </div>
   </section>
 </form>

--- a/templates/actor/vehicle.hbs
+++ b/templates/actor/vehicle.hbs
@@ -25,26 +25,35 @@
     </div>
   </header>
   <section class="sheet-body">
-    <div class="section-attributes anarchy-attributes">
-      {{> "systems/mwd/templates/actor/vehicle/vehicle-attributes.hbs"}}
-    </div>
-    <div class="section-group monitors-row">
-      <div class="anarchy-block">
-      {{> "systems/mwd/templates/monitors/structure.hbs"}}
+    <div class="sheet-layout vehicle-layout">
+      <div class="sheet-column">
+        <div class="section-attributes anarchy-attributes anarchy-block">
+          {{> "systems/mwd/templates/actor/vehicle/vehicle-attributes.hbs"}}
+        </div>
+
+        <div class="vehicle-monitor-grid">
+          <div class="anarchy-block">
+          {{> "systems/mwd/templates/monitors/structure.hbs"}}
+          </div>
+          <div class="anarchy-block">
+          {{> "systems/mwd/templates/monitors/armor.hbs"}}
+          </div>
+        </div>
+
+        <div class="anarchy-block">
+        {{> "systems/mwd/templates/actor/npc-parts/asset-modules.hbs"}}
+        </div>
       </div>
-      <div class="anarchy-block">
-      {{> "systems/mwd/templates/monitors/armor.hbs"}}
+
+      <div class="sheet-column sidebar">
+        <div class="anarchy-block">
+        {{> "systems/mwd/templates/actor/vehicle/vehicle-weapons.hbs"}}
+        </div>
+        <div class="anarchy-block">
+          {{> 'systems/mwd/templates/actor/parts/description.hbs'}}
+          {{> 'systems/mwd/templates/actor/parts/gmnotes.hbs'}}
+        </div>
       </div>
-    </div>
-    <div class="section-group items-group">
-    {{> "systems/mwd/templates/actor/npc-parts/asset-modules.hbs"}}
-    </div>
-    <div class="section-group items-group">
-    {{> "systems/mwd/templates/actor/vehicle/vehicle-weapons.hbs"}}
-    </div>
-    <div class="anarchy-block">
-      {{> 'systems/mwd/templates/actor/parts/description.hbs'}}
-      {{> 'systems/mwd/templates/actor/parts/gmnotes.hbs'}}
     </div>
   </section>
 </form>


### PR DESCRIPTION
## Summary
- restructure character, NPC, vehicle, and battlemech sheets into grid-based layouts that separate primary content from monitors and controls
- add shared layout helpers to provide consistent column widths and reduce flex wrapping on actor templates

## Testing
- npm run validate:json

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930c10d1f04832d8f6df91909ebc141)