### PR TITLE
Load missing Handlebars partials

### DIFF
--- a/src/modules/handlebars-manager.js
+++ b/src/modules/handlebars-manager.js
@@ -15,6 +15,8 @@ const HBS_PARTIAL_TEMPLATES = [
   `${TEMPLATES_PATH}/monitors/anarchy.hbs`,
   `${TEMPLATES_PATH}/monitors/anarchy-actor.hbs`,
   `${TEMPLATES_PATH}/monitors/anarchy-scene.hbs`,
+  `${TEMPLATES_PATH}/common/check-element.hbs`,
+  `${TEMPLATES_PATH}/actor/character/name.hbs`,
   `${TEMPLATES_PATH}/actor/parts/passport-details.hbs`,
 ];
 


### PR DESCRIPTION
## Summary
- preload additional Handlebars partial templates including character name and common check element
- ensure referenced partials are available when loading templates

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932ed1a3680832da68480284413fd4b)