### PR TITLE
Refresh character sheet layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -119,6 +119,147 @@
   object-fit: cover;
   width: 100%;
 }
+
+.character-sheet {
+  --character-panel-bg: #f6f1e7;
+  --character-panel-border: #d7cbb8;
+  --character-panel-shadow: 0 2px 6px rgba(46, 35, 17, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  height: 100%;
+}
+
+.character-sheet .sheet-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.character-sheet .passport-header {
+  align-items: center;
+  background: rgba(255, 255, 255, 0.93);
+  border: 1px solid var(--character-panel-border);
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(46, 35, 17, 0.16);
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: 120px 1fr auto;
+  padding: 0.5rem;
+}
+
+@media (max-width: 700px) {
+  .character-sheet .passport-header {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto auto;
+  }
+
+  .character-sheet .passport-header .passport-img {
+    justify-self: center;
+  }
+}
+
+.character-sheet .passport-img img {
+  background: #f1eadf;
+  border: 1px solid var(--character-panel-border);
+  border-radius: 8px;
+  height: 120px;
+  object-fit: cover;
+  width: 120px;
+}
+
+.character-sheet .passport-column {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.character-sheet .passport-details-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.5rem;
+}
+
+.character-sheet .passport-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.character-sheet .passport-label {
+  font-weight: 600;
+}
+
+.character-sheet .passport-input,
+.character-sheet .passport-detail input {
+  width: 100%;
+}
+
+.character-sheet .passport-action-row {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.character-sheet .passport-action {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.character-sheet .section-group,
+.character-sheet .anarchy-block,
+.character-sheet .section-attributes,
+.character-sheet .items-group {
+  background: rgba(255, 255, 255, 0.93);
+  border: 1px solid var(--character-panel-border);
+  border-radius: 10px;
+  box-shadow: var(--character-panel-shadow);
+  padding: 0.75rem;
+}
+
+.character-sheet .section-group {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.character-sheet .items-group {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 0.75rem;
+}
+
+.character-sheet .section-group-header {
+  border-bottom: 1px solid var(--character-panel-border);
+  font-family: "BebasNeue", var(--font-primary);
+  letter-spacing: 1px;
+  margin-bottom: 0.35rem;
+  padding-bottom: 0.25rem;
+}
+
+.character-sheet .anarchy-words-section {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.character-sheet .monitors-row {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.character-sheet .experience-grid {
+  display: grid;
+  gap: 0.35rem;
+  grid-template-columns: 1fr 80px;
+  align-items: center;
+}
+
+.character-sheet .experience-grid input {
+  width: 100%;
+}
 .sheet .character-enhanced header .name-attributes {
   display: flex;
   flex-direction: column;

--- a/templates/actor/character.hbs
+++ b/templates/actor/character.hbs
@@ -1,326 +1,108 @@
-<form class="{{cssClass}} flexcol character-sheet" autocomplete="off">
+{{#if options.limited}}
+{{>"systems/mwd/templates/actor/character-limited.hbs"}}
+{{else}}
+<form class="{{options.cssClass}} character-sheet" autocomplete="off">
   <header class="sheet-header">
-    <div class="character-identity flexrow">
-      <div class="portrait">
-        <img class="profile-img" src="{{data.img}}" data-edit="img" data-tooltip="{{data.name}}" />
+    <div class="passport-header">
+      <div class="passport-img">
+        <img class="anarchy-img profile-img" src="{{data.img}}" data-edit="img" data-tooltip="{{data.name}}" />
       </div>
-      <div class="identity-fields flexcol">
-        <label>{{localize 'Name'}}</label>
-        <input type="text" name="name" value="{{data.name}}" />
+      <div class="passport-column">
+        {{> "systems/mwd/templates/actor/parts/passport-details.hbs"}}
+        <div class="passport-action-row">
+          <div class="passport-action">
+            {{> "systems/mwd/templates/actor/parts/attributebuttons.hbs"}}
+          </div>
+          {{#if ownerActor}}
+          <div class="passport-action">
+            {{> 'systems/mwd/templates/actor/parts/ownership.hbs'}}
+          </div>
+          {{/if}}
+        </div>
       </div>
+      {{> "systems/mwd/templates/common/view-mode.hbs"}}
     </div>
   </header>
 
-  <section class="sheet-body flexcol">
-    <section class="sheet-section attributes">
-      <h2>{{localize 'ANARCHY.actor.section.attributes'}}</h2>
-      <div class="attribute-grid">
-        <label>{{localize 'ANARCHY.attributes.strength'}}</label>
-        <input type="number" name="system.attributes.strength.value" value="{{system.attributes.strength.value}}" />
-        <label>{{localize 'ANARCHY.attributes.reflexes'}}</label>
-        <input type="number" name="system.attributes.reflexes.value" value="{{system.attributes.reflexes.value}}" />
-        <label>{{localize 'ANARCHY.attributes.intelligence'}}</label>
-        <input type="number" name="system.attributes.intelligence.value" value="{{system.attributes.intelligence.value}}" />
-        <label>{{localize 'ANARCHY.attributes.willpower'}}</label>
-        <input type="number" name="system.attributes.willpower.value" value="{{system.attributes.willpower.value}}" />
-        <label>{{localize 'ANARCHY.attributes.charisma'}}</label>
-        <input type="number" name="system.attributes.charisma.value" value="{{system.attributes.charisma.value}}" />
-        <label>{{localize 'ANARCHY.attributes.edge'}}</label>
-        <input type="number" name="system.attributes.edge.value" value="{{system.attributes.edge.value}}" />
-      </div>
-    </section>
+  <section class="sheet-body">
+    <div class="section-attributes anarchy-attributes">
+      {{> "systems/mwd/templates/actor/parts/attributes.hbs"}}
+    </div>
 
-    <section class="sheet-section skills define-item-type" data-item-type="skill">
-      <div class="section-header flexrow">
-        <h2>{{localize 'ANARCHY.itemType.plural.skill'}}</h2>
-        <button type="button" class="click-item-add">{{localize 'ANARCHY.common.add'}}</button>
+    <div class="section-group anarchy-words-section">
+      <div class="anarchy-words anarchy-keywords">
+      {{> "systems/mwd/templates/actor/parts/words.hbs" wordType='keywords' values=system.keywords}}
       </div>
-      <ul class="item-list">
-        {{#each items.skill as |skill|}}
-          <li class="item" data-item-id="{{skill.id}}">
-            <span class="item-name click-item-edit">{{skill.name}}</span>
-            <span class="item-value">{{skill.system.value}}</span>
-            <div class="item-controls">
-              <button type="button" class="click-item-edit">{{localize 'ANARCHY.common.edit'}}</button>
-              <button type="button" class="click-item-delete">{{localize 'ANARCHY.common.delete'}}</button>
-            </div>
-          </li>
-        {{/each}}
-      </ul>
-    </section>
+      <div class="anarchy-words anarchy-cues">
+      {{> "systems/mwd/templates/actor/parts/words.hbs" wordType='cues' values=system.cues}}
+      </div>
+      <div class="anarchy-words anarchy-dispositions">
+      {{> "systems/mwd/templates/actor/parts/words.hbs" wordType='dispositions' values=system.dispositions}}
+      </div>
+    </div>
 
-    <section class="sheet-section life-modules define-item-type" data-item-type="lifeModule">
-      <div class="section-header flexrow">
-        <h2>{{localize 'ANARCHY.itemType.plural.lifeModule'}}</h2>
-        <button type="button" class="click-item-add">{{localize 'ANARCHY.common.add'}}</button>
+    <div class="section-group items-group">
+      {{> "systems/mwd/templates/actor/parts/skills.hbs"}}
+      {{> "systems/mwd/templates/actor/parts/life-modules.hbs"}}
+    </div>
+
+    <div class="section-group items-group">
+      {{> "systems/mwd/templates/actor/parts/asset-modules.hbs"}}
+      {{> "systems/mwd/templates/actor/parts/qualities.hbs"}}
+    </div>
+
+    <div class="section-group items-group">
+      {{> "systems/mwd/templates/actor/parts/weapons.hbs"}}
+      {{> "systems/mwd/templates/actor/parts/gears.hbs"}}
+    </div>
+
+    <div class="section-group items-group">
+      {{> "systems/mwd/templates/actor/parts/contacts.hbs"}}
+      {{#if ownedActors}}
+      {{> "systems/mwd/templates/actor/parts/owned-actors.hbs"}}
+      {{/if}}
+    </div>
+
+    <div class="section-group monitors-row">
+      <div class="anarchy-block">
+        {{> "systems/mwd/templates/monitors/armor.hbs"}}
       </div>
-      <div class="life-module-columns">
-        <div class="life-module-group">
-          <h3>{{localize 'ANARCHY.item.lifeModule.type.faction'}}</h3>
-          <ul class="item-list">
-            {{#each items.lifeModule as |module|}}
-              {{#if (eq module.system.moduleType 'faction')}}
-                <li class="item" data-item-id="{{module.id}}">
-                  <span class="item-name click-item-edit">{{module.name}}</span>
-                  <div class="item-controls">
-                    <button type="button" class="click-item-edit">{{localize 'ANARCHY.common.edit'}}</button>
-                    <button type="button" class="click-item-delete">{{localize 'ANARCHY.common.delete'}}</button>
-                  </div>
-                </li>
-              {{/if}}
-            {{/each}}
-          </ul>
-        </div>
-        <div class="life-module-group">
-          <h3>{{localize 'ANARCHY.item.lifeModule.type.childhood'}}</h3>
-          <ul class="item-list">
-            {{#each items.lifeModule as |module|}}
-              {{#if (eq module.system.moduleType 'childhood')}}
-                <li class="item" data-item-id="{{module.id}}">
-                  <span class="item-name click-item-edit">{{module.name}}</span>
-                  <div class="item-controls">
-                    <button type="button" class="click-item-edit">{{localize 'ANARCHY.common.edit'}}</button>
-                    <button type="button" class="click-item-delete">{{localize 'ANARCHY.common.delete'}}</button>
-                  </div>
-                </li>
-              {{/if}}
-            {{/each}}
-          </ul>
-        </div>
-        <div class="life-module-group">
-          <h3>{{localize 'ANARCHY.item.lifeModule.type.higherEducation'}}</h3>
-          <ul class="item-list">
-            {{#each items.lifeModule as |module|}}
-              {{#if (eq module.system.moduleType 'higherEducation')}}
-                <li class="item" data-item-id="{{module.id}}">
-                  <span class="item-name click-item-edit">{{module.name}}</span>
-                  <div class="item-controls">
-                    <button type="button" class="click-item-edit">{{localize 'ANARCHY.common.edit'}}</button>
-                    <button type="button" class="click-item-delete">{{localize 'ANARCHY.common.delete'}}</button>
-                  </div>
-                </li>
-              {{/if}}
-            {{/each}}
-          </ul>
-        </div>
-        <div class="life-module-group">
-          <h3>{{localize 'ANARCHY.item.lifeModule.type.realLife'}}</h3>
-          <ul class="item-list">
-            {{#each items.lifeModule as |module|}}
-              {{#if (eq module.system.moduleType 'realLife')}}
-                <li class="item" data-item-id="{{module.id}}">
-                  <span class="item-name click-item-edit">{{module.name}}</span>
-                  <div class="item-controls">
-                    <button type="button" class="click-item-edit">{{localize 'ANARCHY.common.edit'}}</button>
-                    <button type="button" class="click-item-delete">{{localize 'ANARCHY.common.delete'}}</button>
-                  </div>
-                </li>
-              {{/if}}
-            {{/each}}
-          </ul>
+      <div class="anarchy-block">
+        {{> "systems/mwd/templates/monitors/physical.hbs"}}
+      </div>
+      <div class="anarchy-block">
+        {{> "systems/mwd/templates/monitors/fatigue.hbs"}}
+      </div>
+      <div class="anarchy-block flexcol">
+        {{> "systems/mwd/templates/monitors/edge.hbs"}}
+        {{> "systems/mwd/templates/monitors/anarchy-actor.hbs"}}
+      </div>
+    </div>
+
+    <div class="section-group items-group">
+      <div class="anarchy-block">
+        {{> "systems/mwd/templates/monitors/edge-pool.hbs"}}
+      </div>
+      <div class="anarchy-block experience-block">
+        <h3 class="section-group-header">{{localize 'ANARCHY.actor.counters.xp'}}</h3>
+        <div class="experience-grid">
+          <label for="system.counters.xp.value">{{localize 'ANARCHY.actor.counters.current'}}</label>
+          <input type="number" name="system.counters.xp.value" value="{{system.counters.xp.value}}" data-dtype="Number" {{#if options.viewMode}}disabled{{/if}} />
+          <label for="system.counters.xp.total">{{localize 'ANARCHY.actor.counters.lifetime'}}</label>
+          <input type="number" name="system.counters.xp.total" value="{{system.counters.xp.total}}" data-dtype="Number" {{#if options.viewMode}}disabled{{/if}} />
         </div>
       </div>
-    </section>
-
-    <section class="sheet-section traits define-item-type" data-item-type="quality">
-      <div class="section-header flexrow">
-        <h2>{{localize 'ANARCHY.itemType.plural.quality'}}</h2>
-        <button type="button" class="click-item-add">{{localize 'ANARCHY.common.add'}}</button>
+      <div class="anarchy-block">
+        {{> "systems/mwd/templates/actor/character/social-celebrity.hbs"}}
+        {{> "systems/mwd/templates/monitors/social-credibility.hbs"}}
+        {{> "systems/mwd/templates/monitors/social-rumor.hbs"}}
       </div>
-      <ul class="item-list">
-        {{#each items.quality as |quality|}}
-          <li class="item" data-item-id="{{quality.id}}">
-            <span class="item-name click-item-edit">{{quality.name}}</span>
-            <div class="item-controls">
-              <button type="button" class="click-item-edit">{{localize 'ANARCHY.common.edit'}}</button>
-              <button type="button" class="click-item-delete">{{localize 'ANARCHY.common.delete'}}</button>
-            </div>
-          </li>
-        {{/each}}
-      </ul>
-    </section>
+    </div>
 
-    <section class="sheet-section cues">
-      <div class="section-header flexrow define-wordType" data-word-type="cues">
-        <h2>{{localize 'ANARCHY.actor.words.cues'}}</h2>
-        <button type="button" class="click-word-add">{{localize 'ANARCHY.common.add'}}</button>
-      </div>
-      <ul class="word-list">
-        {{#each system.cues as |cue|}}
-          <li class="word-row define-wordType" data-word-type="cues" data-word-id="{{cue.id}}">
-            <input type="text" class="change-word-value" value="{{cue.word}}" />
-            <button type="button" class="click-word-delete">{{localize 'ANARCHY.common.delete'}}</button>
-          </li>
-        {{/each}}
-      </ul>
-    </section>
-
-    <section class="sheet-section dispositions">
-      <div class="section-header flexrow define-wordType" data-word-type="dispositions">
-        <h2>{{localize 'ANARCHY.actor.words.dispositions'}}</h2>
-        <button type="button" class="click-word-add">{{localize 'ANARCHY.common.add'}}</button>
-      </div>
-      <ul class="word-list">
-        {{#each system.dispositions as |disposition|}}
-          <li class="word-row define-wordType" data-word-type="dispositions" data-word-id="{{disposition.id}}">
-            <input type="text" class="change-word-value" value="{{disposition.word}}" />
-            <button type="button" class="click-word-delete">{{localize 'ANARCHY.common.delete'}}</button>
-          </li>
-        {{/each}}
-      </ul>
-    </section>
-
-    <section class="sheet-section personal-weaponry define-item-type" data-item-type="personalWeapon">
-      <div class="section-header flexrow">
-        <h2>{{localize 'ANARCHY.itemType.plural.personalWeapon'}}</h2>
-        <button type="button" class="click-item-add">{{localize 'ANARCHY.common.add'}}</button>
-      </div>
-      <ul class="item-list">
-        {{#each items.personalWeapon as |weapon|}}
-          <li class="item" data-item-id="{{weapon.id}}">
-            <span class="item-name click-item-edit">{{weapon.name}}</span>
-            <div class="item-controls">
-              <button type="button" class="click-item-edit">{{localize 'ANARCHY.common.edit'}}</button>
-              <button type="button" class="click-item-delete">{{localize 'ANARCHY.common.delete'}}</button>
-            </div>
-          </li>
-        {{/each}}
-      </ul>
-    </section>
-
-    <section class="sheet-section armor">
-      <h2>{{localize 'ANARCHY.actor.monitors.armor'}}</h2>
-      <div class="armor-grid">
-        <label>{{localize 'ANARCHY.common.monitorValue'}}</label>
-        <div class="monitor-inputs">
-          <input type="number" name="system.monitors.armor.value" value="{{system.monitors.armor.value}}" />
-          <span>/</span>
-          <input type="number" name="system.monitors.armor.max" value="{{system.monitors.armor.max}}" />
-        </div>
-        <label>{{localize 'ANARCHY.actor.monitors.effect'}}</label>
-        <input type="text" name="system.monitors.armor.effect" value="{{system.monitors.armor.effect}}" />
-        <label>{{localize 'ANARCHY.actor.monitors.resistance'}}</label>
-        <input type="text" name="system.monitors.armor.resistance" value="{{system.monitors.armor.resistance}}" />
-      </div>
-    </section>
-
-    <section class="sheet-section condition-monitors">
-      <h2>{{localize 'ANARCHY.actor.section.conditionMonitors'}}</h2>
-      <div class="monitor-grid">
-        <div class="monitor-block">
-          <label>{{localize 'ANARCHY.monitor.physical'}}</label>
-          <div class="monitor-inputs">
-            <input type="number" name="system.monitors.physical.value" value="{{system.monitors.physical.value}}" />
-            <span>/</span>
-            <input type="number" name="system.monitors.physical.max" value="{{system.monitors.physical.max}}" />
-          </div>
-        </div>
-        <div class="monitor-block">
-          <label>{{localize 'ANARCHY.monitor.fatigue'}}</label>
-          <div class="monitor-inputs">
-            <input type="number" name="system.monitors.fatigue.value" value="{{system.monitors.fatigue.value}}" />
-            <span>/</span>
-            <input type="number" name="system.monitors.fatigue.max" value="{{system.monitors.fatigue.max}}" />
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <section class="sheet-section asset-modules define-item-type" data-item-type="assetModule">
-      <div class="section-header flexrow">
-        <h2>{{localize 'ANARCHY.itemType.plural.assetModule'}}</h2>
-        <button type="button" class="click-item-add">{{localize 'ANARCHY.common.add'}}</button>
-      </div>
-      <ul class="item-list">
-        {{#each items.assetModule as |asset|}}
-          <li class="item" data-item-id="{{asset.id}}">
-            <span class="item-name click-item-edit">{{asset.name}}</span>
-            <div class="item-controls">
-              <button type="button" class="click-item-edit">{{localize 'ANARCHY.common.edit'}}</button>
-              <button type="button" class="click-item-delete">{{localize 'ANARCHY.common.delete'}}</button>
-            </div>
-          </li>
-        {{/each}}
-      </ul>
-    </section>
-
-    <section class="sheet-section inventory define-item-type" data-item-type="gear">
-      <div class="section-header flexrow">
-        <h2>{{localize 'ANARCHY.itemType.plural.gear'}}</h2>
-        <button type="button" class="click-item-add">{{localize 'ANARCHY.common.add'}}</button>
-      </div>
-      <ul class="item-list">
-        {{#each items.gear as |gear|}}
-          <li class="item" data-item-id="{{gear.id}}">
-            <span class="item-name click-item-edit">{{gear.name}}</span>
-            <div class="item-controls">
-              <button type="button" class="click-item-edit">{{localize 'ANARCHY.common.edit'}}</button>
-              <button type="button" class="click-item-delete">{{localize 'ANARCHY.common.delete'}}</button>
-            </div>
-          </li>
-        {{/each}}
-      </ul>
-    </section>
-
-    <section class="sheet-section edge-pools">
-      <h2>{{localize 'ANARCHY.actor.counters.edgePools.title'}}</h2>
-      <div class="edge-pool-columns">
-        <div class="edge-group">
-          <h3>{{localize 'ANARCHY.actor.counters.edgePools.physical'}}</h3>
-          <label>{{localize 'ANARCHY.actor.counters.edgePools.grit'}}</label>
-          <div class="monitor-inputs">
-            <input type="number" name="system.counters.edgePools.grit.value" value="{{system.counters.edgePools.grit.value}}" />
-            <span>/</span>
-            <input type="number" name="system.counters.edgePools.grit.max" value="{{system.counters.edgePools.grit.max}}" />
-          </div>
-          <label>{{localize 'ANARCHY.actor.counters.edgePools.chaos'}}</label>
-          <div class="monitor-inputs">
-            <input type="number" name="system.counters.edgePools.chaos.value" value="{{system.counters.edgePools.chaos.value}}" />
-            <span>/</span>
-            <input type="number" name="system.counters.edgePools.chaos.max" value="{{system.counters.edgePools.chaos.max}}" />
-          </div>
-        </div>
-        <div class="edge-group">
-          <h3>{{localize 'ANARCHY.actor.counters.edgePools.mental'}}</h3>
-          <label>{{localize 'ANARCHY.actor.counters.edgePools.insight'}}</label>
-          <div class="monitor-inputs">
-            <input type="number" name="system.counters.edgePools.insight.value" value="{{system.counters.edgePools.insight.value}}" />
-            <span>/</span>
-            <input type="number" name="system.counters.edgePools.insight.max" value="{{system.counters.edgePools.insight.max}}" />
-          </div>
-          <label>{{localize 'ANARCHY.actor.counters.edgePools.rumor'}}</label>
-          <div class="monitor-inputs">
-            <input type="number" name="system.counters.edgePools.rumor.value" value="{{system.counters.edgePools.rumor.value}}" />
-            <span>/</span>
-            <input type="number" name="system.counters.edgePools.rumor.max" value="{{system.counters.edgePools.rumor.max}}" />
-          </div>
-        </div>
-        <div class="edge-group">
-          <h3>{{localize 'ANARCHY.actor.counters.edgePools.social'}}</h3>
-          <label>{{localize 'ANARCHY.actor.counters.edgePools.legend'}}</label>
-          <div class="monitor-inputs">
-            <input type="number" name="system.counters.edgePools.legend.value" value="{{system.counters.edgePools.legend.value}}" />
-            <span>/</span>
-            <input type="number" name="system.counters.edgePools.legend.max" value="{{system.counters.edgePools.legend.max}}" />
-          </div>
-          <label>{{localize 'ANARCHY.actor.counters.edgePools.credibility'}}</label>
-          <div class="monitor-inputs">
-            <input type="number" name="system.counters.edgePools.credibility.value" value="{{system.counters.edgePools.credibility.value}}" />
-            <span>/</span>
-            <input type="number" name="system.counters.edgePools.credibility.max" value="{{system.counters.edgePools.credibility.max}}" />
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <section class="sheet-section experience">
-      <h2>{{localize 'ANARCHY.actor.counters.xp'}}</h2>
-      <div class="experience-grid">
-        <label>{{localize 'ANARCHY.actor.counters.current'}}</label>
-        <input type="number" name="system.counters.xp.value" value="{{system.counters.xp.value}}" />
-        <label>{{localize 'ANARCHY.actor.counters.lifetime'}}</label>
-        <input type="number" name="system.counters.xp.total" value="{{system.counters.xp.total}}" />
-      </div>
-    </section>
+    <div class="anarchy-block">
+      {{> 'systems/mwd/templates/actor/parts/description.hbs'}}
+      {{> 'systems/mwd/templates/actor/parts/gmnotes.hbs'}}
+    </div>
   </section>
 </form>
+{{/if}}

--- a/templates/actor/parts/passport-details.hbs
+++ b/templates/actor/parts/passport-details.hbs
@@ -3,16 +3,21 @@
   <div class="passport-detail">
     {{> "systems/mwd/templates/actor/character/name.hbs"}}
   </div>
-  {{!-- Metatype and genre removed --}}
+  <div class="passport-detail">
+    {{> "systems/mwd/templates/actor/character/capacity.hbs"}}
+  </div>
+  {{#if (localize 'ANARCHY.actor.counters.essence')}}
+  <div class="passport-detail">
+    {{> "systems/mwd/templates/actor/character/essence.hbs"}}
+  </div>
+  {{/if}}
 {{else}}
   <div class="passport-detail">
     {{> "systems/mwd/templates/actor/character/name.hbs"}}
   </div>
-  {{!-- Metatype and genre removed --}}
   <div class="passport-detail">
     {{> "systems/mwd/templates/actor/character/capacity.hbs"}}
   </div>
-  {{!-- Karma removed --}}
   {{#if (localize 'ANARCHY.actor.counters.essence')}}
   <div class="passport-detail">
     {{> "systems/mwd/templates/actor/character/essence.hbs"}}


### PR DESCRIPTION
## Summary
- Rebuild the character sheet handlebars using the character data model so keywords, items, monitors, and counters mirror the third-party layout
- Expand passport details to show capacity and essence across sheet modes
- Add styling for the updated character sheet structure to match the third-party presentation

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693208617324832dbb7972d0b4a31c80)