### PR TITLE
Fix duplicate ANARCHY import in dice module

### DIFF
--- a/src/modules/roll/dice.js
+++ b/src/modules/roll/dice.js
@@ -1,6 +1,5 @@
 import { ANARCHY } from "../config.js";
 import { SYSTEM_DESCRIPTION, SYSTEM_NAME, THIRD_PARTY_STYLE_PATH } from "../constants.js";
-import { ANARCHY } from "../config.js";
 
 export const GLITCH_COLORSET = 'glitch';
 export const RISK_COLORSET = 'risk';


### PR DESCRIPTION
## Summary
- remove the duplicate ANARCHY import in the dice module to avoid a syntax error on load

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69366e5d3b80832db9232802dce24324)