### PR TITLE
Replace localize helper usage in templates

### DIFF
--- a/templates/actor/character/capacity.hbs
+++ b/templates/actor/character/capacity.hbs
@@ -1,2 +1,2 @@
-<label class="passport-label" for="system.capacity">{{localize 'ANARCHY.actor.capacity'}}</label>
+<label class="passport-label" for="system.capacity">{{ANARCHY.actor.capacity}}</label>
 <input class="passport-input" type="text" name="system.capacity" value="{{system.capacity}}" {{#if options.viewMode}}disabled{{/if}} />

--- a/templates/actor/character/essence.hbs
+++ b/templates/actor/character/essence.hbs
@@ -1,2 +1,2 @@
-<label class="passport-label" for="system.counters.essence">{{localize 'ANARCHY.actor.counters.essence'}}</label>
+<label class="passport-label" for="system.counters.essence">{{ANARCHY.actor.counters.essence}}</label>
 <input class="passport-input" type="number" name="system.counters.essence" data-dtype="Number" value="{{system.counters.essence}}" step="0.1" />

--- a/templates/actor/character/name.hbs
+++ b/templates/actor/character/name.hbs
@@ -1,2 +1,2 @@
-<label class="passport-label" for="name">{{localize 'ANARCHY.actor.name'}}</label>
+<label class="passport-label" for="name">{{ANARCHY.actor.name}}</label>
 <input class="passport-input" type="text" name="name" value="{{actor.name}}" {{#if options.viewMode}}disabled{{/if}} />

--- a/templates/actor/character/social-celebrity.hbs
+++ b/templates/actor/character/social-celebrity.hbs
@@ -1,7 +1,7 @@
 <div class="section-group column">
-  <h2 class="section-group-header">{{localize 'ANARCHY.actor.counters.social.celebrity'}}</h2>
+  <h2 class="section-group-header">{{ANARCHY.actor.counters.social.celebrity}}</h2>
   <div class="edge-pool-entry">
-    <span class="edge-pool-label">{{localize 'ANARCHY.actor.counters.social.legend'}}</span>
+    <span class="edge-pool-label">{{ANARCHY.actor.counters.social.legend}}</span>
     <input type="number" name="system.counters.edgePools.legend.value" data-dtype="Number" value="{{system.counters.edgePools.legend.value}}" min="0" />
   </div>
 </div>

--- a/templates/actor/device.hbs
+++ b/templates/actor/device.hbs
@@ -7,7 +7,7 @@
       <div class="passport-column">
         <div class="passport-details-row">
           <div class="passport-detail">
-            <input class="info-value" name="name" type="text" value="{{data.name}}" placeholder="{{localize ANARCHY.actor.actorName}}"/>
+            <input class="info-value" name="name" type="text" value="{{data.name}}" placeholder="{{ANARCHY.actor.actorName}}"/>
           </div>
           <div class="passport-owner">
             {{> 'systems/mwd/templates/actor/parts/ownership.hbs'}}

--- a/templates/actor/npc-parts/asset-modules.hbs
+++ b/templates/actor/npc-parts/asset-modules.hbs
@@ -1,5 +1,5 @@
 <div class="define-item-type" data-item-type="assetModule">
-  <h2 class="section-group-header">{{localize 'ANARCHY.itemType.plural.assetModule'}}</h2>
+  <h2 class="section-group-header">{{ANARCHY.itemType.plural.assetModule}}</h2>
   <div class="items-group-list">
     {{#each items.assetModule as |assetModule|}}
     {{> 'systems/mwd/templates/actor/npc-parts/asset-module.hbs' assetModule}}

--- a/templates/actor/npc-parts/qualities.hbs
+++ b/templates/actor/npc-parts/qualities.hbs
@@ -1,6 +1,6 @@
 <div class="define-item-type" data-item-type="quality">
   <h2 class="section-group-header">
-    {{localize 'ANARCHY.itemType.plural.quality'}}
+    {{ANARCHY.itemType.plural.quality}}
     {{> 'systems/mwd/templates/common/item-control-add.hbs' itemType='quality'}}
   </h2>
   <div class="items-group-list">

--- a/templates/actor/npc-parts/skill.hbs
+++ b/templates/actor/npc-parts/skill.hbs
@@ -1,6 +1,6 @@
 <div class="item anarchy-skill {{#if system.inactive}}inactive{{/if}}" data-item-id="{{_id}}" data-item-type="skill" draggable="true">
   {{#if (or (eq system.code 'knowledge') (eq system.attribute 'knowledge')) }}
-  <span data-tooltip="{{localize 'ANARCHY.attributes.knowledge'}}">
+  <span data-tooltip="{{ANARCHY.attributes.knowledge}}">
     {{{iconFA 'fas fa-user-graduate'}}}
     <label>{{name}}</label>
   </span>

--- a/templates/actor/npc-parts/skills.hbs
+++ b/templates/actor/npc-parts/skills.hbs
@@ -1,6 +1,6 @@
 <div class="define-item-type" data-item-type="skill">
   <h2 class="section-group-header">
-    {{localize 'ANARCHY.itemType.plural.skill'}}
+    {{ANARCHY.itemType.plural.skill}}
     {{> 'systems/mwd/templates/common/item-control-add.hbs' itemType='skill'}}
   </h2>
   <div class="items-group-list">

--- a/templates/actor/npc-parts/weapons.hbs
+++ b/templates/actor/npc-parts/weapons.hbs
@@ -1,6 +1,6 @@
 <div class="define-item-type" data-item-type="weapon">
   <h2 class="section-group-header">
-    {{localize 'ANARCHY.itemType.plural.weapon'}}
+    {{ANARCHY.itemType.plural.weapon}}
     {{> 'systems/mwd/templates/common/item-control-add.hbs' itemType='weapon'}}
   </h2>
   <ul class="weapon-list">

--- a/templates/actor/npc-sheet.hbs
+++ b/templates/actor/npc-sheet.hbs
@@ -18,7 +18,7 @@
           <div class="passport-detail">
             {{> "systems/mwd/templates/actor/character/capacity.hbs"}}
           </div>
-          {{#if (localize 'ANARCHY.actor.counters.essence')}}
+          {{#if ANARCHY.actor.counters.essence}}
           <div class="passport-detail">
             {{> "systems/mwd/templates/actor/character/essence.hbs"}}
           </div>

--- a/templates/actor/parts/asset-module.hbs
+++ b/templates/actor/parts/asset-module.hbs
@@ -2,7 +2,7 @@
   <img class="anarchy-img item-img" src="{{img}}" alt="{{name}}" data-tooltip="{{name}}" />
   <div class="asset-module-content">
     <label class="item-title">{{name}}</label>
-    {{#if system.level}}<label class="item-subtitle">{{localize 'ANARCHY.item.assetModule.levelShort'}} {{system.level}}</label>{{/if}}
+    {{#if system.level}}<label class="item-subtitle">{{ANARCHY.item.assetModule.levelShort}} {{system.level}}</label>{{/if}}
     {{> 'systems/mwd/templates/actor/character/description.hbs' description=system.description}}
   </div>
   <div class="item-controls">

--- a/templates/actor/parts/asset-modules.hbs
+++ b/templates/actor/parts/asset-modules.hbs
@@ -1,6 +1,6 @@
 <div class="define-item-type" data-item-type="assetModule">
   <h2 class="section-group-header">
-    {{localize 'ANARCHY.itemType.plural.assetModule'}}
+    {{ANARCHY.itemType.plural.assetModule}}
     {{> 'systems/mwd/templates/common/item-control-add.hbs' itemType='assetModule'}}
   </h2>
   <div class="items-group-list">

--- a/templates/actor/parts/attributebutton.hbs
+++ b/templates/actor/parts/attributebutton.hbs
@@ -1,8 +1,8 @@
 <a class="item anarchy-button click-roll-attribute-action flex-grow-0"
-  data-tooltip="{{localize labelkey}}" data-action-code="{{code}}">
+  data-tooltip="{{labelkey}}" data-action-code="{{code}}">
 {{#if icon}}
   {{{icon}}}
 {{else}}
-  <label>{{localize labelkey}}</label>
+  <label>{{labelkey}}</label>
 {{/if}}
 </a>

--- a/templates/actor/parts/battlemech-hardpoints.hbs
+++ b/templates/actor/parts/battlemech-hardpoints.hbs
@@ -1,5 +1,5 @@
 <div class="section-group column">
-  <h2 class="section-group-header">{{localize 'ANARCHY.actor.battlemech.hardpoints'}}</h2>
+  <h2 class="section-group-header">{{ANARCHY.actor.battlemech.hardpoints}}</h2>
   <div class="items-group-list">
     {{#each system.hardpoints as |hardpoint key|}}
     <div class="item"><strong>{{key}}:</strong> {{hardpoint}}</div>

--- a/templates/actor/parts/battlemech-loadout.hbs
+++ b/templates/actor/parts/battlemech-loadout.hbs
@@ -1,5 +1,5 @@
 <div class="section-group column">
-  <h2 class="section-group-header">{{localize 'ANARCHY.actor.battlemech.loadout'}}</h2>
+  <h2 class="section-group-header">{{ANARCHY.actor.battlemech.loadout}}</h2>
   <div class="items-group-list">
     {{#each system.loadout as |slot key|}}
     <div class="item"><strong>{{key}}:</strong> {{slot}}</div>

--- a/templates/actor/parts/battlemech-weapon-groups.hbs
+++ b/templates/actor/parts/battlemech-weapon-groups.hbs
@@ -1,5 +1,5 @@
 <div class="section-group column">
-  <h2 class="section-group-header">{{localize 'ANARCHY.actor.battlemech.weaponGroups'}}</h2>
+  <h2 class="section-group-header">{{ANARCHY.actor.battlemech.weaponGroups}}</h2>
   <div class="items-group-list">
     {{#each system.weaponGroups as |group|}}
     <div class="item">{{group}}</div>

--- a/templates/actor/parts/battlemech-weapons.hbs
+++ b/templates/actor/parts/battlemech-weapons.hbs
@@ -1,5 +1,5 @@
 <div class="define-item-type" data-item-type="mechWeapon">
-  <h2 class="section-group-header">{{localize 'ANARCHY.itemType.plural.mechWeapon'}}</h2>
+  <h2 class="section-group-header">{{ANARCHY.itemType.plural.mechWeapon}}</h2>
   <div class="items-group-list">
     {{#each items.mechWeapon as |weapon|}}
     {{> 'systems/mwd/templates/actor/parts/weapon.hbs' weapon}}

--- a/templates/actor/parts/contacts.hbs
+++ b/templates/actor/parts/contacts.hbs
@@ -1,6 +1,6 @@
 <div class="define-item-type" data-item-type="contact">
   <h2 class="section-group-header">
-    {{localize 'ANARCHY.itemType.plural.contact'}}
+    {{ANARCHY.itemType.plural.contact}}
     {{> 'systems/mwd/templates/common/item-control-add.hbs' itemType='contact'}}
   </h2>
   <div class="flexrow flex-wrap">

--- a/templates/actor/parts/description.hbs
+++ b/templates/actor/parts/description.hbs
@@ -1,5 +1,5 @@
 <div class="section-group column">
-  <h2 class="section-group-header">{{localize 'ANARCHY.common.description'}}</h2>
+  <h2 class="section-group-header">{{ANARCHY.common.description}}</h2>
   <div class="editor actor-editor">
     {{editor 
       system.description 

--- a/templates/actor/parts/gears.hbs
+++ b/templates/actor/parts/gears.hbs
@@ -1,6 +1,6 @@
 <div class="define-item-type" data-item-type="gear">
   <h2 class="section-group-header">
-    {{localize 'ANARCHY.itemType.plural.gear'}}
+    {{ANARCHY.itemType.plural.gear}}
     {{> 'systems/mwd/templates/common/item-control-add.hbs' itemType='gear'}}
   </h2>
   <div class="items-group-list">

--- a/templates/actor/parts/gmnotes.hbs
+++ b/templates/actor/parts/gmnotes.hbs
@@ -1,7 +1,7 @@
 {{#if options.isGM}}
 <div class="section-group column">
   <h2 class="section-group-header">
-    {{localize 'ANARCHY.common.gmnotes'}}
+    {{ANARCHY.common.gmnotes}}
   </h2>
   <div class="editor actor-editor">
     {{editor

--- a/templates/actor/parts/life-modules.hbs
+++ b/templates/actor/parts/life-modules.hbs
@@ -1,6 +1,6 @@
 <div class="define-item-type" data-item-type="lifeModule">
   <h2 class="section-group-header">
-    {{localize 'ANARCHY.itemType.plural.lifeModule'}}
+    {{ANARCHY.itemType.plural.lifeModule}}
     {{> 'systems/mwd/templates/common/item-control-add.hbs' itemType='lifeModule'}}
   </h2>
   <div class="items-group-list">

--- a/templates/actor/parts/mech-quick-actions.hbs
+++ b/templates/actor/parts/mech-quick-actions.hbs
@@ -1,5 +1,5 @@
 <div class="section-group column">
-  <h2 class="section-group-header">{{localize 'ANARCHY.actor.battlemech.quickActions'}}</h2>
+  <h2 class="section-group-header">{{ANARCHY.actor.battlemech.quickActions}}</h2>
   <div class="items-group-list">
     {{#each system.quickActions as |action|}}
     <div class="item">{{action}}</div>

--- a/templates/actor/parts/owned-actor.hbs
+++ b/templates/actor/parts/owned-actor.hbs
@@ -2,7 +2,7 @@
   <a class="click-owned-actor-view">
     {{> 'systems/mwd/templates/common/actor-reference.hbs' this}}
   </a>
-  <a class="item-control click-owned-actor-unlink" data-tooltip="{{localize ANARCHY.common.del}}">
+  <a class="item-control click-owned-actor-unlink" data-tooltip="{{ANARCHY.common.del}}">
     {{{iconFA 'fas fa-trash'}}}
   </a>
 </div>

--- a/templates/actor/parts/owned-actors.hbs
+++ b/templates/actor/parts/owned-actors.hbs
@@ -1,6 +1,6 @@
 <div class="define-item-type" data-item-type="owned-actor">
   <h2 class="section-group-header">
-    {{localize 'ANARCHY.actor.ownership.owned'}}
+    {{ANARCHY.actor.ownership.owned}}
   </h2>
   <div class="items-group-list">
     {{#each ownedActors as |ownedActor|}}

--- a/templates/actor/parts/ownership.hbs
+++ b/templates/actor/parts/ownership.hbs
@@ -1,7 +1,7 @@
 {{#if ownerActor}}
 <label class="info-label">
   {{> 'systems/mwd/templates/common/actor-reference.hbs' ownerActor}}
-  <a class="item-control click-owner-actor-unlink" data-tooltip="{{localize ANARCHY.common.del}}">
+  <a class="item-control click-owner-actor-unlink" data-tooltip="{{ANARCHY.common.del}}">
     {{{iconFA 'fas fa-trash'}}}
   </a>
 </label>

--- a/templates/actor/parts/qualities.hbs
+++ b/templates/actor/parts/qualities.hbs
@@ -1,6 +1,6 @@
 <div class="define-item-type" data-item-type="quality">
   <h2 class="section-group-header">
-    {{localize 'ANARCHY.itemType.plural.quality'}}
+    {{ANARCHY.itemType.plural.quality}}
     {{> 'systems/mwd/templates/common/item-control-add.hbs' itemType='quality'}}
   </h2>
   <div class="items-group-list">

--- a/templates/actor/parts/skill.hbs
+++ b/templates/actor/parts/skill.hbs
@@ -3,7 +3,7 @@
   <img class="anarchy-img item-img" src="{{img}}" alt="{{name}}" data-tooltip="{{name}}"/>
   {{/if}}
   {{#if (or (eq system.code 'knowledge') (eq system.attribute 'knowledge')) }}
-  <span data-tooltip="{{localize 'ANARCHY.attributes.knowledge'}}">
+  <span data-tooltip="{{ANARCHY.attributes.knowledge}}">
     {{{iconFA 'fas fa-user-graduate'}}}
     <label>{{name}}</label>
   </span>

--- a/templates/actor/parts/skills.hbs
+++ b/templates/actor/parts/skills.hbs
@@ -1,6 +1,6 @@
 <div class="define-item-type" data-item-type="skill">
   <h2 class="section-group-header">
-    {{localize 'ANARCHY.itemType.plural.skill'}}
+    {{ANARCHY.itemType.plural.skill}}
     {{> 'systems/mwd/templates/common/item-control-add.hbs' itemType='skill'}}
   </h2>
   <div class="items-group-list">

--- a/templates/actor/parts/weapon.hbs
+++ b/templates/actor/parts/weapon.hbs
@@ -19,7 +19,7 @@
     }}
   </div>
   <div class="weapon-column weapon-stat">
-    {{localize (concat 'ANARCHY.area.' (either system.area 'none'))}}
+    {{lookup ANARCHY.area (either system.area 'none')}}
   </div>
   <div class="weapon-column weapon-stat">
     {{either system.range.short 'OK'}}

--- a/templates/actor/parts/weapons.hbs
+++ b/templates/actor/parts/weapons.hbs
@@ -1,17 +1,17 @@
 <div class="define-item-type" data-item-type="weapon">
   <h2 class="section-group-header">
-    {{localize 'ANARCHY.itemType.plural.weapon'}}
+    {{ANARCHY.itemType.plural.weapon}}
     {{> 'systems/mwd/templates/common/item-control-add.hbs' itemType='weapon'}}
   </h2>
   <ul class="weapon-list">
     <div class="weapon-header">
       <span class="weapon-column weapon-img"></span>
-      <span class="weapon-column weapon-txt">{{localize 'ANARCHY.itemType.singular.weapon'}}</span>
-      <span class="weapon-column weapon-dmg">{{localize 'ANARCHY.item.weapon.damageShort'}}</span>
-      <span class="weapon-column weapon-stat">{{localize 'ANARCHY.item.weapon.areaShort'}}</span>
-      <span class="weapon-column weapon-stat">{{localize 'ANARCHY.range.short'}}</span>
-      <span class="weapon-column weapon-stat">{{localize 'ANARCHY.range.medium'}}</span>
-      <span class="weapon-column weapon-stat">{{localize 'ANARCHY.range.long'}}</span>
+      <span class="weapon-column weapon-txt">{{ANARCHY.itemType.singular.weapon}}</span>
+      <span class="weapon-column weapon-dmg">{{ANARCHY.item.weapon.damageShort}}</span>
+      <span class="weapon-column weapon-stat">{{ANARCHY.item.weapon.areaShort}}</span>
+      <span class="weapon-column weapon-stat">{{ANARCHY.range.short}}</span>
+      <span class="weapon-column weapon-stat">{{ANARCHY.range.medium}}</span>
+      <span class="weapon-column weapon-stat">{{ANARCHY.range.long}}</span>
       <span class="weapon-column weapon-controls">{{{iconFA 'fas fa-pen hide-fontawesome'}}}</span>
     </div>
 

--- a/templates/actor/parts/words.hbs
+++ b/templates/actor/parts/words.hbs
@@ -1,7 +1,7 @@
 <h3 class="define-wordType" data-word-type="{{wordType}}">
-  {{localize (concat 'ANARCHY.actor.words.' wordType)}}
+  {{lookup ANARCHY.actor.words wordType}}
   {{#unless @root.options.viewMode}}
-  <a class="item-control click-word-add" data-tooltip="{{localize ANARCHY.common.add}}">
+  <a class="item-control click-word-add" data-tooltip="{{ANARCHY.common.add}}">
     {{{iconFA 'fas fa-plus-circle'}}}
   </a>
   {{/unless}}
@@ -16,12 +16,12 @@
     />
     <div class="flex-shrink-end">
       {{#if (or (eq ../wordType 'cues') (eq ../wordType 'dispositions')) }}
-      <a class="item-control click-word-say" data-tooltip="{{localize @root.ANARCHY.common.say}} {{wordEntry.word}}">
+      <a class="item-control click-word-say" data-tooltip="{{@root.ANARCHY.common.say}} {{wordEntry.word}}">
         {{{iconFA 'fas fa-comment-dots'}}}
       </a>
       {{/if}}
       {{#unless @root.options.viewMode}}
-      <a class="item-control click-word-delete" data-tooltip="{{localize @root.ANARCHY.common.del}}">
+      <a class="item-control click-word-delete" data-tooltip="{{@root.ANARCHY.common.del}}">
         {{{iconFA 'fas fa-trash'}}}
       </a>
       {{/unless}}

--- a/templates/actor/vehicle/vehicle-attributes.hbs
+++ b/templates/actor/vehicle/vehicle-attributes.hbs
@@ -1,17 +1,17 @@
 <div class="attribute-box secondary-attribute">
-  <label for="system.moves">{{localize ANARCHY.actor.vehicle.moves}}</label>
+  <label for="system.moves">{{ANARCHY.actor.vehicle.moves}}</label>
   <input type="number" data-dtype="Number" maxlength="2"
     name="system.moves" value="{{system.moves}}" 
   />
 </div>
 <div class="attribute-box secondary-attribute">
-  <label for="system.attacks">{{localize ANARCHY.actor.vehicle.attacks}}</label>
+  <label for="system.attacks">{{ANARCHY.actor.vehicle.attacks}}</label>
   <input type="number" data-dtype="Number" maxlength="2"
     name="system.attacks" value="{{system.attacks}}" 
   />
 </div>
 <div class="attribute-box secondary-attribute">
-  <label for="system.stealth">{{localize ANARCHY.actor.vehicle.stealth}}</label>
+  <label for="system.stealth">{{ANARCHY.actor.vehicle.stealth}}</label>
   <input type="number" data-dtype="Number" maxlength="2"
     name="system.stealth" value="{{system.stealth}}" 
   />

--- a/templates/actor/vehicle/vehicle-crew.hbs
+++ b/templates/actor/vehicle/vehicle-crew.hbs
@@ -1,4 +1,4 @@
 <div class="section-group column">
-  <h2 class="section-group-header">{{localize 'ANARCHY.actor.vehicle.crew'}}</h2>
+  <h2 class="section-group-header">{{ANARCHY.actor.vehicle.crew}}</h2>
   <textarea name="system.crew" class="vehicle-crew">{{system.crew}}</textarea>
 </div>

--- a/templates/actor/vehicle/vehicle-pilot.hbs
+++ b/templates/actor/vehicle/vehicle-pilot.hbs
@@ -1,4 +1,4 @@
 <div class="section-group column">
-  <h2 class="section-group-header">{{localize 'ANARCHY.actor.vehicle.pilot'}}</h2>
+  <h2 class="section-group-header">{{ANARCHY.actor.vehicle.pilot}}</h2>
   <textarea name="system.pilot" class="vehicle-pilot">{{system.pilot}}</textarea>
 </div>

--- a/templates/actor/vehicle/vehicle-weapons.hbs
+++ b/templates/actor/vehicle/vehicle-weapons.hbs
@@ -1,5 +1,5 @@
 <div class="define-item-type" data-item-type="weapon">
-  <h2 class="section-group-header">{{localize 'ANARCHY.itemType.plural.weapon'}}</h2>
+  <h2 class="section-group-header">{{ANARCHY.itemType.plural.weapon}}</h2>
   <div class="items-group-list">
     {{#each items.weapon as |weapon|}}
     {{> 'systems/mwd/templates/actor/parts/weapon.hbs' weapon}}

--- a/templates/app/gm-anarchy.hbs
+++ b/templates/app/gm-anarchy.hbs
@@ -1,6 +1,6 @@
 <div class="gm-manager-bar
 	anarchy-monitor">
-	<label>{{localize ANARCHY.actor.counters.plot}}</label>
+        <label>{{ANARCHY.actor.counters.plot}}</label>
 	<span class="flex-grow-3 gm-anarchy-bar">
 		{{> "systems/mwd/templates/monitors/anarchy.hbs"
 			code='plot'
@@ -8,7 +8,7 @@
 			value=anarchy.value
 			max=anarchy.max
 			scene=anarchy.scene
-			labelkey='ANARCHY.actor.counters.plot'
-		}}
+                        label=ANARCHY.actor.counters.plot
+                }}
 	</span>
 </div>

--- a/templates/app/gm-convergence-actors.hbs
+++ b/templates/app/gm-convergence-actors.hbs
@@ -9,7 +9,7 @@
     code='convergence'
     value=c.convergence
     max=(min (sum c.convergence 1) 5)
-    labelkey='ANARCHY.actor.monitors.convergence'
+    label=ANARCHY.actor.monitors.convergence
     rowlength=5
     }}
     </div>

--- a/templates/app/gm-convergence.hbs
+++ b/templates/app/gm-convergence.hbs
@@ -1,5 +1,5 @@
 <div class="gm-manager-bar gm-convergence-bar">
-	<label>{{localize ANARCHY.gmManager.gmConvergence}}</label>
+        <label>{{ANARCHY.gmManager.gmConvergence}}</label>
 	<span class="gm-convergence-content">
   </span>
 </div>

--- a/templates/app/gm-manager.hbs
+++ b/templates/app/gm-manager.hbs
@@ -1,7 +1,7 @@
 <div id="gm-manager"
   class="app window-app {{#each options.classes as |cssClass|}}{{cssClass}}{{/each}}">
   <header class="header app-title-bar">
-    <label>{{localize ANARCHY.gmManager.title}}</label>
+    <label>{{ANARCHY.gmManager.title}}</label>
     <button class="gm-manager-hide-button">
       <i class="fa-solid fa-eye-slash"></i>
     </button>

--- a/templates/chat/anarchy-roll-title.hbs
+++ b/templates/chat/anarchy-roll-title.hbs
@@ -4,10 +4,10 @@
   {{~#if attribute2}}+{{localizeAttribute attribute2}}{{/if~}}
 {{/if}}
 {{#if (eq mode 'attributeAction')}}
-  {{localize (concat 'ANARCHY.attributeAction.' attributeAction)}}
+  {{lookup ANARCHY.attributeAction attributeAction}}
 {{/if}}
 {{#if (eq mode 'defense')}}
-  {{localize (concat 'ANARCHY.defense.' (fixedDefenseCode defenseAction))}}
+  {{lookup ANARCHY.defense (fixedDefenseCode defenseAction)}}
 {{/if}}
 {{#if (eq mode 'skill')}}
   {{actor.name}} - {{skill.name}}

--- a/templates/chat/celebrity-roll.hbs
+++ b/templates/chat/celebrity-roll.hbs
@@ -4,7 +4,7 @@
   </div>
   <div>
     <h3 class="chat-roll-title tooltip tooltip-dotted">
-      {{actor.name}} - {{localize ANARCHY.actor.celebrity}}: {{pool}}
+      {{actor.name}} - {{ANARCHY.actor.celebrity}}: {{pool}}
       <div class="tooltiptext tooltip-roll-parameters">
         {{#each parameters as |parameter|}}
           <div class="parameter">

--- a/templates/chat/edge-reroll-button.hbs
+++ b/templates/chat/edge-reroll-button.hbs
@@ -1,5 +1,5 @@
 <div>
   <a class="anarchy-button click-edge-reroll flex-grow-0">
-    <label>{{localize ANARCHY.common.roll.modifiers.edge}}</label>
+    <label>{{ANARCHY.common.roll.modifiers.edge}}</label>
   </a>
 </div>

--- a/templates/chat/parts/anarchy-risk.hbs
+++ b/templates/chat/parts/anarchy-risk.hbs
@@ -8,6 +8,6 @@
     </span>
   {{/each}}
   <label>
-    {{localize (concat 'ANARCHY.common.roll.risk.' @root.roll.riskOutcome)}}
+    {{lookup ANARCHY.common.roll.risk @root.roll.riskOutcome}}
   </label>
 </div>

--- a/templates/chat/parts/pool-mode-skill.hbs
+++ b/templates/chat/parts/pool-mode-skill.hbs
@@ -1,5 +1,5 @@
 <div>{{localizeAttribute attribute1}}: {{actorAttribute attribute1 actor ''}}</div>
 <div>{{skill.name}}: {{either skill.system.value 0}}</div>
 {{#if modifiers.specialization.used}}
-<div>{{localize ANARCHY.item.skill.specialization}} {{specialization}}: {{numberFormat modifiers.specialization.value decimals=0 sign=true}}</div>
+<div>{{ANARCHY.item.skill.specialization}} {{specialization}}: {{numberFormat modifiers.specialization.value decimals=0 sign=true}}</div>
 {{/if}}

--- a/templates/chat/parts/pool-mode-weapon.hbs
+++ b/templates/chat/parts/pool-mode-weapon.hbs
@@ -1,6 +1,6 @@
   <div>{{localizeAttribute attribute1}}: {{actorAttribute attribute1 actor ''}}</div>
   <div>{{skill.name}}: {{either skill.system.value 0}}</div>
   {{#if modifiers.specialization.used}}
-  <div>{{localize ANARCHY.item.skill.specialization}} {{specialization}}: {{numberFormat modifiers.specialization.value decimals=0 sign=true}}</div>
+  <div>{{ANARCHY.item.skill.specialization}} {{specialization}}: {{numberFormat modifiers.specialization.value decimals=0 sign=true}}</div>
   {{/if}}
   {{> 'systems/mwd/templates/chat/roll-modifier.hbs' modifiers.range}}

--- a/templates/chat/parts/result-mode-weapon.hbs
+++ b/templates/chat/parts/result-mode-weapon.hbs
@@ -1,5 +1,5 @@
 <br>
-{{localize 'ANARCHY.item.weapon.damage'}}
+{{ANARCHY.item.weapon.damage}}
 {{> 'systems/mwd/templates/common/damage-code.hbs'
     damageAttribute=weapon.system.damageAttribute
     actorAttribute=(actorAttribute weapon.system.damageAttribute actor)

--- a/templates/chat/risk-outcome.hbs
+++ b/templates/chat/risk-outcome.hbs
@@ -2,12 +2,12 @@
 {{#if modifiers.anarchyRisk.used}}
   <div class="risk-glitch risk-glitch-{{~#if (eq roll.outcome 'mixed' )}}prowess
   {{else}}{{roll.outcome}}{{/if~}}">
-    {{localize ANARCHY.common.roll.modifiers.anarchyRisk}}:
+    {{ANARCHY.common.roll.modifiers.anarchyRisk}}:
     <span class="risk-glitch-dice {{roll.outcome}}">
       {{{iconD6 roll.subrolls.risk.terms.[0].results.[0].result}}}
     </span>
     {{#unless (eq roll.outcome 'mixed')}}
-      {{localize (concat 'ANARCHY.common.roll.risk.' roll.outcome)}}
+      {{lookup ANARCHY.common.roll.risk roll.outcome}}
     {{/unless}}
   </div>
 {{/if}}
@@ -15,14 +15,14 @@
   <div class="risk-glitch risk-glitch-{{~#if (eq roll.outcome 'prowess' )}}nothing
   {{else if (eq roll.outcome 'mixed' )}}glitch
   {{else}}{{roll.outcome}}{{/if~}}">
-    {{localize ANARCHY.common.roll.modifiers.glitch}}:
+    {{ANARCHY.common.roll.modifiers.glitch}}:
     {{#each roll.subrolls.glitch.terms.[0].results as |dice|}}
       <span class="risk-glitch-dice {{roll.outcome}}">
         {{{iconD6 dice.result}}}
       </span>
     {{/each}}
     {{#unless (eq roll.outcome 'prowess')}}
-      {{localize (concat 'ANARCHY.common.roll.risk.' roll.outcome)}}
+      {{lookup ANARCHY.common.roll.risk roll.outcome}}
     {{/unless}}
   </div>
 {{/if}}

--- a/templates/chat/roll-modifier.hbs
+++ b/templates/chat/roll-modifier.hbs
@@ -2,7 +2,7 @@
   {{#if (eq category 'pool')}}  
   {{#if value}}
     <div>
-    {{localize (concat 'ANARCHY.common.roll.modifiers.' type)}}
+    {{lookup ANARCHY.common.roll.modifiers type}}
     {{#if options}}{{selectedLabel}}{{!-- already i18n --}}{{/if}}:
     {{numberFormat value decimals=0 sign=true}}
     </div>
@@ -10,14 +10,14 @@
   {{/if}}
   {{#if (eq category 'reroll')}}  
   <div>
-    {{localize (concat 'ANARCHY.common.roll.modifiers.' type)}}
+    {{lookup ANARCHY.common.roll.modifiers type}}
     {{numberFormat value decimals=0 sign=false}}
   </div>
   {{/if}}
   {{#if (eq category 'opponent')}}
     {{#if value}}
     <div>
-      {{localize (concat 'ANARCHY.common.roll.modifiers.' type)}}
+      {{lookup ANARCHY.common.roll.modifiers type}}
       {{numberFormat value decimals=0 sign=false}}
     </div>
     {{/if}}
@@ -25,7 +25,7 @@
   {{#if (eq category 'other')}}
     {{#if value}}
     <div>
-      {{localize (concat 'ANARCHY.common.roll.modifiers.' type)}}
+      {{lookup ANARCHY.common.roll.modifiers type}}
     </div>
     {{/if}}
   {{/if}}

--- a/templates/common/damage-armor.hbs
+++ b/templates/common/damage-armor.hbs
@@ -1,5 +1,5 @@
 {{#if (eq armor 'avoidArmor')}}
-<span data-tooltip="{{localize 'ANARCHY.item.weapon.noArmor'}}">{{{iconFA 'fas fa-user-times'}}}</span>
+<span data-tooltip="{{ANARCHY.item.weapon.noArmor}}">{{{iconFA 'fas fa-user-times'}}}</span>
 {{else if (eq armor 'withArmor')}}
-<span data-tooltip="{{localize 'ANARCHY.item.weapon.withArmor'}}">{{{iconFA 'fas fa-user-shield'}}}</span>
+<span data-tooltip="{{ANARCHY.item.weapon.withArmor}}">{{{iconFA 'fas fa-user-shield'}}}</span>
 {{/if}}

--- a/templates/common/favorite.hbs
+++ b/templates/common/favorite.hbs
@@ -1,5 +1,5 @@
 <a class="{{#if isFavorite}}favorite-control{{else}}item-control{{/if}} click-favorite" 
-    data-tooltip="{{#if isFavorite}}{{localize 'ANARCHY.common.delFavorite'}}{{else}}{{localize 'ANARCHY.common.addFavorite'}}{{/if}}"
+    data-tooltip="{{#if isFavorite}}{{ANARCHY.common.delFavorite}}{{else}}{{ANARCHY.common.addFavorite}}{{/if}}"
     {{#if skill}}data-skill-id="{{skill._id}}"{{/if}}
     {{#if specialization}}data-skill-specialization="{{specialization}}"{{/if}}
     {{#if weapon}}data-weapon-id="{{weapon._id}}"{{/if}}

--- a/templates/common/item-control-activate.hbs
+++ b/templates/common/item-control-activate.hbs
@@ -1,4 +1,4 @@
-<a class="item-control click-item-activate" data-tooltip="{{localize ANARCHY.common.activate}}">
+<a class="item-control click-item-activate" data-tooltip="{{ANARCHY.common.activate}}">
   {{#if system.inactive}}
   {{{iconFA 'fas fa-toggle-off'}}}
   {{else}}

--- a/templates/common/item-control-add.hbs
+++ b/templates/common/item-control-add.hbs
@@ -1,6 +1,6 @@
 {{#unless @root.options.viewMode}}
-<a class="define-item-type item-control click-item-add" 
-    data-tooltip="{{localize 'ANARCHY.common.add'}}"
+<a class="define-item-type item-control click-item-add"
+    data-tooltip="{{ANARCHY.common.add}}"
     data-item-type="{{itemType}}">
   {{{iconFA 'fas fa-plus-circle'}}}
 </a>

--- a/templates/roll/roll-dialog-title.hbs
+++ b/templates/roll/roll-dialog-title.hbs
@@ -5,11 +5,11 @@
 {{/if}}
 {{#if (eq mode 'attributeAction')}}
   {{#if item}} - {{{item.name}}}{{/if}}:
-  {{{localize (concat 'ANARCHY.attributeAction.' attributeAction)}}}
+  {{{lookup ANARCHY.attributeAction attributeAction}}}
 {{/if}}
 {{#if (eq mode 'defense')}}
   {{#if item}} - {{{item.name}}}{{/if}}:
-  {{{localize (concat 'ANARCHY.defense.' (fixedDefenseCode defenseAction))}}}
+  {{{lookup ANARCHY.defense (fixedDefenseCode defenseAction)}}}
 {{/if}}
 {{#if (eq mode 'skill')}} - {{{skill.name}}}{{/if}}
 {{#if (eq mode 'weapon')}} - {{{weapon.name}}}{{/if}}

--- a/templates/roll/roll-dialog.hbs
+++ b/templates/roll/roll-dialog.hbs
@@ -21,7 +21,7 @@
         {{>'systems/mwd/templates/roll/roll-parameters-category.hbs' parameters=parameters category='risk'}}
       </div>
       <div class="parameter-category">
-        <label>{{localize 'ANARCHY.common.roll.opponentRoll'}}</label>
+        <label>{{ANARCHY.common.roll.opponentRoll}}</label>
         {{>'systems/mwd/templates/roll/roll-parameters-category.hbs' parameters=parameters category='opponentPool'}}
         {{>'systems/mwd/templates/roll/roll-parameters-category.hbs' parameters=parameters category='opponentReroll'}}
       </div>

--- a/templates/token/hud-shortcuts.hbs
+++ b/templates/token/hud-shortcuts.hbs
@@ -1,6 +1,6 @@
 <div class="control-icon anarchy-shortcuts {{#each options.classes as |cssClass|}}{{cssClass}}{{/each}}" >
-  <img class="anarchy-shortcuts-toggle" src="systems/mwd/icons/misc/digital-trace.svg" 
-    width="36" height="36" data-tooltip="{{localize 'ANARCHY.common.favorite'}}"/>
+  <img class="anarchy-shortcuts-toggle" src="systems/mwd/icons/misc/digital-trace.svg"
+    width="36" height="36" data-tooltip="{{ANARCHY.common.favorite}}"/>
   <div class="anarchy-shortcuts-list" data-token-id="{{tokenId}}">
     {{#each shortcuts as |shortcut|}}
     <div class="control-icon anarchy-shortcut-button" data-shortcut-type="{{shortcut.type}}" data-shortcut-id="{{shortcut.id}}">


### PR DESCRIPTION
## Summary
- replace ANARCHY translation localize helper calls with direct values or lookup helpers across templates
- update label references to consume ANARCHY translation values directly instead of labelkey/localize combinations

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693687bce1b4832d9e44d3af3d9ab3c0)