### PR TITLE
Fix duplicate ANARCHY import in dice module

### DIFF
--- a/src/modules/roll/dice.js
+++ b/src/modules/roll/dice.js
@@ -1,6 +1,5 @@
 import { ANARCHY } from "../config.js";
 import { SYSTEM_DESCRIPTION, SYSTEM_NAME, THIRD_PARTY_STYLE_PATH } from "../constants.js";
-import { ANARCHY } from "../config.js";
 
 export const GLITCH_COLORSET = 'glitch';
 export const RISK_COLORSET = 'risk';


### PR DESCRIPTION
## Summary
- remove duplicate ANARCHY import in roll dice module to prevent identifier redeclaration error

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936743c6a5c832d92c425a1c06a96c0)