### PR TITLE
Fix migrations constants and preload GM template partial

### DIFF
--- a/src/modules/handlebars-manager.js
+++ b/src/modules/handlebars-manager.js
@@ -6,10 +6,13 @@ import { Grammar } from "./grammar.js";
 import { Icons } from "./icons.js";
 import { WeaponItem } from "./item/weapon-item.js";
 import { Misc } from "./misc.js";
+import { TEMPLATES_PATH } from "./constants.js";
 
 const { loadTemplates } = foundry.applications.handlebars;
 
-const HBS_PARTIAL_TEMPLATES = [];
+const HBS_PARTIAL_TEMPLATES = [
+  `${TEMPLATES_PATH}/app/gm-anarchy.hbs`,
+];
 
 export class HandlebarsManager {
 

--- a/src/modules/migrations.js
+++ b/src/modules/migrations.js
@@ -1,8 +1,9 @@
-import { ANARCHY_SYSTEM, LOG_HEAD, SYSTEM_NAME, TEMPLATE } from "./constants.js";
+import { ANARCHY_SYSTEM, LOG_HEAD, SYSTEM_NAME, SYSTEM_SCOPE, TEMPLATE } from "./constants.js";
 import { ANARCHY_SKILLS } from "./skills.js";
 import { ANARCHY_HOOKS, HooksManager } from "./hooks-manager.js";
 import { Misc } from "./misc.js";
 import { AttributeActions } from "./attribute-actions.js";
+import { MESSAGE_DATA } from "./chat/chat-manager.js";
 
 export const DECLARE_MIGRATIONS = 'anarchy-declareMigration';
 const SYSTEM_MIGRATION_CURRENT_VERSION = "systemMigrationVersion";

--- a/templates/actor/character.hbs
+++ b/templates/actor/character.hbs
@@ -102,4 +102,3 @@
     </div>
   </section>
 </form>
-{{/if}}


### PR DESCRIPTION
## Summary
- import the missing chat flag constants used during migrations
- preload the GM Anarchy partial template so the GM Manager can render
- remove an extra Handlebars block closer from the character sheet template

## Testing
- `npm run validate:json` *(fails: npm is not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69328b9dfc08832dbfea8d5999c9a931)