### PR TITLE
Inline English strings and remove game.i18n dependencies

### DIFF
--- a/src/modules/actor/actor-damage.js
+++ b/src/modules/actor/actor-damage.js
@@ -4,6 +4,7 @@ import { SYSTEM_NAME, TEMPLATE } from "../constants.js";
 import { ErrorManager } from "../error-manager.js";
 import { ANARCHY_HOOKS, HooksManager } from "../hooks-manager.js";
 import { Modifiers } from "../modifiers/modifiers.js";
+import { formatString } from "../strings.js";
 
 const DAMAGE_MODE = 'damage-mode'
 const SETTING_KEY_DAMAGE_MODE = `${SYSTEM_NAME}.${DAMAGE_MODE}`;
@@ -33,13 +34,13 @@ export class ActorDamageManager {
 
   static _registerDamageModeSetting() {
     Hooks.callAll(ANARCHY_HOOKS.PROVIDE_DAMAGE_MODE, (code, labelkey, method) => {
-      damageModeChoices[code] = game.i18n.localize(labelkey);
+      damageModeChoices[code] = labelkey;
       damageModeMethods[code] = method;
     });
     game.settings.register(SYSTEM_NAME, DAMAGE_MODE, {
       scope: "world",
-      name: game.i18n.localize(ANARCHY.settings.damageMode.name),
-      hint: game.i18n.localize(ANARCHY.settings.damageMode.hint),
+      name: ANARCHY.settings.damageMode.name,
+      hint: ANARCHY.settings.damageMode.hint,
       config: true,
       default: Object.keys(damageModeChoices)[0],
       choices: damageModeChoices,
@@ -188,29 +189,30 @@ export class ActorDamageManager {
     if (!resistanceDetail || monitor === undefined) {
       return;
     }
-    const monitorLabel = game.i18n.localize(ANARCHY.actor.monitors[monitor] ?? monitor);
+    const monitorLabel = ANARCHY.actor.monitors[monitor] ?? monitor;
     const typeLabel = ActorDamageManager._localizeDamageType(damageType) ?? monitorLabel;
     const sourceKey = resistanceDetail.usedType ? 'type' : 'default';
-    const sourceLabel = game.i18n.localize(ANARCHY.actor.monitors.resistanceSources?.[sourceKey] ?? sourceKey);
-    ui.notifications.info(game.i18n.format(ANARCHY.actor.monitors.resistanceApplied, {
+    const sourceLabel = ANARCHY.actor.monitors.resistanceSources?.[sourceKey] ?? sourceKey;
+    const content = formatString(ANARCHY.actor.monitors.resistanceApplied, {
       actor: actor.name,
       monitor: monitorLabel,
       damageType: typeLabel,
       value: resistanceDetail.value,
       source: sourceLabel,
-    }));
+    });
+    ui.notifications.info(content);
   }
 
   static _localizeDamageType(damageType) {
     if (!damageType) {
       return undefined;
     }
-    return game.i18n.localize(
+    return 
       ANARCHY.mwd.weaponDamageType[damageType]
       ?? ANARCHY.mwd.personalDamageType[damageType]
       ?? ANARCHY.actor.monitors[damageType]
       ?? damageType
-    );
+    ;
   }
 
   static _computeArmorResistance(actor) {

--- a/src/modules/actor/anarchy-actor-sheet.js
+++ b/src/modules/actor/anarchy-actor-sheet.js
@@ -302,7 +302,7 @@ export class AnarchyActorSheet extends HandlebarsApplicationMixin(foundry.applic
       event.stopPropagation();
       const weapon = this.getEventItem(event);
       if (!weapon) {
-        ui.notifications.warn(game.i18n.localize('ANARCHY.common.errors.weaponNotFound'));
+        ui.notifications.warn('ANARCHY.common.errors.weaponNotFound');
         return;
       }
       this.actor.rollWeapon(weapon);
@@ -476,7 +476,7 @@ export class AnarchyActorSheet extends HandlebarsApplicationMixin(foundry.applic
     event.stopPropagation();
     const weapon = this._getItemFromTarget(target);
     if (!weapon) {
-      ui.notifications.warn(game.i18n.localize('ANARCHY.common.errors.weaponNotFound'));
+      ui.notifications.warn('ANARCHY.common.errors.weaponNotFound');
       return;
     }
     this.actor.rollWeapon(weapon);
@@ -579,7 +579,7 @@ export class AnarchyActorSheet extends HandlebarsApplicationMixin(foundry.applic
   }
 
   async createNewItem(itemType) {
-    const singular = game.i18n.localize(ANARCHY.itemType.singular[itemType]);
+    const singular = ANARCHY.itemType.singular[itemType];
     const name = singular + ' ' + this.actor.items.filter(it => it.type == itemType).length;
     await this.actor.createEmbeddedDocuments('Item', [{ name: name, type: itemType }]);
   }

--- a/src/modules/actor/base-actor.js
+++ b/src/modules/actor/base-actor.js
@@ -114,8 +114,8 @@ export class AnarchyBaseActor extends Actor {
       return []
     }
     return buttons.sort((a, b) => {
-      if (game.i18n.localize(a.labelkey) > game.i18n.localize(b.labelkey)) return 1;
-      if (game.i18n.localize(a.labelkey) < game.i18n.localize(b.labelkey)) return -1;
+      if (a.labelkey > b.labelkey) return 1;
+      if (a.labelkey < b.labelkey) return -1;
       return 0;
     })
   }

--- a/src/modules/actor/battlemech-actor.js
+++ b/src/modules/actor/battlemech-actor.js
@@ -3,6 +3,7 @@ import { ANARCHY_SYSTEM, ICONS_PATH, TEMPLATE } from "../constants.js";
 import { SkillItem } from "../item/skill-item.js";
 import { RollDialog } from "../roll/roll-dialog.js";
 import { VehicleActor } from "./vehicle-actor.js";
+import { formatString } from "../strings.js";
 import { BattlemechLoadout } from "../mwd/battlemech-loadout.js";
 
 export class BattlemechActor extends VehicleActor {
@@ -34,7 +35,7 @@ export class BattlemechActor extends VehicleActor {
   async rollRangedAttack() {
     const weaponGroups = this.system.weaponGroups ?? [];
     if (weaponGroups.length === 0) {
-      ui.notifications.warn(game.i18n.localize(ANARCHY.actor.vehicle.quickActions.errors.noRanged));
+      ui.notifications.warn(ANARCHY.actor.vehicle.quickActions.errors.noRanged);
       return;
     }
 
@@ -49,7 +50,7 @@ export class BattlemechActor extends VehicleActor {
 
     await this._rollQuickSkill(this.system.skills.gunnery, {
       quickAction: {
-        title: game.i18n.localize(ANARCHY.actor.vehicle.quickActions.rangedAttack),
+        title: ANARCHY.actor.vehicle.quickActions.rangedAttack,
         weaponGroup: this._serializeWeaponGroup(selectedGroup, weapons)
       }
     });
@@ -58,7 +59,7 @@ export class BattlemechActor extends VehicleActor {
   async rollMeleeAttack() {
     const meleeProfiles = this.system.meleeProfiles ?? [];
     if (meleeProfiles.length === 0) {
-      ui.notifications.warn(game.i18n.localize(ANARCHY.actor.vehicle.quickActions.errors.noMelee));
+      ui.notifications.warn(ANARCHY.actor.vehicle.quickActions.errors.noMelee);
       return;
     }
 
@@ -69,7 +70,7 @@ export class BattlemechActor extends VehicleActor {
 
     await this._rollQuickSkill(this.system.skills.melee, {
       quickAction: {
-        title: game.i18n.localize(ANARCHY.actor.vehicle.quickActions.meleeAttack),
+        title: ANARCHY.actor.vehicle.quickActions.meleeAttack,
         meleeProfile: selectedProfile
       }
     });
@@ -77,20 +78,20 @@ export class BattlemechActor extends VehicleActor {
 
   async rollDodge() {
     await this._rollQuickSkill(this.system.skills.piloting, {
-      quickAction: { title: game.i18n.localize(ANARCHY.actor.vehicle.quickActions.dodgeCheck) }
+      quickAction: { title: ANARCHY.actor.vehicle.quickActions.dodgeCheck }
     });
   }
 
   async rollPilotingCheck() {
     await this._rollQuickSkill(this.system.skills.piloting, {
-      quickAction: { title: game.i18n.localize(ANARCHY.actor.vehicle.quickActions.pilotingCheck) }
+      quickAction: { title: ANARCHY.actor.vehicle.quickActions.pilotingCheck }
     });
   }
 
   async rollSensorSweep() {
     const sensorSkills = [this.system.skills.perception, this.system.skills.technician].filter(it => it);
     if (sensorSkills.length === 0) {
-      ui.notifications.warn(game.i18n.localize(ANARCHY.actor.vehicle.quickActions.errors.noSensorSweep));
+      ui.notifications.warn(ANARCHY.actor.vehicle.quickActions.errors.noSensorSweep);
       return;
     }
 
@@ -101,7 +102,7 @@ export class BattlemechActor extends VehicleActor {
 
     await this._rollQuickSkill(selectedSkill, {
       quickAction: {
-        title: game.i18n.localize(ANARCHY.actor.vehicle.quickActions.sensorSweep),
+        title: ANARCHY.actor.vehicle.quickActions.sensorSweep,
         skillName: selectedSkill.name
       }
     });
@@ -109,7 +110,7 @@ export class BattlemechActor extends VehicleActor {
 
   async rollEmergencyRepair() {
     await this._rollQuickSkill(this.system.skills.technician, {
-      quickAction: { title: game.i18n.localize(ANARCHY.actor.vehicle.quickActions.emergencyRepair) }
+      quickAction: { title: ANARCHY.actor.vehicle.quickActions.emergencyRepair }
     });
   }
 
@@ -146,7 +147,7 @@ export class BattlemechActor extends VehicleActor {
     const status = this._resolveHeatStatus(heat.current, heat.thresholds, heat.max);
     this.system.mwd.heatStatus = {
       code: status,
-      label: game.i18n.localize(ANARCHY.actor.battlemech.heat.status[status] ?? status)
+      label: ANARCHY.actor.battlemech.heat.status[status] ?? status
     };
 
     return heat;
@@ -180,7 +181,7 @@ export class BattlemechActor extends VehicleActor {
       return {
         id: group.id ?? `group-${index + 1}`,
         index,
-        name: group.name || game.i18n.format(ANARCHY.common.newName, { type: game.i18n.localize(ANARCHY.itemType.singular.weapon) }),
+        name: group.name || formatString(ANARCHY.common.newName, { type: ANARCHY.itemType.singular.weapon }),
         weaponIds,
         isPrimary: group.isPrimary ?? false,
         weapons: attachedWeapons,
@@ -199,7 +200,7 @@ export class BattlemechActor extends VehicleActor {
     if (prepared) {
       const labelKey = ANARCHY.skill?.[code];
       return {
-        name: prepared.name ?? (labelKey ? game.i18n.localize(labelKey) : code),
+        name: prepared.name ?? (labelKey ? labelKey : code),
         system: foundry.utils.mergeObject({
           code: code,
           attribute: prepared.system?.attribute,
@@ -237,7 +238,7 @@ export class BattlemechActor extends VehicleActor {
     if (favoriteWeapons.length > 0) {
       groups.push({
         id: 'favorite',
-        name: game.i18n.localize(ANARCHY.actor.vehicle.quickActions.primaryWeapons),
+        name: ANARCHY.actor.vehicle.quickActions.primaryWeapons,
         weaponIds: favoriteWeapons.map(it => it.id),
         isPrimary: true
       });
@@ -245,7 +246,7 @@ export class BattlemechActor extends VehicleActor {
 
     groups.push({
       id: 'all',
-      name: game.i18n.localize(ANARCHY.actor.vehicle.quickActions.allWeapons),
+      name: ANARCHY.actor.vehicle.quickActions.allWeapons,
       weaponIds: weapons.map(it => it.id),
       isPrimary: groups.length === 0
     });
@@ -256,10 +257,10 @@ export class BattlemechActor extends VehicleActor {
   _prepareMeleeProfiles() {
     const profiles = [{
       id: 'unarmed',
-      name: game.i18n.localize(ANARCHY.actor.vehicle.quickActions.unarmed),
+      name: ANARCHY.actor.vehicle.quickActions.unarmed,
       weaponId: null,
       damage: 1,
-      notes: game.i18n.localize(ANARCHY.actor.vehicle.quickActions.unarmedNotes)
+      notes: ANARCHY.actor.vehicle.quickActions.unarmedNotes
     }];
 
     const meleeWeapons = this.items.filter(it =>
@@ -303,13 +304,13 @@ export class BattlemechActor extends VehicleActor {
     const content = `<form class="mwd-quick-select">${groups.map(group => `
       <label class="quick-select-option">
         <input type="radio" name="weapon-group" value="${group.id}" ${group.id === defaultGroup.id ? 'checked' : ''}>
-        <span>${group.name}${group.isPrimary ? ` (${game.i18n.localize(ANARCHY.actor.vehicle.quickActions.primaryLabel)})` : ''}</span>
+        <span>${group.name}${group.isPrimary ? ` (${ANARCHY.actor.vehicle.quickActions.primaryLabel})` : ''}</span>
       </label>`).join('')}</form>`;
 
     const selectedId = await Dialog.prompt({
-      title: game.i18n.localize(ANARCHY.actor.vehicle.quickActions.selectWeaponGroup),
+      title: ANARCHY.actor.vehicle.quickActions.selectWeaponGroup,
       content: content,
-      label: game.i18n.localize(ANARCHY.common.roll.button),
+      label: ANARCHY.common.roll.button,
       callback: html => html.find('input[name="weapon-group"]:checked').val() ?? defaultGroup.id
     });
 
@@ -329,9 +330,9 @@ export class BattlemechActor extends VehicleActor {
       </label>`).join('')}</form>`;
 
     const selectedId = await Dialog.prompt({
-      title: game.i18n.localize(ANARCHY.actor.vehicle.quickActions.selectMeleeProfile),
+      title: ANARCHY.actor.vehicle.quickActions.selectMeleeProfile,
       content: content,
-      label: game.i18n.localize(ANARCHY.common.roll.button),
+      label: ANARCHY.common.roll.button,
       callback: html => html.find('input[name="melee-profile"]:checked').val() ?? defaultProfile.id
     });
 
@@ -350,9 +351,9 @@ export class BattlemechActor extends VehicleActor {
       </label>`).join('')}</form>`;
 
     const selectedCode = await Dialog.prompt({
-      title: game.i18n.localize(ANARCHY.actor.vehicle.quickActions.selectSensorSkill),
+      title: ANARCHY.actor.vehicle.quickActions.selectSensorSkill,
       content: content,
-      label: game.i18n.localize(ANARCHY.common.roll.button),
+      label: ANARCHY.common.roll.button,
       callback: html => html.find('input[name="sensor-skill"]:checked').val()
     });
 

--- a/src/modules/actor/battlemech-sheet.js
+++ b/src/modules/actor/battlemech-sheet.js
@@ -65,7 +65,7 @@ export class BattlemechSheet extends VehicleSheet {
       const weaponGroups = foundry.utils.deepClone(this.actor.system.mwd.weaponGroups ?? []);
       weaponGroups.push({
         id: foundry.utils.randomID(),
-        name: game.i18n.localize(ANARCHY.mwd.loadout.newGroup),
+        name: ANARCHY.mwd.loadout.newGroup,
         weaponIds: [],
         isPrimary: weaponGroups.length === 0,
       });

--- a/src/modules/actor/character-base-sheet.js
+++ b/src/modules/actor/character-base-sheet.js
@@ -126,7 +126,7 @@ export class CharacterBaseSheet extends AnarchyActorSheet {
   }
 
   createNewWord(wordType) {
-    const word = game.i18n.localize(ANARCHY.common.newEntry);
+    const word = ANARCHY.common.newEntry;
     this.actor.createWord(wordType, word);
   }
 

--- a/src/modules/actor/vehicle-actor.js
+++ b/src/modules/actor/vehicle-actor.js
@@ -135,9 +135,9 @@ export class VehicleActor extends AnarchyBaseActor {
     }
     else {
       ui.notifications.warn(
-        game.i18n.localize(ANARCHY.common.errors.noValidPilotForVehicle, {
+        ANARCHY.common.errors.noValidPilotForVehicle, {
           vehicle: this.name
-        }))
+        })
     }
   }
   async _migrateHandlingToAttribute(actor) {

--- a/src/modules/actor/vehicle-sheet.js
+++ b/src/modules/actor/vehicle-sheet.js
@@ -49,11 +49,11 @@ export class VehicleSheet extends AnarchyActorSheet {
   async selectPilotFromActor() {
     const candidates = game.actors.filter(actor => actor.canPilotVehicle());
     if (candidates.length === 0) {
-      ui.notifications.warn(game.i18n.localize(ANARCHY.actor.vehicle.pilot.errors.noActors));
+      ui.notifications.warn(ANARCHY.actor.vehicle.pilot.errors.noActors);
       return;
     }
 
-    const title = game.i18n.localize(ANARCHY.actor.vehicle.pilot.selectActor);
+    const title = ANARCHY.actor.vehicle.pilot.selectActor;
     await SelectActor.selectActor(title, candidates,
       async actor => await this.actor.update({ 'system.pilot.uuid': actor.uuid }));
   }
@@ -61,7 +61,7 @@ export class VehicleSheet extends AnarchyActorSheet {
   async selectPilotFromToken() {
     const selectedToken = canvas?.tokens?.controlled?.find(token => token.actor?.canPilotVehicle());
     if (!selectedToken) {
-      ui.notifications.warn(game.i18n.localize(ANARCHY.actor.vehicle.pilot.errors.noTokens));
+      ui.notifications.warn(ANARCHY.actor.vehicle.pilot.errors.noTokens);
       return;
     }
 

--- a/src/modules/anarchy-system.js
+++ b/src/modules/anarchy-system.js
@@ -140,22 +140,22 @@ export class AnarchySystem {
     Actors.unregisterSheet('core', foundry.appv1.sheets.ActorSheet);
     Actors.unregisterSheet(SYSTEM_NAME, CharacterActorSheet);
     Actors.registerSheet(SYSTEM_NAME, CharacterNPCSheet, {
-      label: game.i18n.localize(ANARCHY.actor.characterNPCSheet),
+      label: ANARCHY.actor.characterNPCSheet,
       makeDefault: true,
       types: ['npc']
     });
     Actors.registerSheet(SYSTEM_NAME, CharacterActorSheet, {
-      label: game.i18n.localize(ANARCHY.actor.characterSheet),
+      label: ANARCHY.actor.characterSheet,
       makeDefault: true,
       types: ['character']
     });
     Actors.registerSheet(SYSTEM_NAME, VehicleSheet, {
-      label: game.i18n.localize(ANARCHY.actor.vehicleSheet),
+      label: ANARCHY.actor.vehicleSheet,
       makeDefault: true,
       types: ['vehicle']
     });
     Actors.registerSheet(SYSTEM_NAME, BattlemechSheet, {
-      label: game.i18n.localize(ANARCHY.actor.battlemechSheet),
+      label: ANARCHY.actor.battlemechSheet,
       makeDefault: true,
       types: ['battlemech']
     });

--- a/src/modules/app/gm-anarchy.js
+++ b/src/modules/app/gm-anarchy.js
@@ -3,6 +3,7 @@ import { ANARCHY } from "../config.js";
 import { SYSTEM_NAME, TEMPLATE } from "../constants.js";
 import { ErrorManager } from "../error-manager.js";
 import { RemoteCall } from "../remotecall.js";
+import { formatString } from "../strings.js";
 
 const { renderTemplate } = foundry.applications.handlebars;
 
@@ -48,7 +49,7 @@ export class GMAnarchy {
       ChatMessage.create({
         user: game.user,
         whisper: ChatMessage.getWhisperRecipients('GM'),
-        content: game.i18n.format(ANARCHY.gmManager.gmReceivedAnarchy,
+        content: formatString(ANARCHY.gmManager.gmReceivedAnarchy,
           {
             anarchy: count,
             actor: actor.name

--- a/src/modules/app/gm-difficulty.js
+++ b/src/modules/app/gm-difficulty.js
@@ -1,5 +1,6 @@
 import { ANARCHY } from "../config.js";
 import { SYSTEM_NAME } from "../constants.js";
+import { formatString } from "../strings.js";
 
 const { renderTemplate } = foundry.applications.handlebars;
 
@@ -15,10 +16,10 @@ export class GMDifficulty {
   onReady() {
     game.settings.register(SYSTEM_NAME, GM_DIFFICULTY_POOLS, {
       scope: "world",
-      name: game.i18n.localize(ANARCHY.settings.gmDifficulty.name),
-      hint: game.i18n.localize(ANARCHY.settings.gmDifficulty.hint),
+      name: ANARCHY.settings.gmDifficulty.name,
+      hint: ANARCHY.settings.gmDifficulty.hint,
       config: true,
-      default: game.i18n.localize(ANARCHY.settings.gmDifficulty.default),
+      default: ANARCHY.settings.gmDifficulty.default,
       type: String
     });
     this.loadDifficultySettings();
@@ -69,7 +70,7 @@ export class GMDifficulty {
     const difficulty = $(event.currentTarget).attr('data-difficulty');
     const roll = new Roll(`${pool}d6cs>=5`);
     await roll.evaluate({ async: true });
-    const flavor = game.i18n.format(ANARCHY.settings.gmDifficulty.chatMessage, {
+    const flavor = formatString(ANARCHY.settings.gmDifficulty.chatMessage, {
       pool: pool,
       difficulty: difficulty ?? pool,
       success: roll.total

--- a/src/modules/app/gm-manager.js
+++ b/src/modules/app/gm-manager.js
@@ -2,6 +2,7 @@ import { HandleDragApplication } from "./handle-drag.js";
 import { ANARCHY } from "../config.js";
 import { SYSTEM_NAME } from "../constants.js";
 import { GMDifficulty } from "./gm-difficulty.js";
+import { formatString } from "../strings.js";
 
 const { renderTemplate } = foundry.applications.handlebars;
 const GM_MANAGER = "gm-manager";
@@ -19,7 +20,7 @@ export class GMManager extends HandlebarsApplicationMixin(ApplicationV2) {
     return foundry.utils.mergeObject(super.DEFAULT_OPTIONS, {
       id: GM_MANAGER,
       window: {
-        title: game.i18n.localize(ANARCHY.gmManager.title),
+        title: ANARCHY.gmManager.title,
         popOut: false,
         resizable: false
       },
@@ -55,8 +56,8 @@ export class GMManager extends HandlebarsApplicationMixin(ApplicationV2) {
     Hooks.on("renderChatLog", async (app, html, data) => {
       const templatePath = "systems/mwd/templates/app/chat-tools.hbs";
       const templateData = {
-        title: game.i18n.localize("ANARCHY.gmManager.title"),
-        rollDice: game.i18n.localize("ANARCHY.chat_actions.rollDice.title"),
+        title: "ANARCHY.gmManager.title",
+        rollDice: "ANARCHY.chat_actions.rollDice.title",
         isGM: game.user.isGM,
       };
       const templateHTML = await renderTemplate(templatePath, templateData);
@@ -68,18 +69,18 @@ export class GMManager extends HandlebarsApplicationMixin(ApplicationV2) {
       buttonDICE.on("click", event => {
         event.preventDefault();
         new Dialog({
-          title: game.i18n.localize("ANARCHY.chat_actions.rollDice.title"),
+          title: ANARCHY.chat_actions.rollDice.title,
           content: "<div style=\"display:flex;margin:4px 0 8px 0;align-items:center;gap:8px\">" +
-            game.i18n.localize("ANARCHY.chat_actions.rollDice.instruction") +
+            ANARCHY.chat_actions.rollDice.instruction +
             '<input class="roll-dice-value" name="macro-roll-count-dice" type="number" value="3" /></div>',
           buttons: {
-            cancel: { label: game.i18n.localize("ANARCHY.common.cancel"), icon: '<i class="fas fa-times"></i>' },
+            cancel: { label: ANARCHY.common.cancel, icon: '<i class="fas fa-times"></i>' },
             submit: {
-              label: game.i18n.localize("ANARCHY.common.roll.button"), icon: '<i class="fas fa-dice"></i>',
+              label: ANARCHY.common.roll.button, icon: '<i class="fas fa-dice"></i>',
               callback: async (html) => {
                 const count = $(html).find('input[name="macro-roll-count-dice"]').val();
                 if (!count || isNaN(count) || count <= 0) {
-                  ui.notifications.warn(game.i18n.localize("ANARCHY.chat_actions.rollDice.error"));
+                  ui.notifications.warn(ANARCHY.chat_actions.rollDice.error);
                   return;
                 }
 
@@ -89,7 +90,7 @@ export class GMManager extends HandlebarsApplicationMixin(ApplicationV2) {
                 const results = roll.terms[0].results;
                 const ones = results.filter(it => it.result == 1).length;
 
-                const flavor = game.i18n.format("ANARCHY.chat_actions.rollDice.result", {
+                const flavor = formatString(ANARCHY.chat_actions.rollDice.result, {
                   count: count,
                   success: roll.total,
                   ones: ones

--- a/src/modules/attribute-actions.js
+++ b/src/modules/attribute-actions.js
@@ -111,7 +111,7 @@ export class AttributeActions {
     if (action) {
       return {
         icon: action.icon,
-        label: game.i18n.localize(action.labelkey),
+        label: action.labelkey,
         callback: (token) => token.actor.rollAttributeAction(actionCode),
       };
     }

--- a/src/modules/chat/chat-manager.js
+++ b/src/modules/chat/chat-manager.js
@@ -71,7 +71,7 @@ export class ChatManager {
       ChatManager.removeFamily(chatMsg.id);
     }
     else {
-      ui.notifications.info(game.i18n.localize(ANARCHY.common.errors.cannotUseEdgeAnymore));
+      ui.notifications.info(ANARCHY.common.errors.cannotUseEdgeAnymore);
     }
   }
 

--- a/src/modules/common/checkbars.js
+++ b/src/modules/common/checkbars.js
@@ -3,6 +3,7 @@ import { ANARCHY } from "../config.js";
 import { AnarchyUsers } from "../users.js";
 import { Icons } from "../icons.js";
 import { TEMPLATE, THIRD_PARTY_STYLE_PATH } from "../constants.js";
+import { formatString } from "../strings.js";
 
 const MONITORS = ANARCHY.actor.monitors;
 const COUNTERS = ANARCHY.actor.counters;
@@ -283,12 +284,13 @@ export class Checkbars {
   }
 
   static _notifyOverflow(target, monitor, overflow, overflowMonitor) {
-    ui.notifications.warn(game.i18n.format(ANARCHY.actor.monitors.overflow, {
+    const content = formatString(ANARCHY.actor.monitors.overflow, {
       actor: target.name,
-      monitor: game.i18n.format('ANARCHY.actor.monitors.' + monitor),
+      monitor: ANARCHY.actor.monitors[monitor],
       overflow: overflow,
-      overflowMonitor: game.i18n.format('ANARCHY.actor.monitors.' + overflowMonitor),
-    }));
+      overflowMonitor: ANARCHY.actor.monitors[overflowMonitor],
+    });
+    ui.notifications.warn(content);
   }
 
   static async _manageFatigueOverflow(target, value, max) {
@@ -340,11 +342,11 @@ export class Checkbars {
   static notifyAnarchyChange(target, monitor, current, newValue) {
     AnarchyUsers.blindMessageToGM({
       from: game.user.id,
-      content: game.i18n.format(ANARCHY.gmManager.playerChangedAnarchy,
+      content: formatString(ANARCHY.gmManager.playerChangedAnarchy,
         {
           user: game.user.name,
           actor: target.name,
-          monitor: game.i18n.localize(ANARCHY.actor.counters[monitor]),
+          monitor: ANARCHY.actor.counters[monitor],
           from: current,
           to: newValue
         })

--- a/src/modules/config.js
+++ b/src/modules/config.js
@@ -1,585 +1,772 @@
-
 export const ANARCHY = {
-    TYPES: {
-        Actor: {
-            character: "TYPES.Actor.character",
-            vehicle: "TYPES.Actor.vehicle",
-            battlemech: "TYPES.Actor.battlemech"
+    "TYPES": {
+        "Actor": {
+            "character": "Character",
+            "vehicle": "Vehicle/drone",
+            "battlemech": "Battlemech"
         },
-        Item: {
-            contact: "TYPES.Item.contact",
-            gear: "TYPES.Item.gear",
-            quality: "TYPES.Item.quality",
-            assetModule: "TYPES.Item.assetModule",
-            skill: "TYPES.Item.skill",
-            lifeModule: "TYPES.Item.lifeModule",
-            mechWeapon: "TYPES.Item.mechWeapon",
-            personalWeapon: "TYPES.Item.personalWeapon"
+        "Item": {
+            "contact": "Contact",
+            "gear": "Gear",
+            "quality": "Trait",
+            "assetModule": "Asset Module",
+            "skill": "Skill",
+            "mechWeapon": "Mech-Scale Weapon",
+            "personalWeapon": "Personal Weapon"
         }
     },
-    settings: {
-        defaultCssClass: {
-            name: 'ANARCHY.settings.defaultCssClass.name',
-            hint: 'ANARCHY.settings.defaultCssClass.hint'
+    "settings": {
+        "defaultCssClass": {
+            "name": "Style of Destiny UI",
+            "hint": "Select the style used for actors, items and GM Manager"
         },
-        anarchyHack: {
-            name: 'ANARCHY.settings.anarchyHack.name',
-            hint: 'ANARCHY.settings.anarchyHack.hint'
+        "anarchyHack": {
+            "name": "Destiny hack",
+            "hint": "Use an Anarchy Hack provided by a module"
         },
-        skillSet: {
-            name: 'ANARCHY.settings.skillSet.name',
-            hint: 'ANARCHY.settings.skillSet.hint'
+        "skillSet": {
+            "name": "Skill set",
+            "hint": "Select the set of skills to use"
         },
-        gmDifficulty: {
-            name: 'ANARCHY.settings.gmDifficulty.name',
-            hint: 'ANARCHY.settings.gmDifficulty.hint',
-            default: 'ANARCHY.settings.gmDifficulty.default',
-            chatMessage: 'ANARCHY.settings.gmDifficulty.chatMessage',
+        "gmDifficulty": {
+            "name": "Default difficulty pools",
+            "hint": "The default difficulty pools, represented as 'Trivial:4,Easy:6' ...",
+            "default": "Trivial:4,Easy:6,Average:8,Hard:10,Very hard:12",
+            "chatMessage": "The difficulty {difficulty} ({pool}d6) is {success}"
         },
-        damageMode: {
-            name: 'ANARCHY.settings.damageMode.name',
-            hint: 'ANARCHY.settings.damageMode.hint',
-            values: {
-                resistanceArmorMonitor: 'ANARCHY.settings.damageMode.values.resistanceArmorMonitor',
-                armorResistanceMonitor: 'ANARCHY.settings.damageMode.values.armorResistanceMonitor',
-                armorGivesResistance: 'ANARCHY.settings.damageMode.values.armorGivesResistance',
-                armorGiveResistanceHitsAvoid: 'ANARCHY.settings.damageMode.values.armorGiveResistanceHitsAvoid',
-            },
-        },
-        useDestinyMechanics: {
-            name: 'ANARCHY.settings.useDestinyMechanics.name',
-            hint: 'ANARCHY.settings.useDestinyMechanics.hint',
-        }
-    },
-    gmManager: {
-        title: 'ANARCHY.gmManager.title',
-        playerChangedAnarchy: 'ANARCHY.gmManager.playerChangedAnarchy',
-        gmReceivedAnarchy: 'ANARCHY.gmManager.gmReceivedAnarchy',
-        gmConvergence: 'ANARCHY.gmManager.gmConvergence',
-    },
-    chat: {
-        blindMessageToGM: 'ANARCHY.chat.blindMessageToGM',
-        sufferedDrain: 'ANARCHY.chat.sufferedDrain',
-        noDrain: 'ANARCHY.chat.noDrain',
-        defendAttack: 'ANARCHY.chat.defendAttack',
-        defendPilotAttack: 'ANARCHY.chat.defendPilotAttack',
-        partiallyDefended: 'ANARCHY.chat.partiallyDefended',
-        fullyDefended: 'ANARCHY.chat.fullyDefended',
-        applyDamage: 'ANARCHY.chat.applyDamage',
-    },
-    user: {
-        selectedTokenActors: 'ANARCHY.user.selectedTokenActors'
-    },
-    common: {
-        newEntry: 'ANARCHY.common.newEntry',
-        newName: 'ANARCHY.common.newName',
-        cancel: 'ANARCHY.common.cancel',
-        add: 'ANARCHY.common.add',
-        edit: 'ANARCHY.common.edit',
-        activate: 'ANARCHY.common.activate',
-        del: 'ANARCHY.common.del',
-        favorite: 'ANARCHY.common.favorite',
-        addFavorite: 'ANARCHY.common.addFavorite',
-        delFavorite: 'ANARCHY.common.delFavorite',
-        attach: 'ANARCHY.common.attach',
-        attachCopy: 'ANARCHY.common.attachCopy',
-        roll: {
-            button: 'ANARCHY.common.roll.button',
-            title: 'ANARCHY.common.roll.title',
-            attribute: 'ANARCHY.common.roll.attribute',
-            attribute2: 'ANARCHY.common.roll.attribute2',
-            modifiers: {
-                edge: 'ANARCHY.common.roll.modifiers.edge',
-                specialization: 'ANARCHY.common.roll.modifiers.specialization',
-                poolModifiers: 'ANARCHY.common.roll.modifiers.poolModifiers',
-                social: {
-                    credibility: 'ANARCHY.common.roll.modifiers.social.credibility',
-                    rumor: 'ANARCHY.common.roll.modifiers.social.rumor',
-                },
-                anarchyDisposition: 'ANARCHY.common.roll.modifiers.anarchyDisposition',
-                anarchyRisk: 'ANARCHY.common.roll.modifiers.anarchyRisk',
-                glitch: 'ANARCHY.common.roll.modifiers.glitch',
-                convergence: 'ANARCHY.common.roll.modifiers.convergence',
-                wounds: 'ANARCHY.common.roll.modifiers.wounds',
-                weaponRange: 'ANARCHY.common.roll.modifiers.weaponRange',
-                weaponArea: 'ANARCHY.common.roll.modifiers.weaponArea',
-                other: 'ANARCHY.common.roll.modifiers.other',
-                virtualReality: 'ANARCHY.common.roll.modifiers.virtualReality',
-                reduced: 'ANARCHY.common.roll.modifiers.reduced',
-                reroll: 'ANARCHY.common.roll.modifiers.reroll',
-                rerollForced: 'ANARCHY.common.roll.modifiers.rerollForced',
-                opponentReroll: 'ANARCHY.common.roll.modifiers.opponentReroll',
-                opponentPool: 'ANARCHY.common.roll.modifiers.opponentPool'
-            },
-            rollTheme: {
-                dicePool: 'ANARCHY.common.roll.rollTheme.dicePool',
-                reroll: 'ANARCHY.common.roll.rollTheme.reroll',
-                removed: 'ANARCHY.common.roll.rollTheme.removed',
-                rerollRemoved: 'ANARCHY.common.roll.rollTheme.rerollRemoved',
-                glitch: 'ANARCHY.common.roll.rollTheme.glitch',
-                convergence: 'ANARCHY.common.roll.rollTheme.convergence',
-                anarchyRisk: 'ANARCHY.common.roll.rollTheme.anarchyRisk',
-            },
-            opponentRoll: 'ANARCHY.common.roll.opponentRoll',
-            totalSuccess: 'ANARCHY.common.roll.totalSuccess',
-            success: 'ANARCHY.common.roll.success',
-            risk: {
-                prowess: 'ANARCHY.common.roll.risk.prowess',
-                nothing: 'ANARCHY.common.roll.risk.nothing',
-                mixed: 'ANARCHY.common.roll.risk.mixed',
-                glitch: 'ANARCHY.common.roll.risk.glitch',
-            },
-            rerollSuccess: 'ANARCHY.common.roll.rerollSuccess',
-            rerollForcedLoss: 'ANARCHY.common.roll.rerollForcedLoss',
-            rerollForcedSuccess: 'ANARCHY.common.roll.rerollForcedSuccess',
-        },
-        confirmation: {
-            del: 'ANARCHY.common.confirmation.del',
-            delItem: 'ANARCHY.common.confirmation.delItem',
-            delOwner: 'ANARCHY.common.confirmation.delOwner',
-            attach: 'ANARCHY.common.confirmation.attach',
-            attachOrCopy: 'ANARCHY.common.confirmation.attachOrCopy',
-        },
-        selection: {
-            actorSettingMarks: 'ANARCHY.common.selection.actorSettingMarks'
-        },
-        errors: {
-            insufficient: 'ANARCHY.common.errors.insufficient',
-            outOfRange: 'ANARCHY.common.errors.outOfRange',
-            onlyGM: 'ANARCHY.common.errors.onlyGM',
-            noEdgeForActor: 'ANARCHY.common.errors.noEdgeForActor',
-            expectedType: 'ANARCHY.common.errors.expectedType',
-            ignoredTargets: 'ANARCHY.common.errors.ignoredTargets',
-            noTargetSelected: 'ANARCHY.common.errors.noTargetSelected',
-            maxTargetsExceedeed: 'ANARCHY.common.errors.maxTargetsExceedeed',
-            noDefenseOnWeapon: 'ANARCHY.common.errors.noDefenseOnWeapon',
-            noTokenActor: 'ANARCHY.common.errors.noTokenActor',
-            noValidPilotForVehicle: 'ANARCHY.common.errors.noValidPilotForVehicle',
-            cannotUseEdgeAnymore: 'ANARCHY.common.errors.cannotUseEdgeAnymore',
-            actorCannotApplyDamage: 'ANARCHY.common.errors.actorCannotApplyDamage',
-            actorCannotReceiveDamage: 'ANARCHY.common.errors.actorCannotReceiveDamage',
-            actorDoesNotHaveDefense: 'ANARCHY.common.errors.actorDoesNotHaveDefense',
-        },
-        sourceReference: 'ANARCHY.common.sourceReference',
-        sourceReferenceHelp: 'ANARCHY.common.sourceReferenceHelp',
-        description: 'ANARCHY.common.description',
-        gmnotes: 'ANARCHY.common.gmnotes',
-    },
-    actor: {
-        characterSheet: 'ANARCHY.actor.characterSheet',
-        characterTabbedSheet: 'ANARCHY.actor.characterTabbedSheet',
-        characterEnhancedSheet: 'ANARCHY.actor.characterEnhancedSheet',
-        vehicleSheet: 'ANARCHY.actor.vehicleSheet',
-        characterNPCSheet: 'ANARCHY.actor.characterNPCSheet',
-        actorName: 'ANARCHY.actor.actorName',
-        celebrity: 'ANARCHY.actor.counters.edgePools.legend',
-        tabs: {
-            main: 'ANARCHY.actor.tabs.main',
-            equipment: 'ANARCHY.actor.tabs.equipment',
-            biography: 'ANARCHY.actor.tabs.biography',
-        },
-        words: {
-            keywords: 'ANARCHY.actor.words.keywords',
-            cues: 'ANARCHY.actor.words.cues',
-            dispositions: 'ANARCHY.actor.words.dispositions',
-        },
-        counters: {
-            xp: 'ANARCHY.actor.counters.xp',
-            xpTotal: 'ANARCHY.actor.counters.xpTotal',
-            edge: 'ANARCHY.actor.counters.edge',
-            anarchy: 'ANARCHY.actor.counters.anarchy',
-            sceneAnarchy: 'ANARCHY.actor.counters.sceneAnarchy',
-            plot: 'ANARCHY.actor.counters.plot',
-            edgePools: {
-                title: 'ANARCHY.actor.counters.edgePools.title',
-                physical: 'ANARCHY.actor.counters.edgePools.physical',
-                mental: 'ANARCHY.actor.counters.edgePools.mental',
-                social: 'ANARCHY.actor.counters.edgePools.social',
-                grit: 'ANARCHY.actor.counters.edgePools.grit',
-                insight: 'ANARCHY.actor.counters.edgePools.insight',
-                rumor: 'ANARCHY.actor.counters.edgePools.rumor',
-                legend: 'ANARCHY.actor.counters.edgePools.legend',
-                credibility: 'ANARCHY.actor.counters.edgePools.credibility',
-                chaos: 'ANARCHY.actor.counters.edgePools.chaos',
-            },
-            mental: {
-                insight: 'ANARCHY.actor.counters.mental.insight',
-                rumor: 'ANARCHY.actor.counters.mental.rumor',
-            },
-            social: {
-                legend: 'ANARCHY.actor.counters.social.legend',
-                credibility: 'ANARCHY.actor.counters.social.credibility',
+        "damageMode": {
+            "name": "Damage application",
+            "hint": "Determine how Armor / Damage Resistance (RD) applies",
+            "values": {
+                "resistanceArmorMonitor": "MechWarrior: Destiny: Resistance, Armor, then Monitor",
+                "armorResistanceMonitor": "Armor, Resistance, Monitor",
+                "armorGivesResistance": "RD = Armor/3 + Str/4, damaged per blow, AA ignores armor",
+                "armorGiveResistanceHitsAvoid": "RD = Armor/3, damaged per blow, AA reduces resistance"
             }
         },
-        monitors: {
-            conditionMonitors: 'ANARCHY.actor.monitors.conditionMonitors',
-            overflow: 'ANARCHY.actor.monitors.overflow',
-            physical: 'ANARCHY.actor.monitors.physical',
-            fatigue: 'ANARCHY.actor.monitors.fatigue',
-            armor: 'ANARCHY.actor.monitors.armor',
-            structure: 'ANARCHY.actor.monitors.structure',
-            heat: 'ANARCHY.actor.monitors.heat',
-            resistance: 'ANARCHY.actor.monitors.resistance',
-        },
-        vehicle: {
-            moves: 'ANARCHY.actor.vehicle.moves',
-            attacks: 'ANARCHY.actor.vehicle.attacks',
-            stealth: 'ANARCHY.actor.vehicle.stealth',
-            category: 'ANARCHY.actor.vehicle.category',
-            skill: 'ANARCHY.actor.vehicle.skill',
-            quickActions: {
-                title: 'ANARCHY.actor.vehicle.quickActions.title',
-                rangedAttack: 'ANARCHY.actor.vehicle.quickActions.rangedAttack',
-                meleeAttack: 'ANARCHY.actor.vehicle.quickActions.meleeAttack',
-                dodgeCheck: 'ANARCHY.actor.vehicle.quickActions.dodgeCheck',
-                pilotingCheck: 'ANARCHY.actor.vehicle.quickActions.pilotingCheck',
-                sensorSweep: 'ANARCHY.actor.vehicle.quickActions.sensorSweep',
-                emergencyRepair: 'ANARCHY.actor.vehicle.quickActions.emergencyRepair',
-                primaryWeapons: 'ANARCHY.actor.vehicle.quickActions.primaryWeapons',
-                allWeapons: 'ANARCHY.actor.vehicle.quickActions.allWeapons',
-                primaryLabel: 'ANARCHY.actor.vehicle.quickActions.primaryLabel',
-                unarmed: 'ANARCHY.actor.vehicle.quickActions.unarmed',
-                unarmedNotes: 'ANARCHY.actor.vehicle.quickActions.unarmedNotes',
-                selectWeaponGroup: 'ANARCHY.actor.vehicle.quickActions.selectWeaponGroup',
-                selectMeleeProfile: 'ANARCHY.actor.vehicle.quickActions.selectMeleeProfile',
-                selectSensorSkill: 'ANARCHY.actor.vehicle.quickActions.selectSensorSkill',
-                weaponGroup: 'ANARCHY.actor.vehicle.quickActions.weaponGroup',
-                weaponsUsed: 'ANARCHY.actor.vehicle.quickActions.weaponsUsed',
-                meleeProfile: 'ANARCHY.actor.vehicle.quickActions.meleeProfile',
-                meleeDamage: 'ANARCHY.actor.vehicle.quickActions.meleeDamage',
-                skillUsed: 'ANARCHY.actor.vehicle.quickActions.skillUsed',
-                tooltips: {
-                    ranged: 'ANARCHY.actor.vehicle.quickActions.tooltips.ranged',
-                    melee: 'ANARCHY.actor.vehicle.quickActions.tooltips.melee',
-                    dodge: 'ANARCHY.actor.vehicle.quickActions.tooltips.dodge',
-                    piloting: 'ANARCHY.actor.vehicle.quickActions.tooltips.piloting',
-                    sensorSweep: 'ANARCHY.actor.vehicle.quickActions.tooltips.sensorSweep',
-                    emergencyRepair: 'ANARCHY.actor.vehicle.quickActions.tooltips.emergencyRepair',
+        "useDestinyMechanics": {
+            "name": "Use Destiny opposed roll mechanics",
+            "hint": "Roll 2D6 and add the computed pool as a modifier instead of counting successes."
+        }
+    },
+    "gmManager": {
+        "title": "GM manager",
+        "gmConvergence": "GOD convergence",
+        "playerChangedAnarchy": "Player {user} changed {actor}'s {monitor} from {from} to {to}",
+        "gmReceivedAnarchy": "Gamemaster receives {anarchy} anarchy from {actor}"
+    },
+    "chat": {
+        "blindMessageToGM": "Blind message from {user}:<br>{message}",
+        "sufferedDrain": "{actor} suffered a drain of {drain}",
+        "noDrain": "{actor} did not suffer any drain",
+        "defendAttack": "Defense against {success} success",
+        "defendPilotAttack": "Pilot defense against {success} success",
+        "partiallyDefended": "Attack exceeds defense of {success} success",
+        "fullyDefended": "The attack is fully defended",
+        "applyDamage": "Apply {damage}"
+    },
+    "chat_actions": {
+        "rollDice": {
+            "title": "Roll Destiny dice",
+            "instruction": "Number of dice to roll: ",
+            "error": "Veuillez entrer un nombre valide de dés.",
+            "result": "Roll of {count}d6, {success} success! {ones} dice with a value of 1"
+        }
+    },
+    "user": {
+        "selectedTokenActors": "Selected actor tokens"
+    },
+    "common": {
+        "newEntry": "New entry...",
+        "newName": "New {type}",
+        "cancel": "Cancel",
+        "add": "Add",
+        "resize": "Resize",
+        "say": "Say:",
+        "edit": "Edit",
+        "activate": "Activate",
+        "del": "Remove",
+        "favorite": "Favorites",
+        "addFavorite": "Add to favorites",
+        "delFavorite": "Remove from favorites",
+        "viewMode": "View mode",
+        "editMode": "Edit mode",
+        "attach": "Change owner",
+        "attachCopy": "Give a copy",
+        "roll": {
+            "button": "Roll",
+            "title": "Roll {name} {specialization}",
+            "attribute": "Attribute",
+            "attribute2": "Second attribute",
+            "modifiers": {
+                "edge": "Use edge",
+                "edgePool": "Spend from",
+                "specialization": "Specialization",
+                "poolModifiers": "Asset Modules",
+                "social": {
+                    "credibility": "Credibility",
+                    "rumor": "Rumor"
                 },
-                errors: {
-                    noRanged: 'ANARCHY.actor.vehicle.quickActions.errors.noRanged',
-                    noMelee: 'ANARCHY.actor.vehicle.quickActions.errors.noMelee',
-                    noSensorSweep: 'ANARCHY.actor.vehicle.quickActions.errors.noSensorSweep',
+                "anarchyDisposition": "Anarchy - Dispositions",
+                "anarchyRisk": "Anarchy - Take risks",
+                "glitch": "Glitch dice",
+                "convergence": "GOD Convergence",
+                "drain": "Drain",
+                "wounds": "Wounds modifiers",
+                "weaponRange": "Range",
+                "weaponArea": "Multiple targets",
+                "other": "Other modifiers",
+                "virtualReality": "Virtual Reality",
+                "reduced": "Pool reduced",
+                "reroll": "Rerolls",
+                "rerollForced": "Rerolls successes",
+                "opponentReroll": "Force opponent rerolls",
+                "opponentPool": "Reduce opponent pool"
+            },
+            "rollTheme": {
+                "dicePool": "Dice pool",
+                "reroll": "Failure rerolls",
+                "removed": "Success to reroll",
+                "rerollRemoved": "Reroll removed success",
+                "glitch": "Glitch dice",
+                "drain": "Drain",
+                "convergence": "Convergence",
+                "anarchyRisk": "Anarchy risk dice"
+            },
+            "opponentRoll": "Opponent roll",
+            "totalSuccess": "Total successes",
+            "success": "Successes",
+            "risk": {
+                "prowess": "Prowess",
+                "mixed": "Prowess and Glitch",
+                "nothing": "no effect",
+                "glitch": "Glitch"
+            },
+            "rerollSuccess": "Successes after reroll",
+            "rerollForcedLoss": "Forced reroll",
+            "rerollForcedSuccess": "Forced reroll successes"
+        },
+        "monitorValue": "Monitor value",
+        "confirmation": {
+            "del": "Confirm removal",
+            "delItem": "Confirm removal of {name} ({type})",
+            "delowner": "Confirm detach from owner {name}",
+            "attach": "Attach actor to owner",
+            "attachOrCopy": "Attach {ownedType} {ownedName} to {ownerType} {ownerName}, or create a copy first"
+        },
+        "selection": {
+            "actorSettingMarks": "Select actor setting Marks on {name}"
+        },
+        "errors": {
+            "insufficient": "Not enough {resource}: required {required}, available {available}",
+            "outOfRange": "Cannot set {resource} to {value}, out of range [{min} , {max}]",
+            "onlyGM": "Only allowed for GM",
+            "noEdgeForActor": "{actor} is a {actorType}, so it cannot use Edge",
+            "expectedType": "Item is of type {type} instead of expected type {expectedType}",
+            "ignoredTargets": "This action cannot target {targets} due to its damage type",
+            "noTargetSelected": "No valid target is selected, consider selecting a valid target before using this {weapon}",
+            "maxTargetsExceedeed": "{weapon} has a {area} area of effect, with a maximum of {max} targets. You are currently targetting {count} targets",
+            "noDefenseOnWeapon": "No defense configured for {actor} weapon: {weapon}.<br>Configure defense against this weapon to be able to attack with it.",
+            "weaponNotFound": "No weapon could be found for this roll.",
+            "noTokenActor": "Token is not attached to an Actor!",
+            "noValidPilotForVehicle": "No valid pilot found for {vehicle} among selected tokens, your main character, and vehicle owner",
+            "cannotUseEdgeAnymore": "Too late to use edge. A defender already rolled his defense!",
+            "actorCannotApplyDamage": "Actor {actor} cannot apply {damageType} : maybe check the decker has connected his cyberdeck",
+            "actorCannotReceiveDamage": "Cannot apply {damageType} to actor {actor} : it does not have a condition monitor for this type of damage",
+            "actorDoesNotHaveDefense": "Actor {actor} does not have a {defense}, the attack should not to target {actorType}.<br>Or it may be a bug, please report and manage manually"
+        },
+        "sourceReference": "Source reference",
+        "sourceReferenceHelp": "rulebook, page, ...",
+        "description": "Description",
+        "gmnotes": "GM notes"
+    },
+    "actor": {
+        "characterSheet": "Character sheet",
+        "characterTabbedSheet": "Character sheet (tabs)",
+        "characterEnhancedSheet": "Character enhanced sheet (tabs)",
+        "vehicleSheet": "Vehicle sheet",
+        "battlemechSheet": "Battlemech sheet",
+        "characterNPCSheet": "NPC sheet",
+        "actorName": "Name",
+        "celebrity": "Legend",
+        "famous": "Fame",
+        "edgePools": {
+            "title": "Edge Pools",
+            "physical": "Physical",
+            "mental": "Mental",
+            "social": "Social",
+            "grit": "Grit",
+            "insight": "Insight",
+            "rumor": "Rumor",
+            "legend": "Legend",
+            "credibility": "Credibility",
+            "chaos": "Chaos"
+        },
+        "tabs": {
+            "main": "Character",
+            "equipment": "Equipment",
+            "biography": "Biography"
+        },
+        "words": {
+            "keywords": "Keywords",
+            "cues": "Cues",
+            "dispositions": "Dispositions"
+        },
+        "counters": {
+            "xp": "XP",
+            "xpUnused": "Unspent XP",
+            "xpTotal": "Lifetime XP",
+            "current": "Current",
+            "lifetime": "Lifetime",
+            "edge": "Edge",
+            "anarchy": "Destiny",
+            "sceneAnarchy": "Chaos",
+            "plot": "Plot",
+            "edgePools": {
+                "physical": "Physical",
+                "mental": "Mental",
+                "social": "Social",
+                "grit": "Grit",
+                "insight": "Insight",
+                "rumor": "Rumor",
+                "legend": "Legend",
+                "credibility": "Credibility",
+                "chaos": "Chaos"
+            },
+            "mental": {
+                "insight": "Insight",
+                "rumor": "Rumor"
+            },
+            "social": {
+                "legend": "Legend",
+                "credibility": "Credibility"
+            }
+        },
+        "monitors": {
+            "conditionMonitors": "Condition monitors",
+            "overflow": "{actor}: Overflow of {monitor} condition monitor, transfering {overflow} to {overflowMonitor} condition monitor",
+            "physical": "Physical",
+            "fatigue": "Fatigue",
+            "armor": "Armor",
+            "structure": "Structure",
+            "heat": "Heat",
+            "effect": "Effect",
+            "grit": "Grit",
+            "insight": "Insight",
+            "rumor": "Rumor",
+            "legend": "Legend",
+            "credibility": "Credibility",
+            "chaos": "Chaos",
+            "resistance": "Resistance",
+            "resistanceBase": "Base resistance",
+            "resistanceByType": "By damage type",
+            "resistanceByTypeButton": "Resist by type",
+            "resistanceByTypeTitle": "Type-specific resistance",
+            "resistanceBonusLabel": "Bonuses",
+            "resistanceTotal": "Total",
+            "resistanceFallback": "Falls back to base",
+            "damageType": "Damage type",
+            "resistancePresets": {
+                "label": "Presets",
+                "biological": "Biological",
+                "armoredVehicle": "Armored vehicle",
+                "energyShielded": "Energy shielded"
+            },
+            "resistanceApplied": "{actor} resisted {value} vs {damageType} on {monitor} ({source})",
+            "resistanceSources": {
+                "default": "base",
+                "type": "type-specific"
+            }
+        },
+        "vehicle": {
+            "moves": "Moves",
+            "attacks": "Attacks",
+            "stealth": "Stealth",
+            "category": "Category",
+            "skill": "Skill",
+            "weapons": "Vehicle Weapons",
+            "heatDissipation": "Heat dissipation",
+            "criticalTrack": "Criticals",
+            "locationFront": "Front effects",
+            "locationSide": "Side effects",
+            "locationRear": "Rear effects",
+            "locationCore": "Core effects",
+            "pilot": {
+                "label": "Pilot",
+                "none": "No pilot selected",
+                "usingPilot": "Using pilot: {{pilot}}",
+                "selectActor": "Select Pilot",
+                "selectToken": "Use Selected Token",
+                "tokenTag": "Token ({{scene}})",
+                "errors": {
+                    "noActors": "No valid actors available to pilot this vehicle.",
+                    "noTokens": "Select a token with permission to pilot as the vehicle's pilot."
+                }
+            },
+            "crew": {
+                "label": "Crew",
+                "placeholder": "Crew names or notes"
+            },
+            "quickActions": {
+                "title": "Quick Actions",
+                "rangedAttack": "Ranged Attack",
+                "meleeAttack": "Melee Attack",
+                "dodgeCheck": "Dodge Check",
+                "pilotingCheck": "Piloting Check",
+                "sensorSweep": "Sensor Sweep",
+                "emergencyRepair": "Emergency Repair",
+                "primaryWeapons": "Primary Weapons",
+                "allWeapons": "All Weapons",
+                "primaryLabel": "Primary",
+                "unarmed": "Unarmed (Punch/Kick)",
+                "unarmedNotes": "Basic unarmed strike.",
+                "selectWeaponGroup": "Select Weapon Group",
+                "selectMeleeProfile": "Select Melee Profile",
+                "selectSensorSkill": "Select Sensor Sweep Skill",
+                "weaponGroup": "Weapon Group",
+                "weaponsUsed": "Weapons",
+                "meleeProfile": "Melee Profile",
+                "meleeDamage": "Damage",
+                "skillUsed": "Skill",
+                "tooltips": {
+                    "ranged": "Roll an attack using any Weapon Group or Primary Weapon",
+                    "melee": "Roll a melee attack using fists, kicks, or installed melee weapons",
+                    "dodge": "Piloting roll to evade incoming fire or avoid danger",
+                    "piloting": "Piloting roll for movement, jumping, stability, or hazard checks",
+                    "sensorSweep": "Perception/Tech roll using sensors or Active Probe",
+                    "emergencyRepair": "Technician roll to stabilize or fix a system during battle"
+                },
+                "errors": {
+                    "noRanged": "No weapon groups available for ranged attack.",
+                    "noMelee": "No melee attacks available.",
+                    "noSensorSweep": "Sensor sweep requires Perception or Technician."
                 }
             }
         },
-        ownership: {
-            owner: 'ANARCHY.actor.ownership.owner',
-            unknown: 'ANARCHY.actor.ownership.unknown',
-            owned: 'ANARCHY.actor.ownership.owned',
-        }
-    },
-    actorType: {
-        character: 'ANARCHY.actorType.character',
-        vehicle: 'ANARCHY.actorType.vehicle',
-        battlemech: 'ANARCHY.actorType.battlemech',
-    },
-    item: {
-        sheet: 'ANARCHY.item.sheet',
-        tabs: {
-            main: 'ANARCHY.item.tabs.main',
-            modifiers: 'ANARCHY.item.tabs.modifiers',
-        },
-        common: {
-            inactive: 'ANARCHY.item.common.inactive',
-        },
-        skill: {
-            code: 'ANARCHY.item.skill.code',
-            copyDefault: 'ANARCHY.item.skill.useDefault',
-            isKnowledge: 'ANARCHY.item.skill.isKnowledge',
-            attribute: 'ANARCHY.item.skill.attribute',
-            value: 'ANARCHY.item.skill.value',
-            specialization: 'ANARCHY.item.skill.specialization',
-            hasDrain: 'ANARCHY.item.skill.isSocial',
-            hasDrain: 'ANARCHY.item.skill.hasDrain',
-            hasConvergence: 'ANARCHY.item.skill.hasConvergence',
-            specializationHelp: 'ANARCHY.item.skill.specializationHelp'
-        },
-        quality: {
-            positive: 'ANARCHY.item.quality.positive'
-        },
-        assetModule: {
-            category: 'ANARCHY.item.assetModule.category',
-            level: 'ANARCHY.item.assetModule.level',
-            levelShort: 'ANARCHY.item.assetModule.levelShort',
-        },
-        mechWeapon: {
-            damage: 'ANARCHY.item.mechWeapon.damage',
-            heat: 'ANARCHY.item.mechWeapon.heat',
-            area: 'ANARCHY.item.mechWeapon.area',
-            range: {
-                max: 'ANARCHY.item.mechWeapon.range.max'
-            }
-        },
-        personalWeapon: {
-            skill: 'ANARCHY.item.personalWeapon.skill',
-            weaponCategory: 'ANARCHY.item.personalWeapon.category',
-            damageCategory: 'ANARCHY.item.personalWeapon.damageCategory',
-            damage: 'ANARCHY.item.personalWeapon.damage',
-            defense: 'ANARCHY.item.personalWeapon.defense',
-            area: 'ANARCHY.item.personalWeapon.area',
-            armorAvoidance: 'ANARCHY.item.personalWeapon.armorAvoidance',
-            damageShort: 'ANARCHY.item.personalWeapon.damageShort',
-            areaShort: 'ANARCHY.item.personalWeapon.areaShort',
-            weaponWithoutActor: 'ANARCHY.item.personalWeapon.weaponWithoutActor',
-            range: {
-                max: 'ANARCHY.item.personalWeapon.range.max'
-            }
-        }
-    },
-    itemType: {
-        singular: {
-            skill: 'ANARCHY.itemType.singular.skill',
-            quality: 'ANARCHY.itemType.singular.quality',
-            assetModule: 'ANARCHY.itemType.singular.assetModule',
-            mechWeapon: 'ANARCHY.itemType.singular.mechWeapon',
-            personalWeapon: 'ANARCHY.itemType.singular.personalWeapon',
-            gear: 'ANARCHY.itemType.singular.gear',
-            contact: 'ANARCHY.itemType.singular.contact',
-            lifeModule: 'ANARCHY.itemType.singular.lifeModule'
-        },
-        plural: {
-            skill: 'ANARCHY.itemType.plural.skill',
-            quality: 'ANARCHY.itemType.plural.quality',
-            assetModule: 'ANARCHY.itemType.plural.assetModule',
-            mechWeapon: 'ANARCHY.itemType.plural.mechWeapon',
-            personalWeapon: 'ANARCHY.itemType.plural.personalWeapon',
-            gear: 'ANARCHY.itemType.plural.gear',
-            contact: 'ANARCHY.itemType.plural.contact',
-            lifeModule: 'ANARCHY.itemType.plural.lifeModule'
-        }
-    },
-    lifeModule: {
-        type: {
-            faction: 'ANARCHY.item.lifeModule.type.faction',
-            childhood: 'ANARCHY.item.lifeModule.type.childhood',
-            higherEducation: 'ANARCHY.item.lifeModule.type.higherEducation',
-            realLife: 'ANARCHY.item.lifeModule.type.realLife',
-        }
-    },
-    monitor: {
-        physical: 'ANARCHY.monitor.physical',
-        fatigue: 'ANARCHY.monitor.fatigue',
-    },
-    monitorLetter: {
-        physical: 'ANARCHY.monitorLetter.physical',
-        fatigue: 'ANARCHY.monitorLetter.fatigue',
-    },
-    assetModuleCategory: {
-        faction: 'ANARCHY.assetModuleCategory.faction',
-        logistics: 'ANARCHY.assetModuleCategory.logistics',
-        training: 'ANARCHY.assetModuleCategory.training',
-        influence: 'ANARCHY.assetModuleCategory.influence',
-        personal: 'ANARCHY.assetModuleCategory.personal',
-        operations: 'ANARCHY.assetModuleCategory.operations'
-    },
-    attributes: {
-        noAttribute: 'ANARCHY.attributes.noAttributes',
-        strength: 'ANARCHY.attributes.strength',
-        reflexes: 'ANARCHY.attributes.reflexes',
-        willpower: 'ANARCHY.attributes.willpower',
-        intelligence: 'ANARCHY.attributes.intelligence',
-        charisma: 'ANARCHY.attributes.charisma',
-        edge: 'ANARCHY.attributes.edge',
-        autopilot: 'ANARCHY.attributes.autopilot',
-        handling: 'ANARCHY.attributes.handling',
-        firewall: 'ANARCHY.attributes.firewall',
-        system: 'ANARCHY.attributes.system',
-        chassis: 'ANARCHY.attributes.chassis',
-        condition: 'ANARCHY.attributes.condition',
-        knowledge: 'ANARCHY.attributes.knowledge',
-    },
-    attributeAction: {
-        defense: 'ANARCHY.attributeAction.defense',
-        judgeIntentions: 'ANARCHY.attributeAction.judgeIntentions',
-        perception: 'ANARCHY.attributeAction.perception',
-        resistTorture: 'ANARCHY.attributeAction.resistTorture',
-        composure: 'ANARCHY.attributeAction.composure',
-        memory: 'ANARCHY.attributeAction.memory',
-        catch: 'ANARCHY.attributeAction.catch',
-        lift: 'ANARCHY.attributeAction.lift'
-    },
-    defense: {
-        physicalDefense: 'ANARCHY.defense.physicalDefense',
-        physicalResistance: 'ANARCHY.defense.physicalResistance',
-        socialDefense: 'ANARCHY.defense.socialDefense',
-        mentalResistance: 'ANARCHY.defense.mentalResistance',
-    },
-    skill: {
-        athletics: 'ANARCHY.skill.athletics',
-        heavyWeapons: 'ANARCHY.skill.heavyWeapons',
-        escapeArtist: 'ANARCHY.skill.escapeArtist',
-        gunnery: 'ANARCHY.skill.gunnery',
-        meleeCombat: 'ANARCHY.skill.meleeCombat',
-        piloting: 'ANARCHY.skill.piloting',
-        projectileWeapons: 'ANARCHY.skill.projectileWeapons',
-        firearms: 'ANARCHY.skill.firearms',
-        stealth: 'ANARCHY.skill.stealth',
-        zeroGOperations: 'ANARCHY.skill.zeroGOperations',
-        art: 'ANARCHY.skill.art',
-        artillery: 'ANARCHY.skill.artillery',
-        communications: 'ANARCHY.skill.communications',
-        computers: 'ANARCHY.skill.computers',
-        demolitions: 'ANARCHY.skill.demolitions',
-        knowledge: 'ANARCHY.skill.knowledge',
-        medTech: 'ANARCHY.skill.medTech',
-        science: 'ANARCHY.skill.science',
-        perception: 'ANARCHY.skill.perception',
-        tactics: 'ANARCHY.skill.tactics',
-        technician: 'ANARCHY.skill.technician',
-        tracking: 'ANARCHY.skill.tracking',
-        navigation: 'ANARCHY.skill.navigation',
-        animalHandling: 'ANARCHY.skill.animalHandling',
-        survival: 'ANARCHY.skill.survival',
-        acting: 'ANARCHY.skill.acting',
-        disguise: 'ANARCHY.skill.disguise',
-        leadership: 'ANARCHY.skill.leadership',
-        negotiation: 'ANARCHY.skill.negotiation',
-        etiquette: 'ANARCHY.skill.etiquette',
-        streetwise: 'ANARCHY.skill.streetwise',
-        intimidation: 'ANARCHY.skill.intimidation',
-    },
-    area: {
-        none: 'ANARCHY.area.none',
-        shotgun: 'ANARCHY.area.shotgun',
-        circle: 'ANARCHY.area.circle',
-        cone: 'ANARCHY.area.cone',
-        rect: 'ANARCHY.area.rect',
-        ray: 'ANARCHY.area.ray'
-    },
-    range: {
-        contact: 'ANARCHY.range.contact',
-        short: 'ANARCHY.range.short',
-        medium: 'ANARCHY.range.medium',
-        far: 'ANARCHY.range.far',
-        extreme: 'ANARCHY.range.extreme',
-    },
-    vehicleCategory: {
-        drone: 'ANARCHY.vehicleCategory.drone',
-        personal: 'ANARCHY.vehicleCategory.personal',
-        combat: 'ANARCHY.vehicleCategory.combat',
-        aerospace: 'ANARCHY.vehicleCategory.aerospace',
-        mech: 'ANARCHY.vehicleCategory.mech',
-    },
-    mwd: {
-        weightClass: {
-            light: 'ANARCHY.mwd.weightClass.light',
-            medium: 'ANARCHY.mwd.weightClass.medium',
-            heavy: 'ANARCHY.mwd.weightClass.heavy',
-            assault: 'ANARCHY.mwd.weightClass.assault',
-        },
-        hardpointType: {
-            ballistic: 'ANARCHY.mwd.hardpoint.type.ballistic',
-            energy: 'ANARCHY.mwd.hardpoint.type.energy',
-            missile: 'ANARCHY.mwd.hardpoint.type.missile',
-            special: 'ANARCHY.mwd.hardpoint.type.special',
-            melee: 'ANARCHY.mwd.hardpoint.type.melee',
-        },
-        hardpointSize: {
-            small: 'ANARCHY.mwd.hardpoint.size.small',
-            medium: 'ANARCHY.mwd.hardpoint.size.medium',
-            large: 'ANARCHY.mwd.hardpoint.size.large',
-        },
-        hardpointLocation: {
-            head: 'ANARCHY.mwd.hardpoint.location.head',
-            torso: 'ANARCHY.mwd.hardpoint.location.torso',
-            arm: 'ANARCHY.mwd.hardpoint.location.arm',
-            leg: 'ANARCHY.mwd.hardpoint.location.leg',
-        },
-        primarySlotMode: {
-            normal: 'ANARCHY.mwd.primarySlot.mode.normal',
-            converted: 'ANARCHY.mwd.primarySlot.mode.converted',
-        },
-        weaponCategory: {
-            ranged: 'ANARCHY.mwd.weaponCategory.ranged',
-            melee: 'ANARCHY.mwd.weaponCategory.melee',
-        },
-        weaponDamageType: {
-            energy: 'ANARCHY.mwd.weapon.damageType.energy',
-            kinetic: 'ANARCHY.mwd.weapon.damageType.kinetic',
-            explosive: 'ANARCHY.mwd.weapon.damageType.explosive',
-            plasma: 'ANARCHY.mwd.weapon.damageType.plasma',
-            none: 'ANARCHY.mwd.weapon.damageType.none'
-        },
-        personalDamageType: {
-            energy: 'ANARCHY.mwd.personalWeapon.damageType.energy',
-            kinetic: 'ANARCHY.mwd.personalWeapon.damageType.kinetic',
-            explosive: 'ANARCHY.mwd.personalWeapon.damageType.explosive',
-            plasma: 'ANARCHY.mwd.personalWeapon.damageType.plasma',
-            corrosive: 'ANARCHY.mwd.personalWeapon.damageType.corrosive',
-            poison: 'ANARCHY.mwd.personalWeapon.damageType.poison'
-        },
-        personalDamageCategory: {
-            physical: 'ANARCHY.mwd.personalWeapon.damageCategory.physical',
-            fatigue: 'ANARCHY.mwd.personalWeapon.damageCategory.fatigue'
-        },
-        meleeLocation: {
-            head: 'ANARCHY.mwd.melee.location.head',
-            torso: 'ANARCHY.mwd.melee.location.torso',
-            arm: 'ANARCHY.mwd.melee.location.arm',
-            leg: 'ANARCHY.mwd.melee.location.leg',
-        },
-    },
-    modifier: {
-        column: {
-            group: 'ANARCHY.modifier.column.group',
-            effect: 'ANARCHY.modifier.column.effect',
-            value: 'ANARCHY.modifier.column.value',
-            category: 'ANARCHY.modifier.column.category',
-            subCategory: 'ANARCHY.modifier.column.subCategory',
-            target: 'ANARCHY.modifier.column.target',
-            condition: 'ANARCHY.modifier.column.condition',
-        },
-        group: {
-            roll: 'ANARCHY.modifier.group.roll',
-            attribute: 'ANARCHY.modifier.group.attribute',
-            monitor: 'ANARCHY.modifier.group.monitor',
-            other: 'ANARCHY.modifier.group.other',
-        },
-        roll: {
-            effect: {
-                pool: 'ANARCHY.modifier.roll.effect.pool',
-                reroll: 'ANARCHY.modifier.roll.effect.reroll',
-                rerollMax: 'ANARCHY.modifier.roll.effect.rerollMax',
-                glitch: 'ANARCHY.modifier.roll.effect.glitch',
-                successReroll: 'ANARCHY.modifier.roll.effect.successReroll',
-                opponentPool: 'ANARCHY.modifier.roll.effect.opponentPool',
-                opponentReroll: 'ANARCHY.modifier.roll.effect.opponentReroll',
-            },
-            category: {
-                attribute: 'ANARCHY.modifier.roll.category.attribute',
-                skill: 'ANARCHY.modifier.roll.category.skill',
-                attributeAction: 'ANARCHY.modifier.roll.category.attributeAction',
-            },
-        },
-            monitor: {
-                effect: {
-                    armor: 'ANARCHY.modifier.monitor.effect.armor',
-                    structure: 'ANARCHY.modifier.monitor.effect.structure',
-                    fatigue: 'ANARCHY.modifier.monitor.effect.fatigue',
-                physical: 'ANARCHY.modifier.monitor.effect.physical',
-                },
-                category: {
-                    max: 'ANARCHY.modifier.monitor.category.max',
-                    resistance: 'ANARCHY.modifier.monitor.category.resistance',
-                    resistanceByType: 'ANARCHY.modifier.monitor.category.resistanceByType',
+        "battlemech": {
+            "chassis": "Chassis",
+            "tonnage": "Tonnage",
+            "heat": {
+                "thresholds": "Heat thresholds",
+                "runningHot": "Running hot",
+                "overheated": "Overheated",
+                "shutdown": "Shutdown",
+                "statusLabel": "Current heat state",
+                "status": {
+                    "safe": "Safe",
+                    "runningHot": "Running hot",
+                    "overheated": "Overheated",
+                    "shutdown": "Shutdown"
                 }
-        },
-        other: {
-            effect: {
-                ignoreWounds: 'ANARCHY.modifier.other.effect.ignoreWounds',
-                damageArmor: 'ANARCHY.modifier.other.effect.damageArmor',
-                sceneAnarchy: 'ANARCHY.modifier.other.effect.sceneAnarchy',
-                locationAnarchy: 'ANARCHY.modifier.other.effect.locationAnarchy',
-                initiative: 'ANARCHY.modifier.other.effect.initiative',
-                celebrity: 'ANARCHY.modifier.other.effect.celebrity',
             },
-            category: {
+            "hardpoints": {
+                "title": "Hardpoint summary",
+                "type": "Type",
+                "size": "Size",
+                "location": "Location",
+                "assigned": "Assigned to",
+                "none": "No hardpoints configured."
+            },
+            "weaponGroups": {
+                "title": "Weapon groups",
+                "mountPoints": "Mount points used: {used} / {total}",
+                "group": "Group",
+                "weapons": "Weapons",
+                "empty": "No weapons assigned to this group.",
+                "none": "No weapon groups configured.",
+                "missingWeapon": "Weapon {missingId} is missing from the actor."
+            },
+            "weapons": {
+                "title": "Battlemech weapons",
+                "weapon": "Weapon",
+                "category": "Category",
+                "mount": "Mount",
+                "hardpoint": "Hardpoint",
+                "heat": "Heat",
+                "none": "No mech weapons equipped.",
+                "mountUnknown": "Unspecified"
             }
         },
-        condition: {
-            always: 'ANARCHY.modifier.condition.always'
+        "ownership": {
+            "owner": "Owner",
+            "unknown": "Unknown",
+            "owned": "Owned"
+        }
+    },
+    "actorType": {
+        "character": "Character",
+        "npc": "NPC",
+        "vehicle": "Vehicle",
+        "battlemech": "Battlemech"
+    },
+    "item": {
+        "sheet": "Sheet for ",
+        "tabs": {
+            "main": "Details",
+            "modifiers": "Modifiers"
+        },
+        "common": {
+            "inactive": "Inactive for actor"
+        },
+        "skill": {
+            "code": "Internal code",
+            "copyDefault": "Configure skill",
+            "isKnowledge": "Knowledge",
+            "attribute": "Attribute",
+            "value": "Level",
+            "specialization": "Specialisation",
+            "specializationHelp": "Type the name to choose a specialization",
+            "isSocial": "Social skill",
+            "hasDrain": "Drain",
+            "hasConvergence": "Convergence"
+        },
+        "quality": {
+            "positive": "Positive if checked"
+        },
+        "assetModule": {
+            "category": "Category",
+            "level": "Level",
+            "levelShort": "Lvl"
+        },
+        "lifeModule": {
+            "moduleType": "Module Type",
+            "type": {
+                "faction": "Faction",
+                "childhood": "Childhood",
+                "higherEducation": "Higher Education",
+                "realLife": "Real Life"
+            }
+        },
+        "mechWeapon": {
+            "category": "Weapon Category",
+            "hardpoint": "Hardpoint",
+            "damage": "Damage Value",
+            "damageType": "Damage Type",
+            "heat": "Heat",
+            "area": "Area of effect",
+            "range": {
+                "max": "Maximum range"
+            }
+        },
+        "personalWeapon": {
+            "skill": "Skill",
+            "category": "Weapon Category",
+            "damageCategory": "Damage Category",
+            "damage": "Damage Value",
+            "damageType": "Damage Type",
+            "defense": "Defense",
+            "area": "Area of effect",
+            "damageShort": "DV",
+            "areaShort": "Area",
+            "weaponWithoutActor": "No Actor",
+            "armorAvoidance": "Armor avoidance",
+            "armorAvoidanceHelp": "Ignore armor on this attack",
+            "range": {
+                "max": "Maximum range"
+            },
+            "noArmor": "Armor avoidance",
+            "withArmor": "Armor protects"
+        }
+    },
+    "itemType": {
+        "singular": {
+            "skill": "Skill",
+            "quality": "Trait",
+            "assetModule": "Asset Module",
+            "gear": "Gear",
+            "contact": "Contact",
+            "lifeModule": "Life Module",
+            "mechWeapon": "Mech-Scale Weapon",
+            "personalWeapon": "Personal Weapon"
+        },
+        "plural": {
+            "skill": "Skills",
+            "quality": "Qualities",
+            "assetModule": "Asset Modules",
+            "gear": "Gears",
+            "contact": "Contacts",
+            "lifeModule": "Life Modules",
+            "action": "Actions",
+            "monitor": "Monitors",
+            "mechWeapon": "Mech-Scale Weapons",
+            "personalWeapon": "Personal Weapons"
+        }
+    },
+    "monitor": {
+        "physical": "Physical",
+        "fatigue": "Fatigue"
+    },
+    "monitorLetter": {
+        "physical": "P",
+        "fatigue": "F"
+    },
+    "assetModuleCategory": {
+        "faction": "Faction",
+        "logistics": "Logistics",
+        "training": "Training",
+        "influence": "Influence",
+        "personal": "Personal",
+        "operations": "Operations"
+    },
+    "attributes": {
+        "strength": "Strength",
+        "reflexes": "Reflexes",
+        "willpower": "Willpower",
+        "intelligence": "Intelligence",
+        "charisma": "Charisma",
+        "edge": "Edge",
+        "agility": "Reflexes",
+        "logic": "Intelligence",
+        "knowledge": "Knowledge",
+        "noAttribute": "No attribute chosen",
+        "autopilot": "Autopilot",
+        "handling": "Handling",
+        "firewall": "Firewall",
+        "system": "System",
+        "chassis": "Chassis",
+        "condition": "Condition"
+    },
+    "attributeAction": {
+        "defense": "Defense",
+        "judgeIntentions": "Judge intentions",
+        "perception": "Perception / Mental resistance",
+        "resistTorture": "Resist torture / Physical resistance",
+        "composure": "Composure / Social resistance",
+        "memory": "Memory",
+        "catch": "Catch object",
+        "lift": "Lift/carry"
+    },
+    "defense": {
+        "physicalDefense": "Physical defense",
+        "physicalResistance": "Physical resistance",
+        "socialDefense": "Social defense",
+        "mentalResistance": "Mental resistance"
+    },
+    "skill": {
+        "athletics": "Athletics",
+        "heavyWeapons": "Heavy Weapons",
+        "escapeArtist": "Escape Artist",
+        "gunnery": "Gunnery",
+        "meleeCombat": "Melee Combat",
+        "piloting": "Piloting",
+        "projectileWeapons": "Projectile Weapons",
+        "firearms": "Firearms",
+        "stealth": "Stealth",
+        "zeroGOperations": "Zero-G Operations",
+        "art": "Art",
+        "artillery": "Artillery",
+        "communications": "Communications",
+        "computers": "Computers",
+        "demolitions": "Demolitions",
+        "knowledge": "Knowledge",
+        "medTech": "MedTech",
+        "science": "Science",
+        "perception": "Perception",
+        "tactics": "Tactics",
+        "technician": "Technician",
+        "tracking": "Tracking",
+        "navigation": "Navigation",
+        "animalHandling": "Animal Handling",
+        "survival": "Survival",
+        "acting": "Acting",
+        "disguise": "Disguise",
+        "leadership": "Leadership",
+        "negotiation": "Negotiation",
+        "etiquette": "Etiquette",
+        "streetwise": "Streetwise",
+        "intimidation": "Intimidation"
+    },
+    "area": {
+        "none": "None",
+        "shotgun": "Shotgun",
+        "circle": "Circle",
+        "cone": "Cone",
+        "rect": "Rectangle",
+        "ray": "Ray"
+    },
+    "range": {
+        "contact": "Contact",
+        "short": "Short",
+        "medium": "Medium",
+        "far": "Far",
+        "extreme": "Extreme"
+    },
+    "vehicleCategory": {
+        "drone": "Drone",
+        "personal": "Personal",
+        "combat": "Combat",
+        "aerospace": "Aerospace",
+        "mech": "Mech"
+    },
+    "mwd": {
+        "weightClass": {
+            "label": "Weight class",
+            "light": "Light",
+            "medium": "Medium",
+            "heavy": "Heavy",
+            "assault": "Assault"
+        },
+        "hardpoint": {
+            "type": {
+                "ballistic": "Ballistic",
+                "energy": "Energy",
+                "missile": "Missile",
+                "special": "Special",
+                "melee": "Melee"
+            },
+            "size": {
+                "small": "Small",
+                "medium": "Medium",
+                "large": "Large"
+            },
+            "location": {
+                "head": "Head",
+                "torso": "Torso",
+                "arm": "Arm",
+                "leg": "Leg"
+            }
+        },
+        "primarySlot": {
+            "mode": {
+                "normal": "Large hardpoint",
+                "converted": "Converted slot"
+            }
+        },
+        "weaponCategory": {
+            "ranged": "Ranged",
+            "melee": "Melee"
+        },
+        "melee": {
+            "title": "Melee options",
+            "baseProfile": "Unarmed",
+            "baseProfileLabel": "Base melee profile",
+            "damagePlaceholder": "Damage code",
+            "notesPlaceholder": "Notes",
+            "maxWeapons": "Maximum equipped melee weapons",
+            "allowedLocations": "Allowed locations",
+            "availableProfiles": "Available melee profiles",
+            "location": {
+                "head": "Head",
+                "torso": "Torso",
+                "arm": "Arm",
+                "leg": "Leg"
+            },
+            "locationAny": "Any location"
+        },
+        "loadout": {
+            "title": "Weapon loadout",
+            "mountPoints": "Mount points used",
+            "primarySlot": {
+                "label": "Primary weapon slot",
+                "noRestriction": "No type restriction",
+                "allowedWeapons": "Allowed primary weapons"
+            },
+            "hardpoints": "Hardpoints",
+            "weaponGroups": "Weapon groups",
+            "primaryTag": "Primary",
+            "occupied": "{{weaponGroup}} assigned",
+            "emptyHardpoint": "Empty",
+            "errors": {
+                "label": "Errors",
+                "multiplePrimary": "Only one primary weapon group is allowed.",
+                "mountPointsExceeded": "Loadout uses {used} mount points but only {total} are available.",
+                "hardpointUnavailable": "No matching hardpoint for {weapon} ({type}, {size}).",
+                "primaryNeedsLarge": "{weapon} must use a large hardpoint to be primary.",
+                "primaryWithoutWeapon": "Primary group needs at least one weapon.",
+                "weaponAlreadyGrouped": "{weapon} is already assigned to another group.",
+                "primaryNotAllowedWeapon": "{weapon} is not allowed in the converted primary slot.",
+                "primaryTypeRestriction": "{weapon} does not match the converted primary slot restriction ({type}).",
+                "meleeLimitExceeded": "Equipped melee weapons {equipped} exceed limit {limit}.",
+                "meleeLocationRestricted": "{weapon} cannot be mounted at that location."
+            },
+            "warnings": {
+                "label": "Warnings",
+                "weaponMissing": "Weapon with id {weapon} is missing."
+            },
+            "newGroup": "New weapon group"
+        },
+        "weapon": {
+            "damageType": {
+                "energy": "Energy",
+                "kinetic": "Kinetic",
+                "explosive": "Explosive",
+                "plasma": "Plasma",
+                "none": "None"
+            }
+        },
+        "personalWeapon": {
+            "damageType": {
+                "energy": "Energy",
+                "kinetic": "Kinetic",
+                "explosive": "Explosive",
+                "plasma": "Plasma",
+                "corrosive": "Corrosive",
+                "poison": "Poison"
+            },
+            "damageCategory": {
+                "physical": "Physical",
+                "fatigue": "Fatigue"
+            }
+        }
+    },
+    "modifier": {
+        "column": {
+            "group": "Group",
+            "effect": "Effect",
+            "value": "Value",
+            "category": "",
+            "subCategory": "",
+            "condition": "When"
+        },
+        "group": {
+            "roll": "Roll",
+            "attribute": "Attribute",
+            "monitor": "Monitor",
+            "other": "Other"
+        },
+        "roll": {
+            "effect": {
+                "pool": "Pool bonus",
+                "reroll": "Rerolls",
+                "rerollMax": "Reroll allowance cap",
+                "glitch": "Glitch dice",
+                "successReroll": "Reroll own successes",
+                "opponentPool": "Opponent pool malus",
+                "opponentReroll": "Opponent rerolls"
+            },
+            "category": {
+                "attribute": "Attribute",
+                "skill": "Skill",
+                "attributeAction": "Attribute action"
+            }
+        },
+        "monitor": {
+            "effect": {
+                "armor": "Armor",
+                "structure": "Structure",
+                "fatigue": "Fatigue",
+                "physical": "Physical",
+                "matrix": "Matrix"
+            },
+            "category": {
+                "max": "Increased max",
+                "resistance": "Resistance",
+                "resistanceByType": "Damage-type resistance"
+            }
+        },
+        "other": {
+            "effect": {
+                "ignoreWounds": "Ignore wounds",
+                "damageArmor": "Damage to armor",
+                "sceneAnarchy": "Chaos",
+                "locationAnarchy": "Location anarchy",
+                "initiative": "Initiative bonus",
+                "celebrity": "Adjust legend"
+            },
+            "category": {}
+        },
+        "condition": {
+            "always": "Always"
         }
     }
 };
-

--- a/src/modules/confirmation.js
+++ b/src/modules/confirmation.js
@@ -1,24 +1,27 @@
 import { ANARCHY } from "./config.js";
 import { Icons } from "./icons.js";
+import { formatString } from "./strings.js";
 
 export class ConfirmationDialog {
 
   static async confirmDeleteItem(item, onConfirm = () => { }) {
+    const itemType = ANARCHY.itemType.singular[item.type];
+    const content = formatString(ANARCHY.common.confirmation.delItem, {
+      name: item.name,
+      type: itemType,
+    });
     let dialog = new Dialog({
-      title: game.i18n.localize(ANARCHY.common.confirmation.del),
-      content: game.i18n.format(ANARCHY.common.confirmation.delItem, {
-        name: item.name,
-        type: game.i18n.localize(ANARCHY.itemType.singular[item.type])
-      }),
+      title: ANARCHY.common.confirmation.del,
+      content,
       buttons: {
         delete: {
           icon: Icons.fontAwesome('fas fa-check'),
-          label: game.i18n.localize(ANARCHY.common.del),
+          label: ANARCHY.common.del,
           callback: onConfirm
         },
         cancel: {
           icon: Icons.fontAwesome('fas fa-times'),
-          label: game.i18n.localize(ANARCHY.common.cancel)
+          label: ANARCHY.common.cancel
         }
       },
       default: "cancel"
@@ -27,20 +30,21 @@ export class ConfirmationDialog {
   }
 
   static async confirmDetachOwnerActor(owner, owned, onConfirm = () => { }) {
+    const content = formatString(ANARCHY.common.confirmation.delowner, {
+      name: owner.name,
+    });
     let dialog = new Dialog({
-      title: game.i18n.localize(ANARCHY.common.confirmation.del),
-      content: game.i18n.format(ANARCHY.common.confirmation.delOwner, {
-        name: owner.name,
-      }),
+      title: ANARCHY.common.confirmation.del,
+      content,
       buttons: {
         delete: {
           icon: Icons.fontAwesome('fas fa-check'),
-          label: game.i18n.localize(ANARCHY.common.del),
+          label: ANARCHY.common.del,
           callback: onConfirm
         },
         cancel: {
           icon: Icons.fontAwesome('fas fa-times'),
-          label: game.i18n.localize(ANARCHY.common.cancel)
+          label: ANARCHY.common.cancel
         }
       },
       default: "cancel"
@@ -50,26 +54,29 @@ export class ConfirmationDialog {
 
 
   static async confirmAttachOrCopy(owner, owned, onAttach = () => { }, onAttachCopy = () => { }) {
+    const content = formatString(ANARCHY.common.confirmation.attachOrCopy, {
+      ownerName: owner.name,
+      ownerType: ANARCHY.actorType[owner.type],
+      ownedName: owned.name,
+      ownedType: ANARCHY.actorType[owned.type],
+    });
     let dialog = new Dialog({
-      title: game.i18n.localize(ANARCHY.common.confirmation.attach),
-      content: game.i18n.format(ANARCHY.common.confirmation.attachOrCopy, {
-        ownerName: owner.name, ownerType: game.i18n.localize(ANARCHY.actorType[owner.type]),
-        ownedName: owned.name, ownedType: game.i18n.localize(ANARCHY.actorType[owned.type])
-      }),
+      title: ANARCHY.common.confirmation.attach,
+      content,
       buttons: {
         attach: {
           icon: Icons.fontAwesome('fas fa-user-tag'),
-          label: game.i18n.localize(ANARCHY.common.attach),
+          label: ANARCHY.common.attach,
           callback: onAttach
         },
         attachCopy: {
           icon: Icons.fontAwesome('fas fa-user-plus'),
-          label: game.i18n.localize(ANARCHY.common.attachCopy),
+          label: ANARCHY.common.attachCopy,
           callback: onAttachCopy
         },
         cancel: {
           icon: Icons.fontAwesome('fas fa-times'),
-          label: game.i18n.localize(ANARCHY.common.cancel)
+          label: ANARCHY.common.cancel
         }
       },
       default: "cancel"

--- a/src/modules/damage.js
+++ b/src/modules/damage.js
@@ -2,10 +2,10 @@ import { Enums } from "./enums.js";
 
 export class Damage {
   static monitor(code) {
-    return game.i18n.localize(Enums.getFromList(Enums.getMonitors(), code) ?? "");
+    return Enums.getFromList(Enums.getMonitors(), code) ?? "";
   }
 
   static letter(code) {
-    return game.i18n.localize(Enums.getFromList(Enums.getMonitorLetters(), code) ?? "");
+    return Enums.getFromList(Enums.getMonitorLetters(), code) ?? "";
   }
 }

--- a/src/modules/dialog/resistance-by-type.js
+++ b/src/modules/dialog/resistance-by-type.js
@@ -61,7 +61,7 @@ export class ResistanceByTypeDialog extends HandlebarsApplicationMixin(Applicati
         labelkey: dt.labelkey,
         value: typedValue,
         source,
-        sourceLabel: game.i18n.localize(ANARCHY.actor.monitors.resistanceSources?.[source] ?? source),
+        sourceLabel: ANARCHY.actor.monitors.resistanceSources?.[source] ?? source,
         bonusTotal: resistanceBonus + typeBonus,
         total: value + resistanceBonus + typeBonus,
       };
@@ -70,7 +70,7 @@ export class ResistanceByTypeDialog extends HandlebarsApplicationMixin(Applicati
     return {
       actor: this.actor,
       monitor: this.monitor,
-      monitorLabel: game.i18n.localize(ANARCHY.actor.monitors[this.monitor] ?? this.monitor),
+      monitorLabel: ANARCHY.actor.monitors[this.monitor] ?? this.monitor,
       resistance,
       resistanceBonus,
       resistanceBonusByType,

--- a/src/modules/enums.js
+++ b/src/modules/enums.js
@@ -76,7 +76,7 @@ export class Enums {
       monitors: Enums.hbsMonitors,
       assetModuleCategories: Enums.hbsAssetModuleCategories,
       skills: game.system.anarchy.skills.getSkills({ withKnowledge })
-        .map(it => { return { value: it.code, label: game.i18n.localize(it.labelkey), labelkey: it.labelkey }; }),
+        .map(it => { return { value: it.code, label: it.labelkey, labelkey: it.labelkey }; }),
       areas: Enums.hbsAreas,
       ranges: Enums.hbsRanges,
       lifeModuleTypes: Enums.hbsLifeModuleTypes,
@@ -121,9 +121,9 @@ export class Enums {
 
   static localizeAttribute(attribute) {
     if (!ANARCHY.attributes[attribute]) {
-      return game.i18n.localize(ANARCHY.attributes['noAttribute']);
+      return ANARCHY.attributes['noAttribute'];
     }
-    return game.i18n.localize(ANARCHY.attributes[attribute]);
+    return ANARCHY.attributes[attribute];
   }
 
   static getFromList(list, key, keyName = 'value', valueName = 'labelkey') {

--- a/src/modules/error-manager.js
+++ b/src/modules/error-manager.js
@@ -1,12 +1,13 @@
 import { ANARCHY } from "./config.js";
 import { TEMPLATE } from "./constants.js";
+import { formatString } from "./strings.js";
 
 export class ErrorManager {
 
   static checkSufficient(resource, required, available) {
     if (required > available) {
-      const error = game.i18n.format(ANARCHY.common.errors.insufficient, {
-        resource: game.i18n.localize(resource),
+      const error = formatString(ANARCHY.common.errors.insufficient, {
+        resource: resource,
         required: required,
         available: available
       });
@@ -17,8 +18,8 @@ export class ErrorManager {
 
   static checkOutOfRange(resource, value, min, max) {
     if (value < min || value > max) {
-      const error = game.i18n.format(ANARCHY.common.errors.outOfRange, {
-        resource: game.i18n.localize(resource),
+      const error = formatString(ANARCHY.common.errors.outOfRange, {
+        resource: resource,
         value: value, min: min, max: max
       });
       ui.notifications.error(error);
@@ -28,7 +29,7 @@ export class ErrorManager {
 
   static checkUserGM() {
     if (!game.user.isGM) {
-      const error = game.i18n.localize(ANARCHY.common.errors.onlyGM);
+      const error = ANARCHY.common.errors.onlyGM;
       ui.notifications.error(error);
       throw error;
     }
@@ -36,9 +37,9 @@ export class ErrorManager {
 
   static checkItemType(item, expectedType) {
     if (item.type != expectedType) {
-      const error = game.i18n.format(ANARCHY.common.errors.expectedType, {
-        type: game.i18n.localize(item.type ? (ANARCHY.itemType.singular[item.type]) : item.type),
-        expectedType: game.i18n.localize(expectedType)
+      const error = formatString(ANARCHY.common.errors.expectedType, {
+        type: item.type ? (ANARCHY.itemType.singular[item.type]) : item.type,
+        expectedType: expectedType
       });
       ui.notifications.error(error);
       throw error;
@@ -47,13 +48,13 @@ export class ErrorManager {
 
   static checkActorCanReceiveDamage(damageType, monitor, actor) {
     if (!monitor) {
-      const error = game.i18n.format(ANARCHY.common.errors.actorCannotReceiveDamage, {
+      const error = formatString(ANARCHY.common.errors.actorCannotReceiveDamage, {
         actor: actor.name,
-        damageType: game.i18n.localize(
+        damageType:
           ANARCHY.actor.monitors[damageType]
           ?? ANARCHY.mwd.weaponDamageType[damageType]
           ?? ANARCHY.mwd.personalDamageType[damageType]
-          ?? damageType)
+          ?? damageType
       });
       ui.notifications.error(error);
       throw error;
@@ -63,7 +64,7 @@ export class ErrorManager {
   static checkWeaponDefense(weapon, actor) {
     const defense = weapon.getDefense();
     if (weapon.type === TEMPLATE.itemType.personalWeapon && !defense) {
-      const error = game.i18n.format(ANARCHY.common.errors.noDefenseOnWeapon, { actor: actor.name, weapon: weapon.name });
+      const error = formatString(ANARCHY.common.errors.noDefenseOnWeapon, { actor: actor.name, weapon: weapon.name });
       ui.notifications.error(error);
       throw error;
     }
@@ -71,9 +72,9 @@ export class ErrorManager {
 
   static checkTargetsCount(maxTargets, targets, area) {
     if (maxTargets > 0 && targets.length > maxTargets) {
-      const error = game.i18n.format(ANARCHY.common.errors.maxTargetsExceedeed, {
+      const error = formatString(ANARCHY.common.errors.maxTargetsExceedeed, {
         weapon: this.name,
-        area: game.i18n.localize(ANARCHY.area[area]),
+        area: ANARCHY.area[area],
         count: targets.length,
         max: maxTargets
       });
@@ -84,10 +85,10 @@ export class ErrorManager {
 
   static checkActorDefenseAction(actorAction, actor, defense) {
     if (!actorAction) {
-      const error = game.i18n.format(ANARCHY.common.errors.actorDoesNotHaveDefense, {
+      const error = formatString(ANARCHY.common.errors.actorDoesNotHaveDefense, {
         actor: actor.name,
-        defense: game.i18n.localize(defense.labelkey),
-        actorType: game.i18n.localize(ANARCHY.actorType[actor.type])
+        defense: defense.labelkey,
+        actorType: ANARCHY.actorType[actor.type]
       });
       ui.notifications.error(error);
       throw error;

--- a/src/modules/hooks-manager.js
+++ b/src/modules/hooks-manager.js
@@ -70,8 +70,8 @@ export class HooksManager {
     });
     game.settings.register(SYSTEM_NAME, ANARCHY_HOOKS.ANARCHY_HACK, {
       scope: "world",
-      name: game.i18n.localize(ANARCHY.settings.anarchyHack.name),
-      hint: game.i18n.localize(ANARCHY.settings.anarchyHack.hint),
+      name: ANARCHY.settings.anarchyHack.name,
+      hint: ANARCHY.settings.anarchyHack.hint,
       config: true,
       default: SHADOWRUN_ANARCHY_NO_HACK.id,
       choices: this.hackNames,

--- a/src/modules/item/base-item-sheet.js
+++ b/src/modules/item/base-item-sheet.js
@@ -84,7 +84,7 @@ export class BaseItemSheet extends HandlebarsApplicationMixin(foundry.applicatio
    * @override
    */
   get title() {
-    const typeLabel = game.i18n.localize(ANARCHY.itemType.singular[this.item.type]);
+    const typeLabel = ANARCHY.itemType.singular[this.item.type];
     return `${typeLabel}: ${this.item.name}`;
   }
 

--- a/src/modules/item/lifemodule-item.js
+++ b/src/modules/item/lifemodule-item.js
@@ -4,8 +4,8 @@ import { AnarchyBaseItem } from "./anarchy-base-item.js";
 export class LifeModuleItem extends AnarchyBaseItem {
 
   constructor(docData, context = {}) {
-    const lifeModuleName = game.i18n.localize('ANARCHY.itemType.singular.lifeModule');
-    if (!docData.name || docData.name === game.i18n.localize('DOCUMENT.Item')) {
+    const lifeModuleName = 'ANARCHY.itemType.singular.lifeModule';
+    if (!docData.name || docData.name === 'DOCUMENT.Item') {
       docData.name = lifeModuleName;
     }
 

--- a/src/modules/item/skill-item.js
+++ b/src/modules/item/skill-item.js
@@ -31,7 +31,7 @@ export class SkillItem extends AnarchyBaseItem {
       }
     }
     if (skill.code != 'knowledge') {
-      updates.name = game.i18n.localize(skill.labelkey)
+      updates.name = skill.labelkey
     }
     return updates
   }

--- a/src/modules/item/weapon-item.js
+++ b/src/modules/item/weapon-item.js
@@ -10,6 +10,7 @@ import { AttributeActions } from "../attribute-actions.js";
 import { ErrorManager } from "../error-manager.js";
 import { Misc } from "../misc.js";
 import { SkillItem } from "./skill-item.js";
+import { formatString } from "../strings.js";
 
 const AREA_TARGETS = {
   none: { targets: 1, adjust: [0] },
@@ -40,7 +41,7 @@ const WEAPON_RANGE_PARAMETER = {
       min: Math.min(...rangeValues),
       max: Math.max(...rangeValues),
       choices: ranges,
-      selected: game.i18n.localize(ranges[0].labelkey)
+      selected: ranges[0].labelkey
     }
   }
 }
@@ -153,7 +154,7 @@ export class WeaponItem extends AnarchyBaseItem {
       }
       else {
         console.warn('Weapon not attached to an actor');
-        return game.i18n.localize(ANARCHY.item.personalWeapon.weaponWithoutActor);
+        return ANARCHY.item.personalWeapon.weaponWithoutActor;
       }
     }
     return damage;
@@ -170,7 +171,7 @@ export class WeaponItem extends AnarchyBaseItem {
   static damageCode(monitor, damage, damageAttribute) {
     let code = '';
     if (damageAttribute && ANARCHY.attributes[damageAttribute]) {
-      code += game.i18n.localize(ANARCHY.attributes[damageAttribute]).substring(0, 3).toUpperCase() + '/2 + ';
+      code += ANARCHY.attributes[damageAttribute].substring(0, 3).toUpperCase() + '/2 + ';
     }
     code += String(damage);
     return code;
@@ -186,7 +187,7 @@ export class WeaponItem extends AnarchyBaseItem {
   getDamageTypeLabel() {
     const labelKey = ANARCHY.mwd.weaponDamageType[this.system.damageType]
       ?? ANARCHY.mwd.personalDamageType[this.system.damageType];
-    return labelKey ? game.i18n.localize(labelKey) : this.system.damageType;
+    return labelKey ? labelKey : this.system.damageType;
   }
 
   getRanges() {
@@ -237,14 +238,16 @@ export class WeaponItem extends AnarchyBaseItem {
       .map(token => token.name)
 
     if (invalidTargets.length > 0) {
-      ui.notifications.info(game.i18n.format(ANARCHY.common.errors.ignoredTargets, {
+      const content = formatString(ANARCHY.common.errors.ignoredTargets, {
         targets: invalidTargets.reduce(Misc.joiner(', ')),
-      }));
+      });
+      ui.notifications.info(content);
     }
     if (validTargets.length == 0) {
-      ui.notifications.info(game.i18n.format(ANARCHY.common.errors.noTargetSelected, {
-        weapon: this.name ?? game.i18n.localize(ANARCHY.itemType.singular.weapon)
-      }));
+      const content = formatString(ANARCHY.common.errors.noTargetSelected, {
+        weapon: this.name ?? ANARCHY.itemType.singular.weapon
+      });
+      ui.notifications.info(content);
     }
     else {
       this.checkWeaponTargetsCount(validTargets)

--- a/src/modules/mwd/battlemech-loadout.js
+++ b/src/modules/mwd/battlemech-loadout.js
@@ -1,5 +1,6 @@
 import { ANARCHY } from "../config.js";
 import { TEMPLATE } from "../constants.js";
+import { formatString } from "../strings.js";
 
 const MOUNT_POINTS = {
   light: 4,
@@ -33,13 +34,13 @@ export class BattlemechLoadout {
     const warnings = [];
 
     if (primaryGroups.length > 1) {
-      errors.push(game.i18n.localize(ANARCHY.mwd.loadout.errors.multiplePrimary));
+      errors.push(ANARCHY.mwd.loadout.errors.multiplePrimary);
     }
 
     const maxGroupCount = primaryGroup ? mountPointTotal - 1 : mountPointTotal;
     const usedMountPoints = groups.length + (primaryGroup ? 1 : 0);
     if (groups.length > maxGroupCount) {
-      errors.push(game.i18n.format(ANARCHY.mwd.loadout.errors.mountPointsExceeded, {
+      errors.push(formatString(ANARCHY.mwd.loadout.errors.mountPointsExceeded, {
         used: usedMountPoints,
         total: mountPointTotal,
       }));
@@ -55,13 +56,13 @@ export class BattlemechLoadout {
       for (const weaponId of group.weaponIds ?? []) {
         const weapon = rangedById.get(weaponId);
         if (!weapon) {
-          warnings.push(game.i18n.format(ANARCHY.mwd.loadout.warnings.weaponMissing, { weapon: weaponId }));
+          warnings.push(formatString(ANARCHY.mwd.loadout.warnings.weaponMissing, { weapon: weaponId }));
           continue;
         }
         const weaponType = weapon.system.hardpointType ?? "energy";
         const weaponSize = weapon.system.hardpointSize ?? "small";
         if (usedWeapons.has(weaponId)) {
-          errors.push(game.i18n.format(ANARCHY.mwd.loadout.errors.weaponAlreadyGrouped, { weapon: weapon.name }));
+          errors.push(formatString(ANARCHY.mwd.loadout.errors.weaponAlreadyGrouped, { weapon: weapon.name }));
           continue;
         }
         usedWeapons.add(weaponId);
@@ -78,10 +79,10 @@ export class BattlemechLoadout {
           && hp.type === weaponType
           && hp.size === weaponSize);
         if (!match) {
-          errors.push(game.i18n.format(ANARCHY.mwd.loadout.errors.hardpointUnavailable, {
+          errors.push(formatString(ANARCHY.mwd.loadout.errors.hardpointUnavailable, {
             weapon: weapon.name,
-            type: game.i18n.localize(ANARCHY.mwd.hardpointType[weaponType] ?? weaponType),
-            size: game.i18n.localize(ANARCHY.mwd.hardpointSize[weaponSize] ?? weaponSize),
+            type: ANARCHY.mwd.hardpointType[weaponType] ?? weaponType,
+            size: ANARCHY.mwd.hardpointSize[weaponSize] ?? weaponSize,
           }));
         }
         else {
@@ -92,7 +93,7 @@ export class BattlemechLoadout {
     }
 
     if (primaryGroup && (!primaryGroup.weaponIds || primaryGroup.weaponIds.length === 0)) {
-      errors.push(game.i18n.localize(ANARCHY.mwd.loadout.errors.primaryWithoutWeapon));
+      errors.push(ANARCHY.mwd.loadout.errors.primaryWithoutWeapon);
     }
 
     const meleeState = this._computeMeleeState(errors);
@@ -117,7 +118,7 @@ export class BattlemechLoadout {
   _normalizeWeaponGroups() {
     return (this.mwd.weaponGroups ?? []).map((group, index) => ({
       id: group.id ?? `group-${index + 1}`,
-      name: group.name || game.i18n.format(ANARCHY.common.newName, { type: game.i18n.localize(ANARCHY.itemType.singular.weapon) }),
+      name: group.name || formatString(ANARCHY.common.newName, { type: ANARCHY.itemType.singular.weapon }),
       weaponIds: this._asArray(group.weaponIds),
       isPrimary: group.isPrimary ?? false,
     }));
@@ -145,7 +146,7 @@ export class BattlemechLoadout {
     const limit = Number(meleeConfig.maxWeapons ?? 0);
 
     if (meleeWeapons.length > limit) {
-      errors.push(game.i18n.format(ANARCHY.mwd.loadout.errors.meleeLimitExceeded, {
+      errors.push(formatString(ANARCHY.mwd.loadout.errors.meleeLimitExceeded, {
         equipped: meleeWeapons.length,
         limit,
       }));
@@ -153,16 +154,16 @@ export class BattlemechLoadout {
 
     const allowedLocations = this._asArray(meleeConfig.allowedLocations);
     profiles.push({
-      name: meleeConfig.baseProfile?.name || game.i18n.localize(ANARCHY.mwd.melee.baseProfile),
+      name: meleeConfig.baseProfile?.name || ANARCHY.mwd.melee.baseProfile,
       damage: meleeConfig.baseProfile?.damage ?? "",
       notes: meleeConfig.baseProfile?.notes ?? "",
     });
 
     meleeWeapons.forEach(weapon => {
       if (allowedLocations.length > 0 && weapon.system.mountLocation && !allowedLocations.includes(weapon.system.mountLocation)) {
-        errors.push(game.i18n.format(ANARCHY.mwd.loadout.errors.meleeLocationRestricted, {
+        errors.push(formatString(ANARCHY.mwd.loadout.errors.meleeLocationRestricted, {
           weapon: weapon.name,
-          location: game.i18n.localize(ANARCHY.mwd.meleeLocation[weapon.system.mountLocation] ?? weapon.system.mountLocation),
+          location: ANARCHY.mwd.meleeLocation[weapon.system.mountLocation] ?? weapon.system.mountLocation,
         }));
       }
       profiles.push({
@@ -178,17 +179,17 @@ export class BattlemechLoadout {
   _validatePrimaryWeapon(weapon, weaponType, weaponSize, primarySlot, errors) {
     if (primarySlot.mode === "converted") {
       if (primarySlot.allowedWeaponIds?.length > 0 && !primarySlot.allowedWeaponIds.includes(weapon.id)) {
-        errors.push(game.i18n.format(ANARCHY.mwd.loadout.errors.primaryNotAllowedWeapon, { weapon: weapon.name }));
+        errors.push(formatString(ANARCHY.mwd.loadout.errors.primaryNotAllowedWeapon, { weapon: weapon.name }));
       }
       if (primarySlot.typeRestriction && weaponType !== primarySlot.typeRestriction) {
-        errors.push(game.i18n.format(ANARCHY.mwd.loadout.errors.primaryTypeRestriction, {
+        errors.push(formatString(ANARCHY.mwd.loadout.errors.primaryTypeRestriction, {
           weapon: weapon.name,
-          type: game.i18n.localize(ANARCHY.mwd.hardpointType[primarySlot.typeRestriction] ?? primarySlot.typeRestriction),
+          type: ANARCHY.mwd.hardpointType[primarySlot.typeRestriction] ?? primarySlot.typeRestriction,
         }));
       }
     }
     else if (weaponSize !== "large") {
-      errors.push(game.i18n.format(ANARCHY.mwd.loadout.errors.primaryNeedsLarge, { weapon: weapon.name }));
+      errors.push(formatString(ANARCHY.mwd.loadout.errors.primaryNeedsLarge, { weapon: weapon.name }));
     }
   }
 

--- a/src/modules/roll/anarchy-roll.js
+++ b/src/modules/roll/anarchy-roll.js
@@ -27,7 +27,7 @@ export class AnarchyRoll {
 
   static onReady() {
     Object.entries(ANARCHY.common.roll.rollTheme).forEach(entry => {
-      ROLL_THEME[entry[0]] = game.i18n.localize(entry[1]);
+      ROLL_THEME[entry[0]] = entry[1];
     });
   }
 

--- a/src/modules/roll/dice.js
+++ b/src/modules/roll/dice.js
@@ -1,5 +1,6 @@
 import { ANARCHY } from "../config.js";
 import { SYSTEM_DESCRIPTION, SYSTEM_NAME, THIRD_PARTY_STYLE_PATH } from "../constants.js";
+import { ANARCHY } from "../config.js";
 
 export const GLITCH_COLORSET = 'glitch';
 export const RISK_COLORSET = 'risk';
@@ -34,22 +35,22 @@ export class AnarchyDice {
     return {
       [REROLL_COLORSET]: {
         name: REROLL_COLORSET,
-        description: game.i18n.localize(ANARCHY.common.roll.rollTheme.reroll),
+        description: ANARCHY.common.roll.rollTheme.reroll,
         category: SYSTEM_DESCRIPTION,
       },
       [REMOVED_COLORSET]: {
         name: RISK_COLORSET,
-        description: game.i18n.localize(ANARCHY.common.roll.rollTheme.removed),
+        description: ANARCHY.common.roll.rollTheme.removed,
         category: SYSTEM_DESCRIPTION,
       },
       [REROLL_REMOVED_COLORSET]: {
         name: REROLL_REMOVED_COLORSET,
-        description: game.i18n.localize(ANARCHY.common.roll.rollTheme.rerollRemoved),
+        description: ANARCHY.common.roll.rollTheme.rerollRemoved,
         category: SYSTEM_DESCRIPTION,
       },
       [GLITCH_COLORSET]: {
         name: GLITCH_COLORSET,
-        description: game.i18n.localize(ANARCHY.common.roll.rollTheme.glitch),
+        description: ANARCHY.common.roll.rollTheme.glitch,
         category: SYSTEM_DESCRIPTION,
         foreground: "white",
         background: "#5c0a5c",
@@ -60,7 +61,7 @@ export class AnarchyDice {
       },
       [RISK_COLORSET]: {
         name: RISK_COLORSET,
-        description: game.i18n.localize(ANARCHY.common.roll.rollTheme.anarchyRisk),
+        description: ANARCHY.common.roll.rollTheme.anarchyRisk,
         category: SYSTEM_DESCRIPTION,
         foreground: "#faecd1",
         background: "#040101",

--- a/src/modules/skills.js
+++ b/src/modules/skills.js
@@ -81,8 +81,8 @@ export class Skills {
     const skillSetChoices = Object.fromEntries(Object.values(this.skillSets).map(e => [e.id, e.name]));
     game.settings.register(SYSTEM_NAME, SELECTED_SKILL_LIST, {
       scope: "world",
-      name: game.i18n.localize(ANARCHY.settings.skillSet.name),
-      hint: game.i18n.localize(ANARCHY.settings.skillSet.hint),
+      name: ANARCHY.settings.skillSet.name,
+      hint: ANARCHY.settings.skillSet.hint,
       config: true,
       default: DEFAULT_SKILLSET_ANARCHY,
       choices: skillSetChoices,

--- a/src/modules/strings.js
+++ b/src/modules/strings.js
@@ -1,0 +1,2 @@
+export const formatString = (template, values = {}) =>
+    template.replace(/\{(.*?)\}/g, (_, key) => values[key] ?? "");

--- a/src/modules/styles.js
+++ b/src/modules/styles.js
@@ -29,8 +29,8 @@ export class Styles {
 
     game.settings.register(SYSTEM_NAME, DEFAULT_CSS_CLASS, {
       scope: "world",
-      name: game.i18n.localize(ANARCHY.settings.defaultCssClass.name),
-      hint: game.i18n.localize(ANARCHY.settings.defaultCssClass.hint),
+      name: ANARCHY.settings.defaultCssClass.name,
+      hint: ANARCHY.settings.defaultCssClass.hint,
       config: true,
       default: CSS_DEFAULT,
       choices: this.availableStyles,

--- a/src/modules/system-settings.js
+++ b/src/modules/system-settings.js
@@ -6,8 +6,8 @@ export class SystemSettings {
 
   static register() {
     game.settings.register(SYSTEM_NAME, "useDestinyMechanics", {
-      name: game.i18n.localize(ANARCHY.settings.useDestinyMechanics.name),
-      hint: game.i18n.localize(ANARCHY.settings.useDestinyMechanics.hint),
+      name: ANARCHY.settings.useDestinyMechanics.name,
+      hint: ANARCHY.settings.useDestinyMechanics.hint,
       scope: "world",
       config: true,
       type: Boolean,

--- a/src/modules/users.js
+++ b/src/modules/users.js
@@ -2,6 +2,7 @@ import { ANARCHY } from "./config.js";
 import { ErrorManager } from "./error-manager.js";
 import { Misc } from "./misc.js";
 import { RemoteCall } from "./remotecall.js";
+import { formatString } from "./strings.js";
 
 const BLIND_MESSAGE_TO_GM = 'Users.blindMessageToGM';
 
@@ -21,7 +22,7 @@ export class AnarchyUsers {
         user: message.user,
         whisper: ChatMessage.getWhisperRecipients('GM'),
         blind: true,
-        content: game.i18n.format(ANARCHY.chat.blindMessageToGM, {
+        content: formatString(ANARCHY.chat.blindMessageToGM, {
           user: game.user.name,
           message: message.content
         })


### PR DESCRIPTION
## Summary
- replace localization keys in config with English values and remove game.i18n usage across modules
- introduce a shared formatString helper for template-style message construction
- update notification, dialog, and roll flows to rely on direct string labels instead of localization helpers

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693653780a40832d89231119379e195f)